### PR TITLE
Initialize `stats` in `LogQueue` to avoid silent crash

### DIFF
--- a/packages/ponder/src/core/indexer/logQueue.ts
+++ b/packages/ponder/src/core/indexer/logQueue.ts
@@ -66,7 +66,12 @@ export const createLogQueue = ({
       );
       return;
     }
-
+    if (!stats.sourceStats[source.name]) {
+      stats.sourceStats[source.name] = {
+        matchedLogCount: 0,
+        handledLogCount: 0,
+      };
+    }
     stats.sourceStats[source.name].matchedLogCount += 1;
 
     const sourceHandlers = userHandlers[source.name];


### PR DESCRIPTION
Currently the `logWorker` is silently crashing. This is happening because the `stats.sourceStats[source.name]` object is uninitialized. When trying to access a field of this `undefined` object the worker silently fails