### PR TITLE
Improve GQL filtering

### DIFF
--- a/packages/core/src/db/entity/entityStore.ts
+++ b/packages/core/src/db/entity/entityStore.ts
@@ -6,7 +6,15 @@ import { SqliteEntityStore } from "./sqliteEntityStore";
 
 export type EntityFilter = {
   where?: {
-    [key: string]: number | string | number[] | string[];
+    [key: string]:
+      | number
+      | string
+      | number[]
+      | string[]
+      | true
+      | false
+      | undefined
+      | null;
   };
   first?: number;
   skip?: number;

--- a/packages/core/src/db/entity/utils.ts
+++ b/packages/core/src/db/entity/utils.ts
@@ -1,8 +1,7 @@
-export const sqlOperatorsForFilterType: Record<
+export const sqlSymbolsForFilterType: Record<
   string,
   | {
       operator: string;
-      isList?: boolean;
       patternPrefix?: string;
       patternSuffix?: string;
     }
@@ -12,8 +11,8 @@ export const sqlOperatorsForFilterType: Record<
   "": { operator: "=" },
   not: { operator: "!=" },
   // singular
-  in: { operator: "in", isList: true },
-  not_in: { operator: "not in", isList: true },
+  in: { operator: "in" },
+  not_in: { operator: "not in" },
   // plural
   contains: { operator: "like", patternPrefix: "%", patternSuffix: "%" },
   contains_nocase: {
@@ -45,4 +44,69 @@ export const sqlOperatorsForFilterType: Record<
   not_starts_with_nocase: { operator: "not like", patternSuffix: "%" },
   not_ends_with: { operator: "not like", patternSuffix: "%" },
   not_ends_with_nocase: { operator: "not like", patternSuffix: "%" },
+};
+
+// Accepts an instance being passed to `insert`, `update`, or `upsert` and
+// returns a list of column names and values to be persisted.
+export const getWhereValue = (
+  value:
+    | boolean
+    | number
+    | string
+    | (number | string | boolean)[]
+    | undefined
+    | null,
+  sqlSymbols: {
+    operator: string;
+    patternPrefix?: string;
+    patternSuffix?: string;
+  }
+): string => {
+  const { operator, patternPrefix, patternSuffix } = sqlSymbols;
+
+  if (value === null) {
+    if (["=", "!="].includes(operator)) {
+      return `${operator === "=" ? "IS" : "IS NOT"} ${value}`;
+    } else {
+      return `${operator} ${value}`;
+    }
+  }
+
+  if (typeof value === "object" && value.length) {
+    return `${operator} (${value
+      .map((v) => (typeof v === "boolean" ? (v ? 1 : 0) : `${v}`))
+      .join(",")})`;
+  }
+
+  if (typeof value === "boolean") {
+    return `${operator} ${value ? 1 : 0}`;
+  }
+
+  let finalValue = value;
+  if (patternPrefix) finalValue = `${patternPrefix}${finalValue}`;
+  if (patternSuffix) finalValue = `${finalValue}${patternSuffix}`;
+
+  return `${operator} '${finalValue}'`;
+};
+
+// Accepts an instance being passed to `insert`, `update`, or `upsert` and
+// returns a list of column names and values to be persisted.
+export const getColumnStatements = (instance: Record<string, unknown>) => {
+  return Object.entries(instance)
+    .map(([fieldName, value]) => {
+      let persistedValue: number | string | null;
+      if (typeof value === "boolean") {
+        persistedValue = value ? 1 : 0;
+      } else if (typeof value === "undefined") {
+        persistedValue = null;
+      } else {
+        persistedValue = `'${value}'`;
+      }
+
+      return {
+        column: `"${fieldName}"`,
+        value: persistedValue,
+      };
+    })
+    .filter(({ value }) => value !== null);
 };


### PR DESCRIPTION
- Improves generation of filter fields to better match subgraph behavior. Known remaining gaps:
  - Relationship fields can now be queried by their ID, but the nested filter field `{fieldName}_: EntityTypeFilter` does not exist (yet)
  - Derived field filter fields do not exist
- Fixes related to the handling of filter fields, especially for booleans, null, and undefined