### PR TITLE
Improve contract calls

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -85,6 +85,9 @@ export class Ponder extends EventEmitter<Events> {
   logsProcessedToTimestamp: number;
   isHandlingLogs: boolean;
 
+  // Contract call state
+  currentEventBlockTag: number;
+
   // Hot reloading
   watchFiles: string[];
   killFrontfillQueues?: () => void;
@@ -124,6 +127,7 @@ export class Ponder extends EventEmitter<Events> {
 
     this.logsProcessedToTimestamp = 0;
     this.isHandlingLogs = false;
+    this.currentEventBlockTag = 0;
     this.ui = getUiState(this.options);
 
     this.config = readPonderConfig(this.options.PONDER_CONFIG_FILE_PATH);

--- a/packages/core/src/codegen/ethers-abitype/README.md
+++ b/packages/core/src/codegen/ethers-abitype/README.md
@@ -1,3 +1,1 @@
-The files in this directory were copied from `wagmi`. This directory exports a generic type `AbitypedEthersContract` that `@ponder/core` re-exports. This generic type is used in the `contracts.ts` file that Ponder generates and handler files import.
-
-In the future, I hope/expect to remove all of this, remove `@ponder/core`'s dependency on `abitype`, and add `abitype` as a dev dependency for Ponder projects.
+The files in this directory were copied and modified from `wagmi`. This directory exports a generic type `ReadOnlyContract` that `@ponder/core` re-exports. This generic type is used in the `contracts.ts` file that Ponder generates and handler files import.

--- a/packages/core/src/codegen/ethers-abitype/contracts.ts
+++ b/packages/core/src/codegen/ethers-abitype/contracts.ts
@@ -1,6 +1,4 @@
-/* eslint-disable prettier/prettier */
-
-import {
+import type {
   Abi,
   AbiEvent,
   AbiFunction,
@@ -14,282 +12,130 @@ import {
   Narrow,
   ResolvedConfig,
 } from 'abitype'
-import { ethers } from 'ethers'
+import type { ethers } from 'ethers'
 
-import { IsNever, Join, NotEqual, Or } from './utils'
+import type { Join } from './utils'
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Contract Configuration Types
+export type Contract<
+  TAbi extends Abi | readonly unknown[] = Abi | readonly unknown[],
+  TFunctionName extends string = string,
+> = { abi: TAbi; functionName: TFunctionName }
 
-/**
- * Configuration options for contract types
- */
-export type Options = {
-  /** Flag for making `abi` optional */
-  isAbiOptional?: boolean
-  /** Flag for making `address` optional */
-  isAddressOptional?: boolean
-  /** Flag for making `args` optional */
-  isArgsOptional?: boolean
-  /** Flag for making `functionName` optional */
-  isFunctionNameOptional?: boolean
-}
-/**
- * Default {@link Options}
- */
-export type DefaultOptions = {
-  isAbiOptional: false
-  isAddressOptional: false
-  isArgsOptional: false
-  isFunctionNameOptional: false
-}
+export type GetConfig<
+  TAbi extends Abi | readonly unknown[] = Abi,
+  TFunctionName extends string = string,
+  TAbiStateMutability extends AbiStateMutability = AbiStateMutability,
+> = {
+  /** Contract ABI */
+  abi: Narrow<TAbi> // infer `TAbi` type for inline usage
+  /** Contract address */
+  address: Address
+  /** Function to invoke on the contract */
+  functionName: GetFunctionName<TAbi, TFunctionName, TAbiStateMutability>
+} & GetArgs<TAbi, TFunctionName>
 
-/**
- * Gets arguments of contract function
- *
- * @param TAbi - Contract {@link Abi}
- * @param TFunctionName - Name of contract function
- * @param TOptions - Options for configuring arguments. Defaults to {@link DefaultOptions}.
- * @returns Inferred args of contract function
- *
- * @example
- * type Result = GetArgs<[…], 'tokenURI'>
- */
+export type GetFunctionName<
+  TAbi extends Abi | readonly unknown[] = Abi,
+  TFunctionName extends string = string,
+  TAbiStateMutability extends AbiStateMutability = AbiStateMutability,
+> = TAbi extends Abi
+  ? ExtractAbiFunctionNames<
+      TAbi,
+      TAbiStateMutability
+    > extends infer AbiFunctionNames
+    ?
+        | AbiFunctionNames
+        | (TFunctionName extends AbiFunctionNames ? TFunctionName : never)
+        | (Abi extends TAbi ? string : never)
+    : never
+  : TFunctionName
+
 export type GetArgs<
   TAbi extends Abi | readonly unknown[],
-  // It's important that we use `TFunction` to parse args so overloads still return the correct types
-  TFunction extends AbiFunction & { type: 'function' },
-  TOptions extends Options = DefaultOptions,
-> = TFunction['inputs'] extends infer TInputs extends readonly AbiParameter[]
-  ? // Check if valid ABI. If `TInputs` is `never` or `TAbi` does not have the same shape as `Abi`, then return optional `readonly unknown[]` args.
-    Or<IsNever<TInputs>, NotEqual<TAbi, Abi>> extends true
-    ? {
-        /**
-         * Arguments to pass contract method
-         *
-         * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link abi} for type inference.
-         */
-        args?: readonly unknown[]
-      }
-    : // If there are no inputs, do not include `args` in the return type.
-    TInputs['length'] extends 0
-    ? { args?: never }
-    : AbiParametersToPrimitiveTypes<TInputs> extends infer TArgs
-    ? TOptions['isArgsOptional'] extends true
-      ? {
-          /** Arguments to pass contract method */
-          args?: TArgs
-        }
-      : {
-          /** Arguments to pass contract method */
-          args: TArgs
-        }
-    : never
-  : never
-
-/**
- * Contract configuration object for inferring function name and arguments based on {@link TAbi}.
- */
-export type ContractConfig<
-  TContract = { [key: string]: unknown },
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = string,
-  TFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
+  TFunctionName extends string,
+  TAbiFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
     ? ExtractAbiFunction<TAbi, TFunctionName>
-    : never,
-  TOptions extends Options = DefaultOptions,
-> = (TOptions['isAbiOptional'] extends true
+    : AbiFunction & { type: 'function' },
+  TArgs = AbiParametersToPrimitiveTypes<TAbiFunction['inputs']>,
+  FailedToParseArgs =
+    | ([TArgs] extends [never] ? true : false)
+    | (readonly unknown[] extends TArgs ? true : false),
+> = true extends FailedToParseArgs
   ? {
-      /** Contract ABI */
-      abi?: Narrow<TAbi>
+      /**
+       * Arguments to pass contract method
+       *
+       * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link abi} for type inference.
+       */
+      args?: readonly unknown[]
     }
+  : TArgs extends readonly []
+  ? { args?: never }
   : {
-      /** Contract ABI */
-      abi: Narrow<TAbi>
-    }) &
-  (TOptions['isAddressOptional'] extends true
-    ? {
-        /** Contract address */
-        address?: string
-      }
-    : {
-        /** Contract address */
-        address: string
-      }) &
-  (TOptions['isFunctionNameOptional'] extends true
-    ? {
-        /** Function to invoke on the contract */
-        // If `TFunctionName` is `never`, then ABI was not parsable. Fall back to `string`.
-        functionName?: IsNever<TFunctionName> extends true
-          ? string
-          : TFunctionName
-      }
-    : {
-        /** Function to invoke on the contract */
-        // If `TFunctionName` is `never`, then ABI was not parsable. Fall back to `string`.
-        functionName: IsNever<TFunctionName> extends true
-          ? string
-          : TFunctionName
-      }) &
-  GetArgs<TAbi, TFunction, TOptions> &
-  TContract
-
-// Properties to remove from extended config since they are added by default with `ContractConfig`
-type OmitConfigProperties = 'abi' | 'args' | 'functionName'
-/**
- * Gets configuration type of contract function
- *
- * @param TContract - Contract config in `{ abi: Abi, functionName: string }` format
- * @param TAbiStateMutibility - State mutability of contract function
- * @param TOptions - Options for configuring arguments. Defaults to {@link DefaultOptions}.
- * @returns Inferred configuration type of contract function
- *
- * @example
- * type Result = GetConfig<{ abi: […], functionName: 'tokenURI' }, 'view'>
- */
-export type GetConfig<
-  TContract = unknown,
-  TAbiStateMutibility extends AbiStateMutability = AbiStateMutability,
-  TOptions extends Options = DefaultOptions,
-> = TContract extends {
-  abi: infer TAbi extends Abi
-  functionName: infer TFunctionName extends string
-}
-  ? ContractConfig<
-      Omit<TContract, OmitConfigProperties>,
-      TAbi,
-      ExtractAbiFunctionNames<TAbi, TAbiStateMutibility>,
-      ExtractAbiFunction<TAbi, TFunctionName>,
-      TOptions
-    >
-  : TContract extends {
-      abi: infer TAbi extends readonly unknown[]
-      functionName: infer TFunctionName extends string
+      /** Arguments to pass contract method */ args: TArgs
     }
-  ? ContractConfig<
-      Omit<TContract, OmitConfigProperties>,
-      TAbi,
-      TFunctionName,
-      never,
-      TOptions
-    >
-  : ContractConfig<
-      Omit<TContract, OmitConfigProperties>,
-      Abi,
-      string,
-      never,
-      TOptions
-    >
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Contract Result Types
-
-/**
- * Unwraps return type of contract function
- *
- * @param TAbi - Contract {@link Abi}
- * @param TFunctionName - Name of contract function
- * @returns Inferred return type of contract function
- *
- * @example
- * type Result = GetResult<[…], 'tokenURI'>
- */
-type GetResult<
+export type GetReturnType<
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-  TFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
+  TAbiFunction extends AbiFunction & {
+    type: 'function'
+  } = TAbi extends Abi
     ? ExtractAbiFunction<TAbi, TFunctionName>
-    : never,
-> =
-  // Save `TOutputs` to local variable
-  TFunction['outputs'] extends infer TOutputs extends readonly AbiParameter[]
-    ? // Check if valid ABI. If `TOutputs` is `never` or `TAbi` does not have the same shape as `Abi`, then return `unknown` as result.
-      Or<IsNever<TOutputs>, NotEqual<TAbi, Abi>> extends true
-      ? unknown
-      : // Save `TLength` to local variable for comparisons
-      TOutputs['length'] extends infer TLength
-      ? TLength extends 0
-        ? void // If there are no outputs, return `void`
-        : TLength extends 1
-        ? AbiParameterToPrimitiveType<TOutputs[0]> // If there is one output, return the primitive type
-        : // If outputs are inferrable, must be a known type. Convert to TypeScript primitives.
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        TOutputs extends readonly [...infer _]
-        ? /**
-           * Return output as array assigned to an object with named keys
-           *
-           * | Outputs                                                               | Result                                                     |
-           * | --------------------------------------------------------------------- | ---------------------------------------------------------- |
-           * | `[{ name: 'foo', type: 'uint256' }, { name: 'bar', type: 'string' }]` | `readonly [bigint, string] & { foo: bigint; bar: string }` |
-           * | `[{ name: 'foo', type: 'uint256' }, { name: '', type: 'string' }]`    | `readonly [bigint, string] & { foo: bigint }`              |
-           */
-          {
-            [Output in TOutputs[number] as Output['name'] extends ''
-              ? never
-              : Output['name']]: AbiParameterToPrimitiveType<Output>
-          } & AbiParametersToPrimitiveTypes<TOutputs>
-        : unknown
-      : never
-    : never
-
-/**
- * Gets return type of contract function
- *
- * @param TContract - Contract config in `{ abi: Abi, functionName: string }` format
- * @returns Inferred return type of contract function
- *
- * @example
- * type Result = GetReturnType<{ abi: […], functionName: 'tokenURI' }>
- */
-export type GetReturnType<TContract = unknown> = TContract extends {
-  abi: infer TAbi extends Abi
-  functionName: infer TFunctionName extends string
-}
-  ? GetResult<TAbi, TFunctionName, ExtractAbiFunction<TAbi, TFunctionName>>
-  : TContract extends {
-      abi: infer TAbi extends readonly unknown[]
-      functionName: infer TFunctionName extends string
+    : AbiFunction & { type: 'function' },
+  TArgs = AbiParametersToPrimitiveTypes<TAbiFunction['outputs']>,
+  FailedToParseArgs =
+    | ([TArgs] extends [never] ? true : false)
+    | (readonly unknown[] extends TArgs ? true : false),
+> = true extends FailedToParseArgs
+  ? unknown
+  : TArgs extends readonly []
+  ? void
+  : TArgs extends readonly [infer Arg]
+  ? Arg
+  : TArgs & {
+      // Construct ethers hybrid array-objects for named outputs.
+      [Output in TAbiFunction['outputs'][number] as Output extends {
+        name: infer Name extends string
+      }
+        ? Name extends ''
+          ? never
+          : Name
+        : never]: AbiParameterToPrimitiveType<Output>
     }
-  ? GetResult<TAbi, TFunctionName>
-  : GetResult
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Contract List Types
 
 // Avoid TS depth-limit error in case of large array literal
 type MAXIMUM_DEPTH = 20
 
 /**
  * ContractsConfig reducer recursively unwraps function arguments to infer/enforce type param
- *
- * @param TContracts - Array of contracts in shape of {@link ContractConfig}
- * @returns Array of inferred contract configurations
  */
 export type ContractsConfig<
-  TContracts extends unknown[],
-  TContractProperties extends { [key: string]: unknown } = {
-    [key: string]: unknown
-  },
-  TOptions extends Options = DefaultOptions,
+  TContracts extends Contract[],
+  TProperties extends Record<string, any> = object,
   Result extends any[] = [],
   Depth extends ReadonlyArray<number> = [],
 > = Depth['length'] extends MAXIMUM_DEPTH
-  ? GetConfig<TContractProperties, 'pure' | 'view', TOptions>[]
+  ? (GetConfig & TProperties)[]
   : TContracts extends []
   ? []
-  : TContracts extends [infer Head]
+  : TContracts extends [infer Head extends Contract]
   ? [
       ...Result,
-      GetConfig<Head & TContractProperties, 'pure' | 'view', TOptions>,
+      GetConfig<Head['abi'], Head['functionName'], 'pure' | 'view'> &
+        TProperties,
     ]
-  : TContracts extends [infer Head, ...infer Tail]
+  : TContracts extends [
+      infer Head extends Contract,
+      ...infer Tail extends Contract[],
+    ]
   ? ContractsConfig<
       [...Tail],
-      TContractProperties,
-      TOptions,
+      TProperties,
       [
         ...Result,
-        GetConfig<Head & TContractProperties, 'pure' | 'view', TOptions>,
+        GetConfig<Head['abi'], Head['functionName'], 'pure' | 'view'> &
+          TProperties,
       ],
       [...Depth, 1]
     >
@@ -297,74 +143,38 @@ export type ContractsConfig<
   ? TContracts
   : // If `TContracts` is *some* array but we couldn't assign `unknown[]` to it, then it must hold some known/homogenous type!
   // use this to infer the param types in the case of Array.map() argument
-  TContracts extends ContractConfig<
-      infer TContract,
-      infer TAbi,
-      infer TFunctionName,
-      infer TFunction
-    >[]
-  ? ContractConfig<
-      Omit<TContract & TContractProperties, OmitConfigProperties>,
-      TAbi,
-      TFunctionName,
-      TFunction,
-      TOptions
-    >[]
-  : GetConfig<TContractProperties, 'pure' | 'view', TOptions>[]
+  TContracts extends GetConfig<infer TAbi, infer TFunctionName>[]
+  ? (GetConfig<TAbi, TFunctionName> & TProperties)[]
+  : (GetConfig & TProperties)[]
 
 /**
  * ContractsResult reducer recursively maps type param to results
- *
- * @param TContracts - Array of contracts in shape of {@link ContractConfig}
- * @returns Array of inferred contract results
  */
 export type ContractsResult<
-  TContracts extends unknown[],
+  TContracts extends Contract[],
   Result extends any[] = [],
   Depth extends ReadonlyArray<number> = [],
 > = Depth['length'] extends MAXIMUM_DEPTH
   ? GetReturnType[]
   : TContracts extends []
   ? []
-  : TContracts extends [infer Head]
-  ? [...Result, GetReturnType<Head>]
-  : TContracts extends [infer Head, ...infer Tail]
-  ? ContractsResult<[...Tail], [...Result, GetReturnType<Head>], [...Depth, 1]>
-  : TContracts extends ContractConfig<
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      infer _TContract,
-      infer TAbi,
-      infer TFunctionName
-    >[]
-  ? // Dynamic-size (homogenous) UseQueryOptions array: map directly to array of results
-    GetReturnType<{ abi: TAbi; functionName: TFunctionName }>[]
+  : TContracts extends [infer Head extends Contract]
+  ? [...Result, GetReturnType<Head['abi'], Head['functionName']>]
+  : TContracts extends [
+      infer Head extends Contract,
+      ...infer Tail extends Contract[],
+    ]
+  ? ContractsResult<
+      [...Tail],
+      [...Result, GetReturnType<Head['abi'], Head['functionName']>],
+      [...Depth, 1]
+    >
+  : TContracts extends GetConfig<infer TAbi, infer TFunctionName>[]
+  ? GetReturnType<TAbi, TFunctionName>[]
   : GetReturnType[]
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Utilities
-
-/**
- * Converts array of {@link AbiEvent} parameters to corresponding TypeScript primitive types.
- *
- * @param TAbiEventParameters - Array of {@link AbiEvent} parameters to convert to TypeScript representations
- * @returns Array of TypeScript primitive types
- */
-export type AbiEventParametersToPrimitiveTypes<
-  TAbiEventParameters extends readonly (AbiParameter & {
-    indexed?: boolean
-  })[],
-  Options extends { AllowNull: boolean } = { AllowNull: false },
-> = {
-  // TODO: Convert to labeled tuple so parameter names show up in autocomplete
-  // e.g. [foo: string, bar: string]
-  // https://github.com/microsoft/TypeScript/issues/44939
-  [K in keyof TAbiEventParameters]: TAbiEventParameters[K]['indexed'] extends true
-    ?
-        | AbiParameterToPrimitiveType<TAbiEventParameters[K]>
-        // If event is not `indexed: true`, add `null` to type
-        | (Options['AllowNull'] extends true ? null : never)
-    : null
-}
 
 /**
  * Get name for {@link AbiFunction} or {@link AbiEvent}
@@ -431,7 +241,7 @@ export type Event<TAbiEvent extends AbiEvent> = Omit<
   ethers.Event,
   'args' | 'event' | 'eventSignature'
 > & {
-  args: AbiEventParametersToPrimitiveTypes<TAbiEvent['inputs']>
+  args: AbiParametersToPrimitiveTypes<TAbiEvent['inputs']>
   event: TAbiEvent['name']
   eventSignature: AbiItemName<TAbiEvent, true>
 }

--- a/packages/core/src/codegen/ethers-abitype/getContract.ts
+++ b/packages/core/src/codegen/ethers-abitype/getContract.ts
@@ -8,171 +8,39 @@ import {
   AbiParametersToPrimitiveTypes,
   AbiParameterToPrimitiveType,
   Address,
-  ExtractAbiEvent,
-  ExtractAbiEventNames,
-  Narrow,
-  ResolvedConfig,
-} from 'abitype'
-import {
-  Contract as EthersContract,
-  ContractInterface,
-  ethers,
-  providers,
-  Signer,
-} from 'ethers'
+} from "abitype";
+import { Contract as EthersContract, ethers } from "ethers";
 
-import {
-  AbiEventParametersToPrimitiveTypes,
-  AbiItemName,
-  Event,
-  GetOverridesForAbiStateMutability,
-} from './contracts'
-import {
-  CountOccurrences,
-  IsUnknown,
-  UnionToIntersection,
-} from './utils'
-
-export type GetContractArgs<TAbi extends Abi | readonly unknown[] = Abi> = {
-  /** Contract address */
-  address: string
-  /** Contract ABI */
-  abi: Narrow<TAbi>
-  /** Signer or provider to attach to contract */
-  signerOrProvider?: Signer | providers.Provider
-}
-
-export type GetContractResult<TAbi = unknown> = TAbi extends Abi
-  ? Contract<TAbi> & EthersContract
-  : EthersContract
-
-export function getContract<TAbi extends Abi | readonly unknown[]>({
-  address,
-  abi,
-  signerOrProvider,
-}: GetContractArgs<TAbi>): GetContractResult<TAbi> {
-  return new EthersContract(
-    address,
-    abi as unknown as ContractInterface,
-    signerOrProvider,
-  ) as GetContractResult<TAbi>
-}
+import { AbiItemName, GetOverridesForAbiStateMutability } from "./contracts";
+import { CountOccurrences, IsUnknown, UnionToIntersection } from "./utils";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Contract
 
-// TODO: Add remaining properties
-type PropertyKeys =
-  | 'address'
-  | 'attach'
-  | 'connect'
-  | 'deployed'
-  | 'interface'
-  | 'resolvedAddress'
-type FunctionKeys =
-  | 'callStatic'
-  | 'estimateGas'
-  | 'functions'
-  | 'populateTransaction'
-type EventKeys =
-  | 'emit'
-  | 'filters'
-  | 'listenerCount'
-  | 'listeners'
-  | 'off'
-  | 'on'
-  | 'once'
-  | 'queryFilter'
-  | 'removeAllListeners'
-  | 'removeListener'
+type Keys = "address" | "interface" | "functions";
 // Create new `BaseContract` and remove keys we are going to type
 type BaseContract<
-  TContract extends Record<
-    keyof Pick<EthersContract, PropertyKeys | FunctionKeys | EventKeys>,
-    unknown
-  >,
-> = Omit<EthersContract, PropertyKeys | FunctionKeys | EventKeys> & TContract
+  TContract extends Record<keyof Pick<EthersContract, Keys>, unknown>
+> = Omit<EthersContract, Keys> & TContract;
 
-// TODO: Add remaining `Interface` properties
-type InterfaceKeys = 'events' | 'functions'
+type InterfaceKeys = "events" | "functions";
 // Create new `Interface` and remove keys we are going to type
 type BaseInterface<
   Interface extends Record<
     keyof Pick<ethers.utils.Interface, InterfaceKeys>,
     unknown
-  >,
-> = Omit<ethers.utils.Interface, InterfaceKeys> & Interface
+  >
+> = Omit<ethers.utils.Interface, InterfaceKeys> & Interface;
 
-export type Contract<
-  TAbi extends Abi,
-  _Functions = Functions<TAbi>,
-> = _Functions &
+export type ReadOnlyContract<TAbi extends Abi> = Functions<TAbi> &
   BaseContract<{
-    address: Address
-    resolvedAddress: Promise<Address>
-    attach(addressOrName: Address | string): Contract<TAbi>
-    connect(
-      signerOrProvider: ethers.Signer | ethers.providers.Provider | string,
-    ): Contract<TAbi>
-    deployed(): Promise<Contract<TAbi>>
+    address: Address;
     interface: BaseInterface<{
-      events: InterfaceEvents<TAbi>
-      functions: InterfaceFunctions<TAbi>
-    }>
-
-    callStatic: _Functions
-    estimateGas: Functions<TAbi, { ReturnType: ResolvedConfig['BigIntType'] }>
-    functions: Functions<TAbi, { ReturnTypeAsArray: true }>
-    populateTransaction: Functions<
-      TAbi,
-      { ReturnType: ethers.PopulatedTransaction }
-    >
-
-    emit<TEventName extends ExtractAbiEventNames<TAbi> | ethers.EventFilter>(
-      eventName: TEventName,
-      ...args: AbiEventParametersToPrimitiveTypes<
-        ExtractAbiEvent<
-          TAbi,
-          TEventName extends string ? TEventName : ExtractAbiEventNames<TAbi>
-        >['inputs']
-      > extends infer TArgs extends readonly unknown[]
-        ? TArgs
-        : never
-    ): boolean
-    filters: Filters<TAbi>
-    listenerCount(): number
-    listenerCount<TEventName extends ExtractAbiEventNames<TAbi>>(
-      eventName: TEventName,
-    ): number
-    // TODO: Improve `eventFilter` type
-    listenerCount(eventFilter: ethers.EventFilter): number
-    listeners(): Array<(...args: any[]) => void>
-    listeners<TEventName extends ExtractAbiEventNames<TAbi>>(
-      eventName: TEventName,
-    ): Array<Listener<TAbi, TEventName>>
-    listeners(
-      // TODO: Improve `eventFilter` and return types
-      eventFilter: ethers.EventFilter,
-    ): Array<Listener<TAbi, ExtractAbiEventNames<TAbi>>>
-    off: EventListener<TAbi>
-    on: EventListener<TAbi>
-    once: EventListener<TAbi>
-    queryFilter<TEventName extends ExtractAbiEventNames<TAbi>>(
-      event: TEventName,
-      fromBlockOrBlockhash?: string | number,
-      toBlock?: string | number,
-    ): Promise<Array<ethers.Event>>
-    // TODO: Improve `eventFilter` and return types
-    queryFilter(
-      eventFilter: ethers.EventFilter,
-      fromBlockOrBlockhash?: string | number,
-      toBlock?: string | number,
-    ): Promise<Array<ethers.Event>>
-    removeAllListeners(eventName?: ExtractAbiEventNames<TAbi>): Contract<TAbi>
-    // TODO: Improve `eventFilter` type
-    removeAllListeners(eventFilter: ethers.EventFilter): Contract<TAbi>
-    removeListener: EventListener<TAbi>
-  }>
+      events: InterfaceEvents<TAbi>;
+      functions: InterfaceFunctions<TAbi>;
+    }>;
+    functions: Functions<TAbi, { ReturnTypeAsArray: true }>;
+  }>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Functions
@@ -192,6 +60,7 @@ export type Functions<
     // 3. Convert functions to TypeScript function signatures
     [K in keyof TAbi]: TAbi[K] extends infer TAbiFunction extends AbiFunction & {
       type: 'function'
+      stateMutability: 'pure' | 'view'
     }
       ? {
           // If function name occurs more than once, it is overloaded. Grab full string signature as name (what ethers does).
@@ -241,9 +110,13 @@ type AbiFunctionReturnType<
       : TLength extends 1
       ? AbiParameterToPrimitiveType<TAbiFunction['outputs'][0]>
       : {
-          [Output in TAbiFunction['outputs'][number] as Output['name'] extends ''
-            ? never
-            : Output['name']]: AbiParameterToPrimitiveType<Output>
+          [Output in TAbiFunction['outputs'][number] as Output extends {
+            name: string
+          }
+            ? Output['name'] extends ''
+              ? never
+              : Output['name']
+            : never]: AbiParameterToPrimitiveType<Output>
         } & AbiParametersToPrimitiveTypes<TAbiFunction['outputs']>
     : never
 })[TAbiFunction['stateMutability']]
@@ -265,52 +138,6 @@ type InterfaceEvents<TAbi extends Abi> = UnionToIntersection<
     [K in keyof TAbi]: TAbi[K] extends infer TAbiEvent extends AbiEvent
       ? {
           [K in AbiItemName<TAbiEvent, true>]: ethers.utils.EventFragment // TODO: Infer `EventFragment` type
-        }
-      : never
-  }[number]
->
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Events
-
-export interface EventListener<TAbi extends Abi> {
-  <TEventName extends ExtractAbiEventNames<TAbi>>(
-    eventName: TEventName,
-    listener: Listener<TAbi, TEventName>,
-  ): Contract<TAbi>
-  (
-    // TODO: Improve `eventFilter` and `listener` types
-    eventFilter: ethers.EventFilter,
-    listener: Listener<TAbi, ExtractAbiEventNames<TAbi>>,
-  ): Contract<TAbi>
-}
-
-type Listener<
-  TAbi extends Abi,
-  TEventName extends string,
-  TAbiEvent extends AbiEvent = ExtractAbiEvent<TAbi, TEventName>,
-> = AbiEventParametersToPrimitiveTypes<
-  TAbiEvent['inputs']
-> extends infer TArgs extends readonly unknown[]
-  ? (...args: [...args: TArgs, event: Event<TAbiEvent>]) => void
-  : never
-
-type Filters<TAbi extends Abi> = UnionToIntersection<
-  {
-    [K in keyof TAbi]: TAbi[K] extends infer TAbiEvent extends AbiEvent
-      ? {
-          [K in CountOccurrences<TAbi, { name: TAbiEvent['name'] }> extends 1
-            ? AbiItemName<TAbiEvent>
-            : AbiItemName<TAbiEvent, true>]: (
-            ...args: TAbiEvent['inputs'] extends infer TAbiParameters extends readonly (AbiParameter & {
-              indexed?: boolean
-            })[]
-              ? AbiEventParametersToPrimitiveTypes<
-                  TAbiParameters,
-                  { AllowNull: true }
-                >
-              : never
-          ) => ethers.EventFilter
         }
       : never
   }[number]

--- a/packages/core/src/codegen/ethers-abitype/index.ts
+++ b/packages/core/src/codegen/ethers-abitype/index.ts
@@ -1,1 +1,11 @@
-export type { Contract as AbitypedEthersContract } from "./getContract";
+import { ethers } from "ethers";
+
+declare module "abitype" {
+  export interface Config {
+    // TODO: Drop `BigNumber` once ethers supports `bigint` natively
+    BigIntType: ethers.BigNumber;
+    IntType: number;
+  }
+}
+
+export type { ReadOnlyContract } from "./getContract";

--- a/packages/core/src/codegen/generateContractTypes.ts
+++ b/packages/core/src/codegen/generateContractTypes.ts
@@ -9,14 +9,14 @@ import { formatPrettier } from "./utils";
 export const generateContractTypes = ({ ponder }: { ponder: Ponder }) => {
   ponder.sources.forEach((source) => {
     const raw = `
-      import { AbitypedEthersContract } from "@ponder/core";
+      import { ReadOnlyContract } from "@ponder/core";
 
       const ${source.name}Abi = ${JSON.stringify(
       source.abi
     ).trimEnd()} as const;
 
       export type ${source.name} =
-        AbitypedEthersContract<typeof ${source.name}Abi>;
+        ReadOnlyContract<typeof ${source.name}Abi>;
     `;
     const final = formatPrettier(raw);
 

--- a/packages/core/src/handlers/handlerQueue.ts
+++ b/packages/core/src/handlers/handlerQueue.ts
@@ -154,6 +154,10 @@ export const createHandlerQueue = ({
       transaction,
     };
 
+    // This enables contract calls occurring within the
+    // handler code to use the event block number by default.
+    ponder.currentEventBlockTag = block.number;
+
     // Running user code here!
     await handler(event, handlerContext);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export type { AbitypedEthersContract } from "@/codegen/ethers-abitype";
+export type { ReadOnlyContract } from "@/codegen/ethers-abitype";
 export type { PonderLogger } from "@/common/logger";
 export type { PonderOptions } from "@/common/options";
 export type { PonderConfig } from "@/common/readPonderConfig";

--- a/packages/core/src/networks/buildNetworks.ts
+++ b/packages/core/src/networks/buildNetworks.ts
@@ -27,7 +27,7 @@ export const buildNetworks = ({ ponder }: { ponder: Ponder }) => {
 
     let provider = cachedProvidersByChainId[chainId];
     if (!provider) {
-      provider = new CachedProvider(ponder.cacheStore, rpcUrl, chainId);
+      provider = new CachedProvider(ponder, rpcUrl, chainId);
       cachedProvidersByChainId[chainId] = provider;
     }
 


### PR DESCRIPTION
This PR improves the typing of the `ethers.Contract` objects that are injected into event handlers via the `context` argument. It also makes it so specifying a `blockTag` for contract calls is optional, and ponder will use a default of `event.block.number` (matching the behavior of the contract calls in subgraphs).

- Fixes a bug where contract function return types were mistyped as `bigint` instead of `ethers.BigNumber`
- Limits the contract type to read functions (`stateMutability` either `view` or `pure`)
- Sets a new default `blockTag` of `event.block.timestamp` for contract calls (the `overrides.blockTag` argument is no longer required)