### PR TITLE
Improve `Ponder` lifecycle mgmt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,10 @@ jobs:
             packages/**/node_modules
             packages/**/dist
           key: modules-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Build core
+        run: pnpm --filter "@ponder/core" prerelease
+      - name: Build dependents
+        run: pnpm --filter \!"@ponder/core" prerelease
       - name: Typecheck
         run: pnpm typecheck
       - name: Lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,37 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm i
 
+  lint:
+    name: Lint
+    needs: install
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          cache: "pnpm"
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            examples/**/node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: modules-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Lint
+        run: pnpm lint
+
   test:
     name: Test
     needs: install

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   ],
   "scripts": {
     "preinstall": "npx -y only-allow pnpm",
+    "typecheck": "pnpm --parallel typecheck",
+    "lint": "pnpm --parallel lint",
     "build": "pnpm --parallel build",
     "test": "pnpm --parallel --no-bail test"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "pnpm --parallel typecheck",
     "lint": "pnpm --parallel lint",
     "build": "pnpm --parallel build",
+    "declarations": "pnpm --parallel declarations",
     "test": "pnpm --parallel --no-bail test"
   },
   "devDependencies": {

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,8 @@
+/** @returns {Promise<import('jest').Config>} */
+module.exports = async () => {
+  return {
+    verbose: true,
+    roots: ["dist"],
+    testTimeout: 5_000, // 5 seconds
+  };
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,7 @@
     "format-dist": "prettier dist --write --loglevel warn",
     "prerelease": "$npm_execpath run build && $npm_execpath run declarations && $npm_execpath run format-dist",
     "release": "$npm_execpath run prerelease && VERSION=$(npm version patch) && npm publish && git add ./package.json && git commit -m \"release(@ponder/core): $VERSION\"",
-    "test": "jest dist",
-    "t": "$npm_execpath run build && jest dist"
+    "test": "jest dist"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.6.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,13 +14,14 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "(tsc || exit 0) && eslint src",
+    "typecheck": "tsc",
+    "lint": "eslint src",
     "format": "prettier src --write",
     "replace-paths": "tsconfig-replace-paths --src .",
     "esbuild": "esbuild `find . \\( -name '*.ts' -o -name '*.tsx' \\)` --platform=node --format=cjs --outdir=dist && $npm_execpath run replace-paths",
     "build": "$npm_execpath run clean && $npm_execpath run esbuild && mv dist/src/bin/ponder.js dist/src/bin/ponder",
     "declarations": "(tsc --noEmit false --declaration --emitDeclarationOnly || exit 0) && $npm_execpath run replace-paths",
-    "format-dist": "prettier dist --write --loglevel warn",
+    "format-dist": "prettier dist --write --loglevel warn --ignore-path dist/src/codegen/ethers-abitype/*",
     "prerelease": "$npm_execpath run build && $npm_execpath run declarations && $npm_execpath run format-dist",
     "release": "$npm_execpath run prerelease && VERSION=$(npm version patch) && npm publish && git add ./package.json && git commit -m \"release(@ponder/core): $VERSION\"",
     "test": "jest"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "format-dist": "prettier dist --write --loglevel warn",
     "prerelease": "$npm_execpath run build && $npm_execpath run declarations && $npm_execpath run format-dist",
     "release": "$npm_execpath run prerelease && VERSION=$(npm version patch) && npm publish && git add ./package.json && git commit -m \"release(@ponder/core): $VERSION\"",
-    "test": "jest dist"
+    "test": "jest"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.6.4",

--- a/packages/core/src/indexer/tasks/startBackfillForSource.ts
+++ b/packages/core/src/indexer/tasks/startBackfillForSource.ts
@@ -105,21 +105,34 @@ export const startBackfillForSource = async ({
     }
   }
 
-  const logQueueLength = logBackfillQueue.length();
-  logger.debug(`${source.name}: Started ${logQueueLength} log backfill tasks`);
-  if (!logBackfillQueue.idle()) {
-    await logBackfillQueue.drained();
-  }
-  logger.debug(`${source.name}: Finished ${logQueueLength} log backfill tasks`);
+  const killQueues = () => {
+    logBackfillQueue.kill();
+    blockBackfillQueue.kill();
+  };
 
-  const blockQueueLength = logBackfillQueue.length();
-  logger.debug(
-    `${source.name}: Started ${blockQueueLength} block backfill tasks`
-  );
-  if (!blockBackfillQueue.idle()) {
-    await blockBackfillQueue.drained();
-  }
-  logger.debug(
-    `${source.name}: Finished ${blockQueueLength} block backfill tasks`
-  );
+  const drainQueues = async () => {
+    const logQueueLength = logBackfillQueue.length();
+    logger.debug(
+      `${source.name}: Started ${logQueueLength} log backfill tasks`
+    );
+    if (!logBackfillQueue.idle()) {
+      await logBackfillQueue.drained();
+    }
+    logger.debug(
+      `${source.name}: Finished ${logQueueLength} log backfill tasks`
+    );
+
+    const blockQueueLength = blockBackfillQueue.length();
+    logger.debug(
+      `${source.name}: Started ${blockQueueLength} block backfill tasks`
+    );
+    if (!blockBackfillQueue.idle()) {
+      await blockBackfillQueue.drained();
+    }
+    logger.debug(
+      `${source.name}: Finished ${blockQueueLength} block backfill tasks`
+    );
+  };
+
+  return { killQueues, drainQueues };
 };

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -4,6 +4,7 @@ export type ResolvedPonderPlugin = {
   name: string;
   setup?: (ponder: Ponder) => Promise<void>;
   reload?: (ponder: Ponder) => Promise<void>;
+  teardown?: (ponder: Ponder) => Promise<void>;
 };
 
 export type PonderPlugin<PluginOptions = Record<string, unknown>> = (

--- a/packages/core/test/main.test.ts
+++ b/packages/core/test/main.test.ts
@@ -146,4 +146,16 @@ describe("Ponder", () => {
       expect(ponder.handlerQueue?.length()).toBe(0);
     });
   });
+
+  describe("backfill()", () => {
+    beforeEach(async () => {
+      await ponder.setup();
+    });
+
+    it("works", async () => {
+      await ponder.backfill();
+
+      expect(1).toBe(2);
+    });
+  });
 });

--- a/packages/core/test/main.test.ts
+++ b/packages/core/test/main.test.ts
@@ -158,15 +158,15 @@ describe("Ponder", () => {
     });
   });
 
-  describe("backfill()", () => {
-    beforeEach(async () => {
-      await ponder.setup();
-    });
+  // describe("backfill()", () => {
+  //   beforeEach(async () => {
+  //     await ponder.setup();
+  //   });
 
-    it("works", async () => {
-      await ponder.backfill();
+  //   it("works", async () => {
+  //     await ponder.backfill();
 
-      expect(1).toBe(2);
-    });
-  });
+  //     expect(1).toBe(2);
+  //   });
+  // });
 });

--- a/packages/core/test/main.test.ts
+++ b/packages/core/test/main.test.ts
@@ -16,9 +16,20 @@ jest.mock("@ethersproject/providers", () => {
     }
 
     async send(method: string, params: Array<unknown>) {
-      console.log({ method, params });
-
-      return null;
+      switch (method) {
+        case "eth_getBlockByNumber": {
+          if (params[0] === "latest") {
+            return {};
+          } else {
+            return {};
+          }
+        }
+        default: {
+          throw new Error(
+            `MockedStaticJsonRpcProvider: Unhandled method ${method}`
+          );
+        }
+      }
     }
   }
 

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "(tsc || exit 0) && eslint src",
+    "typecheck": "tsc",
+    "lint": "eslint src",
     "format": "prettier src --write",
     "replace-paths": "tsconfig-replace-paths --src src",
     "esbuild": "esbuild `find src \\( -name '*.ts' \\)` --platform=node --format=cjs --outdir=dist && $npm_execpath run replace-paths",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -11,7 +11,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "(tsc || exit 0) && eslint src",
+    "typecheck": "tsc",
+    "lint": "eslint src",
     "format": "prettier src --write",
     "replace-paths": "tsconfig-replace-paths --src src",
     "esbuild": "esbuild `find src \\( -name '*.ts' \\)` --platform=node --format=cjs --outdir=dist && $npm_execpath run replace-paths",

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -48,5 +48,8 @@ export const graphqlPlugin: PonderPlugin<PonderGraphqlPluginOptions> = ({
 
       server.start(gqlSchema, port);
     },
+    teardown: async () => {
+      server.teardown();
+    },
   };
 };

--- a/packages/graphql/src/server/index.ts
+++ b/packages/graphql/src/server/index.ts
@@ -47,4 +47,8 @@ export class GraphqlServer {
       // this.logger.debug(`\x1b[35m${`Restarted GraphQL server`}\x1b[0m`); // magenta
     }
   }
+
+  teardown() {
+    this.server?.close();
+  }
 }


### PR DESCRIPTION
Changes
- Adds an optional `teardown` method to plugins
- Makes the `Ponder.kill()` method work (process should exit gracefully)

Also
- Add a Lint CI step