### PR TITLE
Fix zero downtime deployment bug & improve graceful shutdown 

### DIFF
--- a/.changeset/shy-wombats-invite.md
+++ b/.changeset/shy-wombats-invite.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed zero downtime deployment bug

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -157,6 +157,7 @@ export class Ponder extends EventEmitter<PonderEvents> {
     this.killFrontfillQueues?.();
     this.killBackfillQueues?.();
     await this.server.teardown();
+    await this.entityStore.teardown();
     await this.killWatchers?.();
   }
 
@@ -224,7 +225,7 @@ export class Ponder extends EventEmitter<PonderEvents> {
   }
 
   async resetEntityStore() {
-    await this.entityStore.migrate(this.schema);
+    await this.entityStore.load(this.schema);
   }
 
   async reload() {

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -153,9 +153,13 @@ export class Ponder extends EventEmitter<PonderEvents> {
     unmount();
     clearInterval(this.renderInterval);
     clearInterval(this.etaInterval);
-    this.handlerQueue?.kill();
+
     this.killFrontfillQueues?.();
     this.killBackfillQueues?.();
+
+    this.handlerQueue?.kill();
+    delete this.handlerQueue;
+
     await this.server.teardown();
     await this.entityStore.teardown();
     await this.killWatchers?.();

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -5,6 +5,7 @@ import { cac } from "cac";
 import dotenv from "dotenv";
 
 import { buildOptions } from "@/common/options";
+import { registerKilledProcessListener } from "@/common/utils";
 import { buildPonderConfig } from "@/config/buildPonderConfig";
 import { Ponder } from "@/Ponder";
 
@@ -43,6 +44,7 @@ cli
     const options = buildOptions({ ...cliOptions, logType: "dev" });
     const config = await buildPonderConfig(options);
     const ponder = new Ponder({ options, config });
+    registerKilledProcessListener(() => ponder.kill());
     await ponder.dev();
   });
 
@@ -54,6 +56,7 @@ cli
     const options = buildOptions({ ...cliOptions, logType: "start" });
     const config = await buildPonderConfig(options);
     const ponder = new Ponder({ options, config });
+    registerKilledProcessListener(() => ponder.kill());
     await ponder.start();
   });
 
@@ -65,6 +68,7 @@ cli
     const options = buildOptions({ ...cliOptions, logType: "codegen" });
     const config = await buildPonderConfig(options);
     const ponder = new Ponder({ options, config });
+    registerKilledProcessListener(() => ponder.kill());
     ponder.codegen();
   });
 

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -19,6 +19,21 @@ export const groupBy = <T>(array: T[], fn: (item: T) => string | number) => {
   }, {});
 };
 
+export const registerKilledProcessListener = (fn: () => Promise<unknown>) => {
+  let calledCount = 0;
+
+  const listener = async () => {
+    calledCount++;
+    if (calledCount > 1) return;
+    await fn();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", listener); // CTRL+C
+  process.on("SIGQUIT", listener); // Keyboard quit
+  process.on("SIGTERM", listener); // `kill` command
+};
+
 export const startBenchmark = () => process.hrtime();
 export const endBenchmark = (hrt: [number, number]) => {
   const diffHrt = process.hrtime(hrt);

--- a/packages/core/src/db/entity/entityStore.ts
+++ b/packages/core/src/db/entity/entityStore.ts
@@ -26,37 +26,35 @@ type Entity = Record<string, unknown>;
 type MaybePromise<T> = T | Promise<T>;
 
 export interface EntityStore {
-  migrate(schema?: Schema): MaybePromise<void>;
+  load(schema?: Schema): MaybePromise<void>;
+  teardown(): MaybePromise<void>;
 
-  getEntity(entityName: string, id: string): MaybePromise<Entity | null>;
+  getEntity(entityId: string, id: string): MaybePromise<Entity | null>;
 
   insertEntity(
-    entityName: string,
+    entityId: string,
     id: string,
     instance: Entity
   ): MaybePromise<Entity>;
 
   upsertEntity(
-    entityName: string,
+    entityId: string,
     id: string,
     instance: Entity
   ): MaybePromise<Entity>;
 
   updateEntity(
-    entityName: string,
+    entityId: string,
     id: string,
     instance: Partial<Entity>
   ): MaybePromise<Entity>;
 
-  deleteEntity(entityName: string, id: string): MaybePromise<boolean>;
+  deleteEntity(entityId: string, id: string): MaybePromise<boolean>;
 
-  getEntities(
-    entityName: string,
-    filter?: EntityFilter
-  ): MaybePromise<Entity[]>;
+  getEntities(entityId: string, filter?: EntityFilter): MaybePromise<Entity[]>;
 
   getEntityDerivedField(
-    entityName: string,
+    entityId: string,
     id: string,
     derivedFieldName: string
   ): MaybePromise<unknown[]>;

--- a/packages/core/src/handlers/handlerQueue.ts
+++ b/packages/core/src/handlers/handlerQueue.ts
@@ -37,19 +37,18 @@ export const createHandlerQueue = ({
   // Build entity models for event handler context.
   const entityModels: Record<string, unknown> = {};
   ponder.schema.entities.forEach((entity) => {
-    const entityName = entity.name;
-    const entityModel = {
-      get: (id: string) => ponder.entityStore.getEntity(entityName, id),
-      delete: (id: string) => ponder.entityStore.deleteEntity(entityName, id),
-      insert: (id: string, obj: Record<string, unknown>) =>
-        ponder.entityStore.insertEntity(entityName, id, obj),
-      update: (id: string, obj: Record<string, unknown>) =>
-        ponder.entityStore.updateEntity(entityName, id, obj),
-      upsert: (id: string, obj: Record<string, unknown>) =>
-        ponder.entityStore.upsertEntity(entityName, id, obj),
-    };
+    const { id: entityId, name: entityName } = entity;
 
-    entityModels[entityName] = entityModel;
+    entityModels[entityName] = {
+      get: (id: string) => ponder.entityStore.getEntity(entityId, id),
+      delete: (id: string) => ponder.entityStore.deleteEntity(entityId, id),
+      insert: (id: string, obj: Record<string, unknown>) =>
+        ponder.entityStore.insertEntity(entityId, id, obj),
+      update: (id: string, obj: Record<string, unknown>) =>
+        ponder.entityStore.updateEntity(entityId, id, obj),
+      upsert: (id: string, obj: Record<string, unknown>) =>
+        ponder.entityStore.upsertEntity(entityId, id, obj),
+    };
   });
 
   const handlerContext = {

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -143,7 +143,8 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
           fieldName,
           baseType,
           originalFieldType,
-          isNotNull
+          isNotNull,
+          instanceId
         );
       }
 
@@ -322,7 +323,8 @@ const getRelationshipField = (
   fieldName: string,
   baseType: GraphQLObjectType,
   originalFieldType: TypeNode,
-  isNotNull: boolean
+  isNotNull: boolean,
+  instanceId: string
 ) => {
   let migrateUpStatement = `"${fieldName}" TEXT`;
   if (isNotNull) {
@@ -343,7 +345,7 @@ const getRelationshipField = (
     notNull: isNotNull,
     migrateUpStatement,
     sqlType: "text", // foreign key
-    relatedEntityName: baseType.name,
+    relatedEntityId: `${baseType.name}_${instanceId}`,
   };
 };
 

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -14,6 +14,7 @@ import {
   StringValueNode,
   TypeNode,
 } from "graphql";
+import { randomUUID } from "node:crypto";
 
 import {
   DerivedField,
@@ -61,6 +62,9 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
   const gqlEntityTypes = getEntityTypes(graphqlSchema);
   const gqlEnumTypes = getEnumTypes(graphqlSchema);
   const gqlCustomScalarTypes = getCustomScalarTypes(graphqlSchema);
+
+  // The `id` field is used as a table name prefix in the EntityStore to avoid entity table name collisions.
+  const instanceId = randomUUID();
 
   const entities = gqlEntityTypes.map((entity) => {
     const entityName = entity.name;
@@ -193,6 +197,7 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
     });
 
     return <Entity>{
+      id: `${entityName}_${instanceId}`,
       name: entityName,
       gqlType: entity,
       isImmutable: entityIsImmutable,
@@ -201,12 +206,10 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
     };
   });
 
-  const entityByName: Record<string, Entity> = {};
-  entities.forEach((entity) => {
-    entityByName[entity.name] = entity;
-  });
-
-  const schema: Schema = { entities, entityByName };
+  const schema: Schema = {
+    instanceId,
+    entities,
+  };
 
   return schema;
 };

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -66,7 +66,7 @@ export type RelationshipField = {
   notNull: boolean;
   migrateUpStatement: string;
   sqlType: string;
-  relatedEntityName: string;
+  relatedEntityId: string;
 };
 
 export type DerivedField = {

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -88,6 +88,7 @@ export type Field =
   | DerivedField;
 
 export type Entity = {
+  id: string;
   name: string;
   gqlType: GraphQLObjectType;
   isImmutable: boolean;
@@ -96,6 +97,6 @@ export type Entity = {
 };
 
 export type Schema = {
+  instanceId: string;
   entities: Entity[];
-  entityByName: Record<string, Entity>;
 };

--- a/packages/core/src/server/Server.ts
+++ b/packages/core/src/server/Server.ts
@@ -20,6 +20,8 @@ export class Server {
     this.app.use(cors());
     this.server = this.app.listen(ponder.options.PORT);
 
+    this.app.get("/", (req, res) => res.redirect(302, "/graphql"));
+
     // By default, the server will respond as unhealthy until the backfill logs have
     // been processed OR 4.5 minutes have passed since the app was created. This
     // enables zero-downtime deployments on PaaS platforms like Railway and Render.
@@ -57,7 +59,6 @@ export class Server {
       graphiql: true,
     });
 
-    this.app.get("/", (req, res) => res.redirect(302, "/graphql"));
     this.app.use("/graphql", (...args) => this.graphqlMiddleware?.(...args));
   }
 

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -68,7 +68,7 @@ export const buildEntityType = (
               const entityId = parent.id;
 
               return await store.getEntityDerivedField(
-                entity.name,
+                entity.id,
                 entityId,
                 field.name
               );

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -37,11 +37,11 @@ export const buildEntityType = (
               // Then, the GraphQL server serves the resolved object here instead of the ID.
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
-              const relatedEntityId = parent[field.name];
+              const relatedInstanceId = parent[field.name];
 
               return await store.getEntity(
-                field.baseGqlType.name,
-                relatedEntityId
+                field.relatedEntityId,
+                relatedInstanceId
               );
             };
 

--- a/packages/core/src/server/graphql/buildPluralField.ts
+++ b/packages/core/src/server/graphql/buildPluralField.ts
@@ -178,7 +178,7 @@ const buildPluralField = (
 
     const filter = args;
 
-    return await store.getEntities(entity.name, filter);
+    return await store.getEntities(entity.id, filter);
   };
 
   return {

--- a/packages/core/test/basic.test.ts
+++ b/packages/core/test/basic.test.ts
@@ -123,7 +123,7 @@ describe("Ponder", () => {
         .all();
       const tableNames = tables.map((t) => t.name);
 
-      expect(tableNames).toContain("Entity");
+      expect(tableNames).toContain(`Entity_${ponder.schema?.instanceId}`);
     });
 
     it("does not watch files", async () => {

--- a/packages/core/test/ens.test.ts
+++ b/packages/core/test/ens.test.ts
@@ -40,7 +40,7 @@ describe("Ponder", () => {
   });
 
   afterEach(async () => {
-    await ponder?.kill();
+    await ponder.kill();
   });
 
   describe("backfill()", () => {
@@ -81,7 +81,7 @@ describe("Ponder", () => {
 
     it("inserts data into the entity store", async () => {
       const ensNfts = (ponder.database as SqliteDb).db
-        .prepare(`SELECT * FROM EnsNft`)
+        .prepare(`SELECT * FROM "EnsNft_${ponder.schema?.instanceId}"`)
         .all();
 
       expect(ensNfts.length).toBe(58);


### PR DESCRIPTION
This PR adds an "instance ID" to entity table names, which should fix a bug with zero-downtime deployments and enable multiple Ponder apps that use the same entity names to share the same database (like the same app deployed to both a testnet and mainnet).

It also improves the graceful shutdown behavior (cleans up entity tables).