### PR TITLE
Fix entity store extra quotations and small refactor

### DIFF
--- a/packages/core/src/db/entity/utils.ts
+++ b/packages/core/src/db/entity/utils.ts
@@ -91,7 +91,7 @@ export const getWhereValue = (
 
 // Accepts an instance being passed to `insert`, `update`, or `upsert` and
 // returns a list of column names and values to be persisted.
-export const getColumnStatements = (instance: Record<string, unknown>) => {
+export const getColumnValuePairs = (instance: Record<string, unknown>) => {
   return Object.entries(instance)
     .map(([fieldName, value]) => {
       let persistedValue: number | string | null;
@@ -100,7 +100,7 @@ export const getColumnStatements = (instance: Record<string, unknown>) => {
       } else if (typeof value === "undefined") {
         persistedValue = null;
       } else {
-        persistedValue = `'${value}'`;
+        persistedValue = value as number | string | null;
       }
 
       return {
@@ -108,5 +108,12 @@ export const getColumnStatements = (instance: Record<string, unknown>) => {
         value: persistedValue,
       };
     })
-    .filter(({ value }) => value !== null);
+    .filter(
+      (
+        col
+      ): col is {
+        column: string;
+        value: string | number;
+      } => col.value !== null
+    );
 };


### PR DESCRIPTION
This PR extends the changes in https://github.com/0xOlias/ponder/pull/46 to use the postgres bound parameter syntax of `$1`, `$2` vs the SQLite syntax of `?`, `?`. Also a tiny refactor of the surrounding code.

I manually verified that these methods work locally. Need more automated testing for this type of thing 🙃 

cc @holic 