### PR TITLE
Improve logs, error handling, and docs polish

### DIFF
--- a/docs/pages/api-reference/schema-graphql.mdx
+++ b/docs/pages/api-reference/schema-graphql.mdx
@@ -10,8 +10,8 @@ Ponder currently supports a subset of the Graph Protocol schema definition langu
 
 <Callout type="warning">
   In a future release, Ponder will likely deprecate the Graph Protocol schema
-  definition language in favor of a Ponder-native approach. To make this
-  eventual migration easier, avoid using new & advanced Graph Protocol features.
+  definition language in favor of a Ponder-native approach. Avoid using new &
+  advanced Graph Protocol features.
 </Callout>
 
 ## Supported features
@@ -28,3 +28,4 @@ Ponder currently supports a subset of the Graph Protocol schema definition langu
 - Call handlers
 - Block handlers
 - Anonymous events
+- The `immutable` argument to the `@entity` type directive is allowed for compatibility, but immutability is not enforced

--- a/docs/pages/faq/production.mdx
+++ b/docs/pages/faq/production.mdx
@@ -12,14 +12,14 @@ It's very easy to deploy Ponder apps to [Render](https://render.com), a Heroku-l
 
 ### Update `ponder.config.js`
 
-In production, Ponder apps use Postgres. Update your `ponder.config.js` file to use Postgres in production, and SQLite in development. Render will provide the `POSTGRES_URL` environment variable.
+In production, Ponder apps use Postgres. Update your `ponder.config.js` file to use Postgres in production, and SQLite in development. Render will provide the `DATABASE_URL` environment variable.
 
 ```js filename="ponder.config.js"
 module.exports = {
     database: process.env.NODE_ENV === "production"
       ? {
           kind: "postgres",
-          connectionString: process.env.POSTGRES_URL,
+          connectionString: process.env.DATABASE_URL,
         }
       : {
           kind: "sqlite",
@@ -48,7 +48,7 @@ services:
     buildCommand: pnpm install # Or yarn, npm
     startCommand: pnpm start # Or yarn, npm
     envVars:
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase:
           name: my-ponder-db
           property: connectionString

--- a/examples/ethfs/render.yaml
+++ b/examples/ethfs/render.yaml
@@ -8,7 +8,7 @@ services:
     buildCommand: pnpm install
     startCommand: pnpm run start
     envVars:
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase:
           name: ponder-db
           property: connectionString

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -4,6 +4,8 @@
 import { cac } from "cac";
 import dotenv from "dotenv";
 
+import { Ponder } from "@/Ponder";
+
 dotenv.config({ path: ".env.local" });
 
 const cli = cac("ponder")
@@ -28,26 +30,29 @@ export type PonderCliOptions = {
 
 cli
   .command("dev", "Start the development server")
-  .action((options: PonderCliOptions) => {
+  .action(async (options: PonderCliOptions) => {
     if (options.help) process.exit(0);
 
-    require("../cli/dev").dev(options);
+    const ponder = new Ponder({ isDev: true, ...options });
+    await ponder.dev();
   });
 
 cli
   .command("start", "Start the production server")
-  .action((options: PonderCliOptions) => {
+  .action(async (options: PonderCliOptions) => {
     if (options.help) process.exit(0);
 
-    require("../cli/start").start(options);
+    const ponder = new Ponder({ isDev: false, ...options });
+    await ponder.start();
   });
 
 cli
   .command("codegen", "Emit type files, then exit")
-  .action((options: PonderCliOptions) => {
+  .action(async (options: PonderCliOptions) => {
     if (options.help) process.exit(0);
 
-    require("../cli/codegen").codegen(options);
+    const ponder = new Ponder({ isDev: true, ...options });
+    ponder.codegen();
   });
 
 cli.parse();

--- a/packages/core/src/cli/codegen.ts
+++ b/packages/core/src/cli/codegen.ts
@@ -1,8 +1,0 @@
-import type { PonderCliOptions } from "@/bin/ponder";
-import { Ponder } from "@/Ponder";
-
-export const codegen = async (options: PonderCliOptions) => {
-  const ponder = new Ponder(options);
-
-  ponder.codegen();
-};

--- a/packages/core/src/cli/dev.ts
+++ b/packages/core/src/cli/dev.ts
@@ -1,8 +1,0 @@
-import type { PonderCliOptions } from "@/bin/ponder";
-import { Ponder } from "@/Ponder";
-
-export const dev = async (options: PonderCliOptions) => {
-  const ponder = new Ponder(options);
-
-  await ponder.dev();
-};

--- a/packages/core/src/cli/start.ts
+++ b/packages/core/src/cli/start.ts
@@ -1,8 +1,0 @@
-import type { PonderCliOptions } from "@/bin/ponder";
-import { Ponder } from "@/Ponder";
-
-export const start = async (options: PonderCliOptions) => {
-  const ponder = new Ponder(options);
-
-  await ponder.start();
-};

--- a/packages/core/src/codegen/generateHandlerTypes.ts
+++ b/packages/core/src/codegen/generateHandlerTypes.ts
@@ -9,6 +9,8 @@ import { buildEventTypes } from "./buildEventTypes";
 import { formatPrettier } from "./utils";
 
 export const generateHandlerTypes = ({ ponder }: { ponder: Ponder }) => {
+  if (!ponder.schema) return;
+
   const contractNames = ponder.sources.map((source) => source.name);
   const entityNames = (ponder.schema.entities || []).map(
     (entity) => entity.name

--- a/packages/core/src/codegen/utils.ts
+++ b/packages/core/src/codegen/utils.ts
@@ -11,7 +11,7 @@ const loadPrettierConfig = async () => {
   if (configFilePath) {
     const foundConfig = await prettier.resolveConfig(configFilePath);
     if (foundConfig) {
-      logger.info(`Found prettier config at: ${configFilePath}`);
+      logger.trace(`found prettier config at: ${configFilePath}`);
       prettierConfig = foundConfig;
     }
   }

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -1,3 +1,5 @@
+import pico from "picocolors";
+
 export enum LogLevel {
   // Silent 0
   Error, // 1
@@ -39,4 +41,48 @@ export const logger: PonderLogger = {
   trace: (...args: Parameters<typeof console.log>) => {
     if (LOG_LEVEL > LogLevel.Trace) console.log(...args);
   },
+};
+
+// This function is specifically for message logs.
+
+export enum MessageKind {
+  EVENT = "event",
+  ERROR = "error",
+  BACKFILL = "backfill",
+  FRONTFILL = "frontfill",
+  INDEXER = "indexer",
+}
+
+const DEV_WIDTH = 5;
+const START_WIDTH = 9;
+
+export const logMessage = (
+  kind: MessageKind,
+  message: string,
+  isDev = true
+) => {
+  const padded = kind.padEnd(isDev ? DEV_WIDTH : START_WIDTH, " ");
+
+  switch (kind) {
+    case MessageKind.EVENT: {
+      logger.info(pico.magenta(padded) + " - " + message);
+      break;
+    }
+    case MessageKind.ERROR: {
+      logger.error(pico.red(padded) + " - " + message);
+      break;
+    }
+    case MessageKind.BACKFILL: {
+      logger.info(pico.yellow(padded) + " - " + message);
+      break;
+    }
+    case MessageKind.FRONTFILL: {
+      logger.info(pico.cyan(padded) + " - " + message);
+      break;
+    }
+    case MessageKind.INDEXER: {
+      logger.info(pico.blue(padded) + " - " + message);
+      break;
+    }
+  }
 };

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -41,6 +41,13 @@ export const formatEta = (ms: number) => {
   return `${hstr}${mstr}${sstr}`;
 };
 
+export const formatPercentage = (cacheRate: number) => {
+  const decimal = Math.round(cacheRate * 1000) / 10;
+  return Number.isInteger(decimal) && decimal < 100
+    ? `${decimal}.0%`
+    : `${decimal}%`;
+};
+
 const latestFileHash: Record<string, string | undefined> = {};
 
 export const isFileChanged = (filePath: string) => {

--- a/packages/core/src/db/entity/sqliteEntityStore.ts
+++ b/packages/core/src/db/entity/sqliteEntityStore.ts
@@ -26,7 +26,10 @@ export class SqliteEntityStore implements EntityStore {
       try {
         return func(...args);
       } catch (err) {
-        this.ponder.emit("indexer_taskError", { error: err as Error });
+        this.ponder.emit("dev_error", {
+          context: "SQLite error",
+          error: err as Error,
+        });
         return undefined as unknown as T;
       }
     };
@@ -57,7 +60,10 @@ export class SqliteEntityStore implements EntityStore {
 
       this.schema = schema;
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
     }
   }
 
@@ -76,7 +82,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return this.deserialize(entityName, instance);
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return null;
     }
@@ -119,7 +128,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return this.deserialize(entityName, insertedEntity);
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return {};
     }
@@ -154,7 +166,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return this.deserialize(entityName, updatedEntity);
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return {};
     }
@@ -202,7 +217,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return this.deserialize(entityName, upsertedEntity);
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return {};
     }
@@ -223,7 +241,10 @@ export class SqliteEntityStore implements EntityStore {
       // `changes` is equal to the number of rows that were updated/inserted/deleted by the query.
       return changes === 1;
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return false;
     }
@@ -308,7 +329,10 @@ export class SqliteEntityStore implements EntityStore {
         this.deserialize(entityName, instance)
       );
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return [];
     }
@@ -353,7 +377,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return derivedFieldInstances;
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return [];
     }
@@ -393,7 +420,10 @@ export class SqliteEntityStore implements EntityStore {
 
       return deserializedInstance as Record<string, unknown>;
     } catch (err) {
-      this.ponder.emit("indexer_taskError", { error: err as Error });
+      this.ponder.emit("dev_error", {
+        context: "SQLite error",
+        error: err as Error,
+      });
 
       return {};
     }

--- a/packages/core/src/handlers/handlerQueue.ts
+++ b/packages/core/src/handlers/handlerQueue.ts
@@ -163,7 +163,7 @@ export const createHandlerQueue = ({
   const queue = createNotSoFastQueue(handlerWorker, (error) => {
     if (error) {
       ponder.emit("dev_error", {
-        context: "Handler file error: " + pico.bold(error.message),
+        context: "handler file error: " + pico.bold(error.message),
         error,
       });
     }

--- a/packages/core/src/handlers/readHandlers.ts
+++ b/packages/core/src/handlers/readHandlers.ts
@@ -29,8 +29,11 @@ export const readHandlers = async ({ ponder }: { ponder: Ponder }) => {
   );
 
   if (!existsSync(handlersRootFilePath)) {
-    ponder.emit("config_error", {
-      error: `Handlers not found, expected file: ${handlersRootFilePath}`,
+    ponder.emit("dev_error", {
+      context: `Reading handler files`,
+      error: new Error(
+        `Handlers not found, expected file: ${handlersRootFilePath}`
+      ),
     });
     return null;
   }
@@ -56,7 +59,8 @@ export const readHandlers = async ({ ponder }: { ponder: Ponder }) => {
     });
     error.stack = stackTraces.join("\n");
 
-    ponder.emit("indexer_taskError", { error });
+    ponder.emit("dev_error", { context: "Building handler files", error });
+
     return null;
   }
 

--- a/packages/core/src/handlers/readHandlers.ts
+++ b/packages/core/src/handlers/readHandlers.ts
@@ -30,7 +30,7 @@ export const readHandlers = async ({ ponder }: { ponder: Ponder }) => {
 
   if (!existsSync(handlersRootFilePath)) {
     ponder.emit("dev_error", {
-      context: `Reading handler files`,
+      context: `reading handler files`,
       error: new Error(
         `Handlers not found, expected file: ${handlersRootFilePath}`
       ),
@@ -59,7 +59,10 @@ export const readHandlers = async ({ ponder }: { ponder: Ponder }) => {
     });
     error.stack = stackTraces.join("\n");
 
-    ponder.emit("dev_error", { context: "Building handler files", error });
+    ponder.emit("dev_error", {
+      context: `building handler files`,
+      error,
+    });
 
     return null;
   }

--- a/packages/core/src/indexer/tasks/startBackfillForSource.ts
+++ b/packages/core/src/indexer/tasks/startBackfillForSource.ts
@@ -57,8 +57,6 @@ export const startBackfillForSource = async ({
     cacheRate: cacheRate,
   });
 
-  let totalLogTasks = 0;
-
   for (const blockInterval of requiredBlockIntervals) {
     const [startBlock, endBlock] = blockInterval;
     let fromBlock = startBlock;
@@ -75,7 +73,6 @@ export const startBackfillForSource = async ({
         source: source.name,
         taskCount: 1,
       });
-      totalLogTasks++;
       continue;
     }
 
@@ -92,14 +89,7 @@ export const startBackfillForSource = async ({
         source: source.name,
         taskCount: 1,
       });
-      totalLogTasks++;
     }
-  }
-
-  if (ponder.ui.isProd) {
-    ponder.logger.info(
-      `${source.name}: Added ${totalLogTasks} log backfill tasks`
-    );
   }
 
   const killQueues = () => {

--- a/packages/core/src/networks/buildNetworks.ts
+++ b/packages/core/src/networks/buildNetworks.ts
@@ -9,7 +9,7 @@ export const buildNetworks = ({ ponder }: { ponder: Ponder }) => {
   const networks = ponder.config.networks.map(({ name, rpcUrl, chainId }) => {
     if (chainId === undefined || typeof chainId !== "number") {
       ponder.emit("config_error", {
-        context: `Parsing ponder.config.js`,
+        context: `parsing ponder.config.js`,
         error: new Error(
           `Invalid or missing chain ID for network "${name}" in ponder.config.js`
         ),
@@ -18,7 +18,7 @@ export const buildNetworks = ({ ponder }: { ponder: Ponder }) => {
 
     if (rpcUrl === undefined || rpcUrl === "") {
       ponder.emit("config_error", {
-        context: `Parsing ponder.config.js`,
+        context: `parsing ponder.config.js`,
         error: new Error(
           `Invalid or missing RPC URL for network "${name}" in ponder.config.js`
         ),

--- a/packages/core/src/networks/buildNetworks.ts
+++ b/packages/core/src/networks/buildNetworks.ts
@@ -9,14 +9,19 @@ export const buildNetworks = ({ ponder }: { ponder: Ponder }) => {
   const networks = ponder.config.networks.map(({ name, rpcUrl, chainId }) => {
     if (chainId === undefined || typeof chainId !== "number") {
       ponder.emit("config_error", {
-        error: `Invalid or missing chain ID for network "${name}" in ponder.config.js`,
+        context: `Parsing ponder.config.js`,
+        error: new Error(
+          `Invalid or missing chain ID for network "${name}" in ponder.config.js`
+        ),
       });
     }
 
-    // This is a hack, we don't want to actually throw an error inside
     if (rpcUrl === undefined || rpcUrl === "") {
       ponder.emit("config_error", {
-        error: `Invalid or missing RPC URL for network "${name}" in ponder.config.js`,
+        context: `Parsing ponder.config.js`,
+        error: new Error(
+          `Invalid or missing RPC URL for network "${name}" in ponder.config.js`
+        ),
       });
     }
 

--- a/packages/core/src/schema/readSchema.ts
+++ b/packages/core/src/schema/readSchema.ts
@@ -19,9 +19,17 @@ scalar BigInt
 const readSchema = ({ ponder }: { ponder: Ponder }) => {
   const schemaBody = readFileSync(ponder.options.SCHEMA_FILE_PATH);
   const schemaSource = schemaHeader + schemaBody.toString();
-  const schema = buildSchema(schemaSource);
 
-  return schema;
+  try {
+    const schema = buildSchema(schemaSource);
+    return schema;
+  } catch (error) {
+    ponder.emit("dev_error", {
+      context: "Parsing schema.graphql",
+      error: error as Error,
+    });
+    return null;
+  }
 };
 
 export { readSchema };

--- a/packages/core/src/schema/readSchema.ts
+++ b/packages/core/src/schema/readSchema.ts
@@ -25,7 +25,7 @@ const readSchema = ({ ponder }: { ponder: Ponder }) => {
     return schema;
   } catch (error) {
     ponder.emit("dev_error", {
-      context: "Parsing schema.graphql",
+      context: "parsing schema.graphql",
       error: error as Error,
     });
     return null;

--- a/packages/core/src/ui/HandlersBar.tsx
+++ b/packages/core/src/ui/HandlersBar.tsx
@@ -55,7 +55,14 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
           | {ui.handlersCurrent}/{ui.handlersTotal} events
         </Text>
       );
-    if (isStarted) return <Text> | {ui.handlersCurrent}/??? events</Text>;
+    if (isStarted)
+      return (
+        <Text>
+          {" "}
+          | {ui.handlersCurrent}/
+          {"?".repeat(ui.handlersCurrent.toString().length)} events
+        </Text>
+      );
     return null;
   };
 

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -148,12 +148,15 @@ const App = (ui: UiState) => {
       <HandlersBar ui={ui} />
 
       <Box flexDirection="column">
+        <Text bold={true}>Frontfill </Text>
         {Object.values(networks).map((network) => (
           <Box flexDirection="row" key={network.name}>
-            <Text color="cyanBright">[{network.name}] </Text>
+            <Text>
+              {network.name.slice(0, 1).toUpperCase() + network.name.slice(1)} @{" "}
+            </Text>
             {network.blockTxnCount !== -1 ? (
               <Text>
-                Block {network.blockNumber} ({network.blockTxnCount} txs,{" "}
+                block {network.blockNumber} ({network.blockTxnCount} txs,{" "}
                 {network.matchedLogCount} matched logs,{" "}
                 {timestamp - network.blockTimestamp}s ago)
               </Text>
@@ -170,9 +173,9 @@ const App = (ui: UiState) => {
 
       {handlersCurrent > 0 && (
         <Box flexDirection="column">
+          <Text bold={true}>GraphQL </Text>
           <Box flexDirection="row">
-            <Text color="magentaBright">[graphql] </Text>
-            <Text>server live at http://localhost:42069/graphql</Text>
+            <Text>Server live at http://localhost:42069/graphql</Text>
           </Box>
         </Box>
       )}

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -37,12 +37,10 @@ export type UiState = {
   isBackfillComplete: boolean;
   backfillDuration: string;
 
+  handlerError: { context: string; error?: Error } | null;
   handlersCurrent: number;
   handlersTotal: number;
   handlersToTimestamp: number;
-
-  configError: string | null;
-  handlerError: Error | null;
 
   networks: Record<
     string,
@@ -56,7 +54,7 @@ export type UiState = {
   >;
 };
 
-export const getUiState = (options: PonderOptions): UiState => {
+export const getUiState = (options: Pick<PonderOptions, "SILENT">): UiState => {
   return {
     isSilent: options.SILENT,
     isProd: false,
@@ -68,12 +66,10 @@ export const getUiState = (options: PonderOptions): UiState => {
     isBackfillComplete: false,
     backfillDuration: "",
 
+    handlerError: null,
     handlersCurrent: 0,
     handlersTotal: 0,
     handlersToTimestamp: 0,
-
-    configError: null,
-    handlerError: null,
 
     networks: {},
   };
@@ -112,7 +108,6 @@ const App = (ui: UiState) => {
     isBackfillComplete,
     backfillDuration,
     handlersCurrent,
-    configError,
     handlerError,
     networks,
   } = ui;
@@ -121,27 +116,11 @@ const App = (ui: UiState) => {
 
   if (isProd) return null;
 
-  if (configError) {
-    return (
-      <Box flexDirection="column">
-        <Box flexDirection="row">
-          <Text color="redBright" bold={true}>
-            [Config error]{" "}
-          </Text>
-          <Text>
-            {configError}
-            <Newline />
-          </Text>
-        </Box>
-      </Box>
-    );
-  }
-
   if (handlerError) {
     return (
       <Box flexDirection="column">
         <Text> </Text>
-        <Text>{handlerError.stack}</Text>
+        <Text>{handlerError.error?.stack}</Text>
         <Text> </Text>
         <Text color="cyan">
           Resolve the error and save your changes to reload the server.
@@ -212,6 +191,17 @@ const App = (ui: UiState) => {
   );
 };
 
+const {
+  rerender,
+  unmount: inkUnmount,
+  clear,
+} = inkRender(<App {...getUiState({ SILENT: true })} />);
+
 export const render = (ui: UiState) => {
-  inkRender(<App {...ui} />);
+  rerender(<App {...ui} />);
+};
+
+export const unmount = async () => {
+  clear();
+  inkUnmount();
 };

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -9,11 +9,8 @@ import { HandlersBar } from "./HandlersBar";
 
 export type UiState = {
   isSilent: boolean;
-  isProd: boolean;
-
   timestamp: number;
 
-  // See src/README.md. This maps source name to backfill stats.
   stats: Record<
     string,
     {
@@ -57,7 +54,6 @@ export type UiState = {
 export const getUiState = (options: Pick<PonderOptions, "SILENT">): UiState => {
   return {
     isSilent: options.SILENT,
-    isProd: false,
 
     timestamp: 0,
 
@@ -102,7 +98,6 @@ export const hydrateUi = ({
 const App = (ui: UiState) => {
   const {
     isSilent,
-    isProd,
     timestamp,
     stats,
     isBackfillComplete,
@@ -113,8 +108,6 @@ const App = (ui: UiState) => {
   } = ui;
 
   if (isSilent) return null;
-
-  if (isProd) return null;
 
   if (handlerError) {
     return (
@@ -157,9 +150,7 @@ const App = (ui: UiState) => {
       <Box flexDirection="column">
         {Object.values(networks).map((network) => (
           <Box flexDirection="row" key={network.name}>
-            <Text color="cyanBright" bold={true}>
-              [{network.name}]{" "}
-            </Text>
+            <Text color="cyanBright">[{network.name}] </Text>
             {network.blockTxnCount !== -1 ? (
               <Text>
                 Block {network.blockNumber} ({network.blockTxnCount} txs,{" "}
@@ -168,7 +159,7 @@ const App = (ui: UiState) => {
               </Text>
             ) : (
               <Text>
-                Block {network.blockNumber} (
+                block {network.blockNumber} (
                 {Math.max(timestamp - network.blockTimestamp, 0)}s ago)
               </Text>
             )}
@@ -180,10 +171,8 @@ const App = (ui: UiState) => {
       {handlersCurrent > 0 && (
         <Box flexDirection="column">
           <Box flexDirection="row">
-            <Text color="magentaBright" bold={true}>
-              [graphql]{" "}
-            </Text>
-            <Text>Server live at http://localhost:42069/graphql</Text>
+            <Text color="magentaBright">[graphql] </Text>
+            <Text>server live at http://localhost:42069/graphql</Text>
           </Box>
         </Box>
       )}
@@ -197,11 +186,11 @@ const {
   clear,
 } = inkRender(<App {...getUiState({ SILENT: true })} />);
 
-export const render = (ui: UiState) => {
-  rerender(<App {...ui} />);
+export const render = (isDev: boolean, ui: UiState) => {
+  if (isDev) rerender(<App {...ui} />);
 };
 
-export const unmount = async () => {
+export const unmount = () => {
   clear();
   inkUnmount();
 };

--- a/packages/core/test/main.test.ts
+++ b/packages/core/test/main.test.ts
@@ -45,6 +45,7 @@ describe("Ponder", () => {
 
   beforeEach(() => {
     ponder = new Ponder({
+      isDev: true,
       rootDir: "./test/basic",
       configFile: "ponder.config.js",
       silent: false,
@@ -96,13 +97,10 @@ describe("Ponder", () => {
       expect(ponder.entityStore).toBeInstanceOf(SqliteEntityStore);
     });
 
-    it("builds the schema", async () => {
-      expect(ponder.schema.entities.length).toBe(1);
-    });
-
     it("registers event listeners", async () => {
       expect(ponder.eventNames()).toMatchObject([
         "config_error",
+        "dev_error",
         "backfill_networkConnected",
         "backfill_sourceStarted",
         "backfill_logTasksAdded",
@@ -113,7 +111,6 @@ describe("Ponder", () => {
         "frontfill_newLogs",
         "indexer_taskStarted",
         "indexer_taskDone",
-        "indexer_taskError",
       ]);
     });
 
@@ -147,6 +144,18 @@ describe("Ponder", () => {
       expect(tableNames).toContain("__ponder__v1__contractCalls");
     });
 
+    it("creates the handler queue", async () => {
+      await ponder.setup();
+
+      expect(ponder.handlerQueue).toBeTruthy();
+    });
+
+    it("builds the schema", async () => {
+      await ponder.setup();
+
+      expect(ponder.schema?.entities.length).toBe(1);
+    });
+
     it("migrates the entity store", async () => {
       await ponder.setup();
 
@@ -156,12 +165,6 @@ describe("Ponder", () => {
       const tableNames = tables.map((t) => t.name);
 
       expect(tableNames).toContain("File");
-    });
-
-    it("creates the handler queue", async () => {
-      await ponder.setup();
-
-      expect(ponder.handlerQueue).toBeTruthy();
     });
   });
 

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -210,7 +210,7 @@ services:
     buildCommand: ${packageManager} install
     startCommand: ${runCommand} start
     envVars:
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase:
           name: ponder-db
           property: connectionString

--- a/packages/create-ponder/src/templates/etherscan.ts
+++ b/packages/create-ponder/src/templates/etherscan.ts
@@ -48,7 +48,7 @@ export const fromEtherscan = async (options: CreatePonderOptions) => {
   // Write contract ABI file.
   const abiRelativePath = `./abis/${contractName}.json`;
   const abiAbsolutePath = path.join(ponderRootDir, abiRelativePath);
-  writeFileSync(abiAbsolutePath, abi);
+  writeFileSync(abiAbsolutePath, prettier.format(abi, { parser: "json" }));
 
   const schemaGraphqlFileContents = `
     type ExampleEntity @entity {

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -18,9 +18,6 @@ export const graphqlPlugin: PonderPlugin<PonderGraphqlPluginOptions> = ({
     name: "graphql",
     setup: async (ponder) => {
       if (!ponder.schema) {
-        ponder.logger.error(
-          "Cannot setup @ponder/graphql before building schema"
-        );
         return;
       }
 
@@ -38,9 +35,6 @@ export const graphqlPlugin: PonderPlugin<PonderGraphqlPluginOptions> = ({
     },
     reload: async (ponder) => {
       if (!ponder.schema) {
-        ponder.logger.error(
-          "Cannot setup @ponder/graphql before building schema"
-        );
         return;
       }
 

--- a/packages/graphql/src/server/index.ts
+++ b/packages/graphql/src/server/index.ts
@@ -36,9 +36,6 @@ export class GraphqlServer {
       const port = newPort || this.port;
       this.app.use("/graphql", (...args) => this.graphqlMiddleware!(...args));
       this.server = this.app.listen(port);
-      // this.logger.info(
-      //   `\x1b[35m${`Serving GraphQL API at http://localhost:${port}/graphql`}\x1b[0m`
-      // ); // magenta
     } else if (newPort && newPort !== this.port) {
       this.port = newPort;
       // Close all connections to the now-stale server.

--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,7 @@ services:
         sync: false
       - key: START_BLOCK
         sync: false
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase:
           name: ponder-examples-db
           property: connectionString
@@ -27,7 +27,7 @@ services:
     envVars:
       - key: PONDER_RPC_URL_1
         sync: false
-      - key: POSTGRES_URL
+      - key: DATABASE_URL
         fromDatabase:
           name: ponder-examples-db
           property: connectionString


### PR DESCRIPTION
This PR aims to improve logging and error handling.

- `schema.graphql` is now hot reloaded and schema parsing errors are handled by the dev error handler (shouldn't exit process)
- `ponder dev` displays the dev UI + `event` and `error` messages
- `ponder start` does not display the dev UI but logs `backfill`, `frontfill`, and `indexer` messages

Also
- Fixes a bug where `create-ponder` would not format ABIs downloaded from etherscan
- Renames `POSTGRES_URL` -> `DATABASE_URL` everywhere (for consistency with Railway naming)
- Refactors the `ponder` script to directly init the `Ponder` instance; deletes the `cli/` dir and files in there