### PR TITLE
Healthchecks

### DIFF
--- a/.changeset/tough-months-sleep.md
+++ b/.changeset/tough-months-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added a health check path at `/health` to enable zero-downtime deployments

--- a/docs/pages/guides/production.mdx
+++ b/docs/pages/guides/production.mdx
@@ -20,10 +20,10 @@ Connect your GitHub account, and make sure that your Ponder app has been pushed 
 
 From the Railway console:
 
-1. Click **New Project**
-2. Click **Deploy from GitHub repo**, then select your repo from the list
-3. Click **Add variables**, then add your project's RPC URL (e.g. `PONDER_RPC_URL_1`) and any other environment variables your project needs
-4. Open the **Settings** tab, and click **Generate Domain** in **Environment** section
+1. Click **New Project** → **Deploy from GitHub repo** and select your repo from the list
+2. Click **Add variables**, then add your project's RPC URL (e.g. `PONDER_RPC_URL_1`) and any other environment variables
+3. Expose your service to the public internet. Open the **Settings** tab and click **Generate Domain** under **Environment**
+4. Enable zero-downtime deployments by adding a healthcheck path. In the **Settings** tab, enter `/health` for **Healthcheck Path** under **Deploy**
 
 <Callout type="warning">
   _Monorepo users:_ You'll need to update your service's **Start Command**. This


### PR DESCRIPTION
This PR adds a healthcheck path at `/health`. That path will respond with a 200 if either of the following are true:
1. The backfill is complete and all logs fetched during the backfill have been processed
2. 4.5 minutes have passed since the app started

If neither of these conditions are met, `/health` will respond with a 503. This should enable zero downtime deployments on most cloud platforms. See #24 for more details.

Fixes #24