### PR TITLE
spin up on PORT, fall back to 42069

### DIFF
--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -12,7 +12,7 @@ export type PonderGraphqlPluginOptions = {
 let server: GraphqlServer | undefined;
 
 export const graphqlPlugin: PonderPlugin<PonderGraphqlPluginOptions> = ({
-  port = 42069,
+  port = parseInt(process.env.PORT ?? "0") || 42069,
 } = {}) => {
   return {
     name: "graphql",


### PR DESCRIPTION
This should make it easier to publish to PaaS (i.e. Railway) without extra config.