### PR TITLE
Resolve leading zeros issue #73

### DIFF
--- a/packages/core/src/indexer/queues/blockFrontfillQueue.ts
+++ b/packages/core/src/indexer/queues/blockFrontfillQueue.ts
@@ -1,4 +1,4 @@
-import { BigNumber, utils } from "ethers";
+import { utils } from "ethers";
 import fastq from "fastq";
 
 import type { Network } from "@/config/networks";
@@ -56,14 +56,11 @@ async function blockFrontfillWorker(
     provider.send("eth_getLogs", [
       {
         address: contractAddresses,
-        fromBlock: utils.hexValue(BigNumber.from(blockNumber)),
-        toBlock: utils.hexValue(BigNumber.from(blockNumber)),
+        fromBlock: utils.hexValue(blockNumber),
+        toBlock: utils.hexValue(blockNumber),
       },
     ]),
-    provider.send("eth_getBlockByNumber", [
-      utils.hexValue(BigNumber.from(blockNumber)),
-      true,
-    ]),
+    provider.send("eth_getBlockByNumber", [utils.hexValue(blockNumber), true]),
   ]);
 
   const block = parseBlock(rawBlock);

--- a/packages/core/src/indexer/queues/blockFrontfillQueue.ts
+++ b/packages/core/src/indexer/queues/blockFrontfillQueue.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, utils } from "ethers";
 import fastq from "fastq";
 
 import type { Network } from "@/config/networks";
@@ -56,12 +56,12 @@ async function blockFrontfillWorker(
     provider.send("eth_getLogs", [
       {
         address: contractAddresses,
-        fromBlock: BigNumber.from(blockNumber).toHexString(),
-        toBlock: BigNumber.from(blockNumber).toHexString(),
+        fromBlock: utils.hexValue(BigNumber.from(blockNumber)),
+        toBlock: utils.hexValue(BigNumber.from(blockNumber)),
       },
     ]),
     provider.send("eth_getBlockByNumber", [
-      BigNumber.from(blockNumber).toHexString(),
+      utils.hexValue(BigNumber.from(blockNumber)),
       true,
     ]),
   ]);

--- a/packages/core/src/indexer/queues/logBackfillQueue.ts
+++ b/packages/core/src/indexer/queues/logBackfillQueue.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { utils } from "ethers";
 import fastq from "fastq";
 
 import type { Contract } from "@/config/contracts";
@@ -57,14 +57,11 @@ async function logBackfillWorker(
     provider.send("eth_getLogs", [
       {
         address: contractAddresses,
-        fromBlock: BigNumber.from(fromBlock).toHexString(),
-        toBlock: BigNumber.from(toBlock).toHexString(),
+        fromBlock: utils.hexValue(fromBlock),
+        toBlock: utils.hexValue(toBlock),
       },
     ]),
-    provider.send("eth_getBlockByNumber", [
-      BigNumber.from(toBlock).toHexString(),
-      false,
-    ]),
+    provider.send("eth_getBlockByNumber", [utils.hexValue(toBlock), false]),
   ]);
 
   // The timestamp of the toBlock is required to properly update the cached intervals below.


### PR DESCRIPTION
Should fix issue #73 - note I was not able to get the tests running properly so I'm not certain, but should be a good starting point.

Essentially `toHexString()` converts a `BigNumber` to a padded bytes string of fixed length, where `utils.hexValue` converts them to a quantity and strips leading zeros.