### PR TITLE
Fix entity type gen

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -214,8 +214,17 @@ export class Ponder extends EventEmitter<PonderEvents> {
     const graphqlSchema = readGraphqlSchema({ ponder: this });
     // It's possible for `readGraphqlSchema` to emit a dev_error and return null.
     if (!graphqlSchema) return;
-    this.schema = buildSchema(graphqlSchema);
-    this.graphqlSchema = buildGqlSchema(this.schema);
+
+    try {
+      this.schema = buildSchema(graphqlSchema);
+      this.graphqlSchema = buildGqlSchema(this.schema);
+    } catch (err) {
+      this.emit("dev_error", {
+        context: "parsing schema",
+        error: err as Error,
+      });
+      return;
+    }
 
     this.server.reload();
   }

--- a/packages/core/src/codegen/buildEntityTypes.ts
+++ b/packages/core/src/codegen/buildEntityTypes.ts
@@ -74,7 +74,7 @@ export const buildEntityTypes = (entities: Entity[]) => {
             }
 
             if (!field.isListElementNotNull) {
-              tsBaseType = `(${tsBaseType} | undefined)`;
+              tsBaseType = `(${tsBaseType} | null)`;
             }
 
             return `${field.name}${field.notNull ? "" : "?"}: ${tsBaseType}[];`;

--- a/packages/core/src/codegen/buildEntityTypes.ts
+++ b/packages/core/src/codegen/buildEntityTypes.ts
@@ -73,6 +73,10 @@ export const buildEntityTypes = (entities: Entity[]) => {
               );
             }
 
+            if (!field.isListElementNotNull) {
+              tsBaseType = `(${tsBaseType} | undefined)`;
+            }
+
             return `${field.name}${field.notNull ? "" : "?"}: ${tsBaseType}[];`;
           }
           case FieldKind.RELATIONSHIP: {

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -128,6 +128,12 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
       }
 
       if (entityBaseType) {
+        if (isList) {
+          throw new Error(
+            `Invalid field: "${entityName}.${fieldName}". Lists of entities must use the @derivedFrom directive.`
+          );
+        }
+
         const baseType = entityBaseType;
         return getRelationshipField(
           fieldName,

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -78,8 +78,13 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
     const fields = gqlFields.map((field) => {
       const originalFieldType = field.type;
 
-      const { fieldName, fieldTypeName, isNotNull, isList } =
-        unwrapFieldDefinition(field);
+      const {
+        fieldName,
+        fieldTypeName,
+        isNotNull,
+        isList,
+        isListElementNotNull,
+      } = unwrapFieldDefinition(field);
 
       // Try to find a GQL type that matches the base type of this field.
       const builtInScalarBaseType = gqlScalarTypeByName[fieldTypeName];
@@ -139,7 +144,8 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
             fieldName,
             baseType,
             originalFieldType,
-            isNotNull
+            isNotNull,
+            isListElementNotNull
           );
         } else {
           return getScalarField(
@@ -159,7 +165,8 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
             fieldName,
             baseType,
             originalFieldType,
-            isNotNull
+            isNotNull,
+            isListElementNotNull
           );
         } else {
           return getEnumField(
@@ -282,7 +289,8 @@ const getListField = (
   fieldName: string,
   baseType: GraphQLEnumType | GraphQLScalarType,
   originalFieldType: TypeNode,
-  isNotNull: boolean
+  isNotNull: boolean,
+  isListElementNotNull: boolean
 ) => {
   let migrateUpStatement = `"${fieldName}" TEXT`;
   if (isNotNull) {
@@ -297,6 +305,7 @@ const getListField = (
     notNull: isNotNull,
     migrateUpStatement,
     sqlType: "text", // JSON
+    isListElementNotNull,
   };
 };
 

--- a/packages/core/src/schema/readGraphqlSchema.ts
+++ b/packages/core/src/schema/readGraphqlSchema.ts
@@ -16,20 +16,10 @@ scalar Bytes
 scalar BigInt
 `;
 
-const readGraphqlSchema = ({ ponder }: { ponder: Ponder }) => {
+export const readGraphqlSchema = ({ ponder }: { ponder: Ponder }) => {
   const schemaBody = readFileSync(ponder.options.SCHEMA_FILE_PATH);
   const schemaSource = schemaHeader + schemaBody.toString();
 
-  try {
-    const schema = buildSchema(schemaSource);
-    return schema;
-  } catch (error) {
-    ponder.emit("dev_error", {
-      context: "parsing schema.graphql",
-      error: error as Error,
-    });
-    return null;
-  }
+  const schema = buildSchema(schemaSource);
+  return schema;
 };
-
-export { readGraphqlSchema };

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -55,6 +55,7 @@ export type ListField = {
   notNull: boolean;
   migrateUpStatement: string;
   sqlType: "text";
+  isListElementNotNull: boolean;
 };
 
 export type RelationshipField = {

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -87,7 +87,9 @@ export const buildEntityType = (
           }
           case FieldKind.LIST: {
             const listType = new GraphQLList(
-              new GraphQLNonNull(field.baseGqlType as GraphQLOutputType)
+              field.isListElementNotNull
+                ? new GraphQLNonNull(field.baseGqlType as GraphQLOutputType)
+                : field.baseGqlType
             );
             fieldConfigMap[field.name] = {
               type: field.notNull ? new GraphQLNonNull(listType) : listType,


### PR DESCRIPTION
This PR fixes a bug where generated entity types were incorrect. It also improves dev error logging for schema errors.

For a given schema:
```graphql
type MyEntity @entity {
  id: ID!
  string: String
  nonNullString: String!
  stringList: [String]
  nonNullStringList: [String!]
  stringNonNullList: [String]!
  nonNullStringNonNullList: [String!]!
}
```

Before:
```ts
export type GobbledArtInstance = {
  id: string;
  string?: string;
  nonNullString: string;
  stringList?: string[];
  nonNullStringList: string[];
  stringNonNullList: string[];
  nonNullStringNonNullList: string[];
};
```


After:
```ts
export type MyEntityInstance = {
  id: string;
  string?: string;
  nonNullString: string;
  stringList?: (string | null)[];
  nonNullStringList?: string[];
  stringNonNullList: (string | null)[];
  nonNullStringNonNullList: string[];
};
```