### PR TITLE
Only process logs if a handler has been registered

### DIFF
--- a/.changeset/kind-clocks-report.md
+++ b/.changeset/kind-clocks-report.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed bug where unhandled logs would be fetched from the cache store, also bumped cache store to v2

--- a/packages/core/src/db/cache/cacheStore.ts
+++ b/packages/core/src/db/cache/cacheStore.ts
@@ -23,7 +23,7 @@ export interface CacheStore {
 
   insertCachedInterval(interval: CachedInterval): Promise<void>;
 
-  insertLogs(log: Log[]): Promise<void>;
+  insertLogs(logs: Log[]): Promise<void>;
 
   insertBlock(block: Block): Promise<void>;
 

--- a/packages/core/src/db/cache/cacheStore.ts
+++ b/packages/core/src/db/cache/cacheStore.ts
@@ -32,7 +32,8 @@ export interface CacheStore {
   getLogs(
     contractAddress: string,
     fromBlockTimestamp: number,
-    toBlockTimestamp: number
+    toBlockTimestamp: number,
+    eventSigHashes?: string[]
   ): Promise<Log[]>;
 
   getBlock(hash: string): Promise<Block | null>;

--- a/packages/core/src/db/cache/postgresCacheStore.ts
+++ b/packages/core/src/db/cache/postgresCacheStore.ts
@@ -6,7 +6,7 @@ import type { Block, Log, Transaction } from "@/types";
 
 import type { CachedInterval, CacheStore, ContractCall } from "./cacheStore";
 
-const POSTGRES_TABLE_PREFIX = "__ponder__v1__";
+const POSTGRES_TABLE_PREFIX = "__ponder__v2__";
 
 const cachedIntervalsTableName = `${POSTGRES_TABLE_PREFIX}cachedIntervals`;
 const logsTableName = `${POSTGRES_TABLE_PREFIX}logs`;
@@ -60,7 +60,10 @@ export class PostgresCacheStore implements CacheStore {
           "logSortKey" BIGINT NOT NULL,
           "address" TEXT NOT NULL,
           "data" TEXT NOT NULL,
-          "topics" TEXT NOT NULL,
+          "topic0" TEXT,
+          "topic1" TEXT,
+          "topic2" TEXT,
+          "topic3" TEXT,
           "blockHash" TEXT NOT NULL,
           "blockNumber" INTEGER NOT NULL,
           "blockTimestamp" INTEGER,
@@ -73,6 +76,10 @@ export class PostgresCacheStore implements CacheStore {
       await client.query(`
         CREATE INDEX IF NOT EXISTS "${logsTableName}BlockTimestamp"
         ON "${logsTableName}" ("blockTimestamp")
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS "${logsTableName}Topic0"
+        ON "${logsTableName}" ("topic0")
       `);
 
       await client.query(`
@@ -234,7 +241,10 @@ export class PostgresCacheStore implements CacheStore {
         log.logSortKey,
         log.address,
         log.data,
-        log.topics,
+        log.topic0,
+        log.topic1,
+        log.topic2,
+        log.topic3,
         log.blockHash,
         log.blockNumber,
         log.logIndex,
@@ -250,14 +260,17 @@ export class PostgresCacheStore implements CacheStore {
         "logSortKey",
         "address",
         "data",
-        "topics",
+        "topic0",
+        "topic1",
+        "topic2",
+        "topic3",
         "blockHash",
         "blockNumber",
         "logIndex",
         "transactionHash",
         "transactionIndex",
         "removed"
-      ) VALUES ${buildInsertParams(11, logs.length)}
+      ) VALUES ${buildInsertParams(14, logs.length)}
       ON CONFLICT("logId") DO NOTHING
     `;
 

--- a/packages/core/src/db/cache/sqliteCacheStore.ts
+++ b/packages/core/src/db/cache/sqliteCacheStore.ts
@@ -6,7 +6,7 @@ import type { Block, Log, Transaction } from "@/types";
 
 import type { CachedInterval, CacheStore, ContractCall } from "./cacheStore";
 
-const SQLITE_TABLE_PREFIX = "__ponder__v1__";
+const SQLITE_TABLE_PREFIX = "__ponder__v2__";
 
 const cachedIntervalsTableName = `${SQLITE_TABLE_PREFIX}cachedIntervals`;
 const logsTableName = `${SQLITE_TABLE_PREFIX}logs`;
@@ -52,7 +52,10 @@ export class SqliteCacheStore implements CacheStore {
           "logSortKey" INTEGER NOT NULL,
           "address" TEXT NOT NULL,
           "data" TEXT NOT NULL,
-          "topics" TEXT NOT NULL,
+          "topic0" TEXT,
+          "topic1" TEXT,
+          "topic2" TEXT,
+          "topic3" TEXT,
           "blockHash" TEXT NOT NULL,
           "blockNumber" INTEGER NOT NULL,
           "blockTimestamp" INTEGER,
@@ -69,6 +72,14 @@ export class SqliteCacheStore implements CacheStore {
         `
         CREATE INDEX IF NOT EXISTS "${logsTableName}BlockTimestamp"
         ON "${logsTableName}" ("blockTimestamp")
+        `
+      )
+      .run();
+    this.db
+      .prepare(
+        `
+        CREATE INDEX IF NOT EXISTS "${logsTableName}Topic0"
+        ON "${logsTableName}" ("topic0")
         `
       )
       .run();
@@ -229,7 +240,10 @@ export class SqliteCacheStore implements CacheStore {
         "logSortKey",
         "address",
         "data",
-        "topics",
+        "topic0",
+        "topic1",
+        "topic2",
+        "topic3",
         "blockHash",
         "blockNumber",
         "logIndex",
@@ -241,7 +255,10 @@ export class SqliteCacheStore implements CacheStore {
         @logSortKey,
         @address,
         @data,
-        @topics,
+        @topic0,
+        @topic1,
+        @topic2,
+        @topic3,
         @blockHash,
         @blockNumber,
         @logIndex,

--- a/packages/core/src/db/cache/utils.ts
+++ b/packages/core/src/db/cache/utils.ts
@@ -129,22 +129,29 @@ export const parseTransaction = (txn: any): Transaction => ({
   seem to export types that correspond to the return type of the raw RPC methods.
 */
 
-export const parseLog = (log: any): Log => ({
-  logId: `${log.blockHash}-${log.logIndex}`,
-  logSortKey:
-    hexStringToDecimal(log.blockNumber) * 100000 +
-    hexStringToDecimal(log.logIndex),
+export const parseLog = (log: any): Log => {
+  const topics = log.topics as (string | undefined)[];
 
-  address: log.address,
-  data: log.data,
-  topics: JSON.stringify(log.topics),
+  return {
+    logId: `${log.blockHash}-${log.logIndex}`,
+    logSortKey:
+      hexStringToDecimal(log.blockNumber) * 100000 +
+      hexStringToDecimal(log.logIndex),
 
-  blockHash: log.blockHash,
-  blockNumber: hexStringToDecimal(log.blockNumber),
-  logIndex: hexStringToDecimal(log.logIndex),
+    address: log.address,
+    data: log.data,
+    topic0: topics[0],
+    topic1: topics[1],
+    topic2: topics[2],
+    topic3: topics[3],
 
-  transactionHash: log.transactionHash,
-  transactionIndex: hexStringToDecimal(log.transactionIndex),
+    blockHash: log.blockHash,
+    blockNumber: hexStringToDecimal(log.blockNumber),
+    logIndex: hexStringToDecimal(log.logIndex),
 
-  removed: log.removed === true ? 1 : 0,
-});
+    transactionHash: log.transactionHash,
+    transactionIndex: hexStringToDecimal(log.transactionIndex),
+
+    removed: log.removed === true ? 1 : 0,
+  };
+};

--- a/packages/core/src/handlers/decodeLog.ts
+++ b/packages/core/src/handlers/decodeLog.ts
@@ -14,7 +14,9 @@ export const decodeLog = ({
   try {
     const parsedLog = abiInterface.parseLog({
       data: log.data,
-      topics: JSON.parse(log.topics),
+      topics: [log.topic0, log.topic1, log.topic2, log.topic3].filter(
+        (element): element is string => element !== undefined
+      ),
     });
 
     const eventName = parsedLog.name;

--- a/packages/core/src/handlers/decodeLog.ts
+++ b/packages/core/src/handlers/decodeLog.ts
@@ -12,11 +12,13 @@ export const decodeLog = ({
   abiInterface: ethers.utils.Interface;
 }) => {
   try {
+    const topics = [log.topic0, log.topic1, log.topic2, log.topic3].filter(
+      (element): element is string => !!element
+    );
+
     const parsedLog = abiInterface.parseLog({
       data: log.data,
-      topics: [log.topic0, log.topic1, log.topic2, log.topic3].filter(
-        (element): element is string => element !== undefined
-      ),
+      topics: topics,
     });
 
     const eventName = parsedLog.name;

--- a/packages/core/src/handlers/handlerQueue.ts
+++ b/packages/core/src/handlers/handlerQueue.ts
@@ -82,7 +82,12 @@ export const createHandlerQueue = ({
     const decodedLog = decodeLog({ log, abiInterface: contract.abiInterface });
     if (!decodedLog) {
       logger.warn(
-        `Event log not found in ABI, data: ${log.data} topics: ${log.topics}`
+        `Event log not found in ABI, data: ${log.data} topics: ${[
+          log.topic0,
+          log.topic1,
+          log.topic2,
+          log.topic3,
+        ]}`
       );
       return;
     }

--- a/packages/core/src/indexer/tasks/getLogs.ts
+++ b/packages/core/src/indexer/tasks/getLogs.ts
@@ -1,3 +1,5 @@
+import { utils } from "ethers";
+
 import { Ponder } from "@/Ponder";
 
 export const getLogs = async ({
@@ -44,15 +46,51 @@ export const getLogs = async ({
     return { hasNewLogs: false, logs: [], toTimestamp: fromTimestamp };
   }
 
+  // For UI/reporting purposes, also keep track of the total number of logs
+  // found (not just those being handled)
+  let totalLogCount = 0;
+
   // NOTE: cacheStore.getLogs is exclusive to the left and inclusive to the right.
   // This is fine because this.latestProcessedTimestamp starts at zero.
   const rawLogs = await Promise.all(
-    contracts.map((contract) =>
-      ponder.cacheStore.getLogs(contract.address, fromTimestamp, toTimestamp)
-    )
+    contracts.map(async (contract) => {
+      const handlers = ponder.handlers ?? {};
+
+      const contractHandlers = handlers[contract.name] ?? {};
+      const eventNames = Object.keys(contractHandlers);
+
+      const eventSigHashes = eventNames
+        .map((eventName) => {
+          try {
+            const fragment = contract.abiInterface.getEvent(eventName);
+            const signature = fragment.format();
+            const hash = utils.solidityKeccak256(["string"], [signature]);
+            return hash;
+          } catch (err) {
+            ponder.logger.error(
+              `Unable to generate event sig hash for event: ${eventName}`
+            );
+          }
+        })
+        .filter((hash): hash is string => !!hash);
+
+      const [logs, totalLogs] = await Promise.all([
+        ponder.cacheStore.getLogs(
+          contract.address,
+          fromTimestamp,
+          toTimestamp,
+          eventSigHashes
+        ),
+        ponder.cacheStore.getLogs(contract.address, fromTimestamp, toTimestamp),
+      ]);
+
+      totalLogCount += totalLogs.length;
+
+      return logs;
+    })
   );
 
   const logs = rawLogs.flat().sort((a, b) => a.logSortKey - b.logSortKey);
 
-  return { hasNewLogs: true, toTimestamp, logs };
+  return { hasNewLogs: true, toTimestamp, logs, totalLogCount };
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,7 +111,10 @@ export interface Log {
 
   address: string;
   data: string;
-  topics: string; // JSON.stringify-ed array of topic strings
+  topic0?: string;
+  topic1?: string;
+  topic2?: string;
+  topic3?: string;
 
   blockHash: string;
   blockNumber: number;

--- a/packages/core/src/ui/HandlersBar.tsx
+++ b/packages/core/src/ui/HandlersBar.tsx
@@ -5,7 +5,8 @@ import { UiState } from "./app";
 import { ProgressBar } from "./ProgressBar";
 
 export const HandlersBar = ({ ui }: { ui: UiState }) => {
-  const completionRate = ui.handlersCurrent / Math.max(ui.handlersTotal, 1);
+  const completionRate =
+    ui.handlersCurrent / Math.max(ui.handlersHandledTotal, 1);
   const completionDecimal = Math.round(completionRate * 1000) / 10;
   const completionText =
     Number.isInteger(completionDecimal) && completionDecimal < 100
@@ -33,7 +34,7 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
   const dateText = `${month} ${day}, ${year}`;
 
   const isUpToDate =
-    ui.isBackfillComplete && ui.handlersCurrent === ui.handlersTotal;
+    ui.isBackfillComplete && ui.handlersCurrent === ui.handlersHandledTotal;
   const isStarted = ui.handlersToTimestamp > 0;
 
   const titleText = () => {
@@ -52,7 +53,8 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
       return (
         <Text>
           {" "}
-          | {ui.handlersCurrent}/{ui.handlersTotal} events
+          | {ui.handlersCurrent}/{ui.handlersHandledTotal} events (
+          {ui.handlersTotal} total)
         </Text>
       );
     if (isStarted)
@@ -60,7 +62,8 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
         <Text>
           {" "}
           | {ui.handlersCurrent}/
-          {"?".repeat(ui.handlersCurrent.toString().length)} events
+          {"?".repeat(ui.handlersCurrent.toString().length)} events (
+          {ui.handlersTotal} total)
         </Text>
       );
     return null;
@@ -76,7 +79,7 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
       <Box flexDirection="row">
         <ProgressBar
           current={ui.handlersCurrent}
-          end={Math.max(ui.handlersTotal, 1)}
+          end={Math.max(ui.handlersHandledTotal, 1)}
         />
         <Text>
           {" "}

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -37,6 +37,7 @@ export type UiState = {
   handlerError: boolean;
   handlersCurrent: number;
   handlersTotal: number;
+  handlersHandledTotal: number;
   handlersToTimestamp: number;
 
   networks: Record<
@@ -65,6 +66,7 @@ export const getUiState = (options: Pick<PonderOptions, "SILENT">): UiState => {
     handlerError: false,
     handlersCurrent: 0,
     handlersTotal: 0,
+    handlersHandledTotal: 0,
     handlersToTimestamp: 0,
 
     networks: {},

--- a/packages/core/test/basic.test.ts
+++ b/packages/core/test/basic.test.ts
@@ -102,11 +102,11 @@ describe("Ponder", () => {
         .all();
       const tableNames = tables.map((t) => t.name);
 
-      expect(tableNames).toContain("__ponder__v1__cachedIntervals");
-      expect(tableNames).toContain("__ponder__v1__logs");
-      expect(tableNames).toContain("__ponder__v1__blocks");
-      expect(tableNames).toContain("__ponder__v1__transactions");
-      expect(tableNames).toContain("__ponder__v1__contractCalls");
+      expect(tableNames).toContain("__ponder__v2__cachedIntervals");
+      expect(tableNames).toContain("__ponder__v2__logs");
+      expect(tableNames).toContain("__ponder__v2__blocks");
+      expect(tableNames).toContain("__ponder__v2__transactions");
+      expect(tableNames).toContain("__ponder__v2__contractCalls");
     });
 
     it("creates the handler queue", async () => {
@@ -166,7 +166,7 @@ describe("Ponder", () => {
       expect(ponder.ui.isBackfillComplete).toBe(true);
 
       const cachedIntervals = (ponder.database as SqliteDb).db
-        .prepare(`SELECT * FROM __ponder__v1__cachedIntervals`)
+        .prepare(`SELECT * FROM __ponder__v2__cachedIntervals`)
         .all();
       expect(cachedIntervals.length).toBeGreaterThan(0);
     });

--- a/packages/core/test/ens.test.ts
+++ b/packages/core/test/ens.test.ts
@@ -54,15 +54,15 @@ describe("Ponder", () => {
       expect(ponder.ui.isBackfillComplete).toBe(true);
 
       const logs = (ponder.database as SqliteDb).db
-        .prepare(`SELECT * FROM __ponder__v1__logs`)
+        .prepare(`SELECT * FROM __ponder__v2__logs`)
         .all();
 
       const blocks = (ponder.database as SqliteDb).db
-        .prepare(`SELECT * FROM __ponder__v1__blocks`)
+        .prepare(`SELECT * FROM __ponder__v2__blocks`)
         .all();
 
       const transactions = (ponder.database as SqliteDb).db
-        .prepare(`SELECT * FROM __ponder__v1__transactions`)
+        .prepare(`SELECT * FROM __ponder__v2__transactions`)
         .all();
 
       expect(logs.length).toBe(148);


### PR DESCRIPTION
Updates cache store schema to store all 4 topics in separate columns
Updates `getLogs` to only query for and process logs that the user has registered a handler for 

Fixes #25 