### PR TITLE
Add `create-ponder --from-subgraph-id`

### DIFF
--- a/.changeset/curvy-otters-begin.md
+++ b/.changeset/curvy-otters-begin.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Added `--from-subgraph-id` option, renamed `--from-subgraph` to `--from-subgraph-repo`, and added `prompts`

--- a/.changeset/stupid-baboons-check.md
+++ b/.changeset/stupid-baboons-check.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Updated schema definition to allow `Bytes` and `String` types for entity `id` fields

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -225,8 +225,14 @@ const getIdField = (
     throw new Error(`${entityName}.id field must be non-null`);
   }
 
-  if (baseType.name !== "ID") {
-    throw new Error(`${entityName}.id field must have type ID`);
+  if (
+    baseType.name !== "ID" &&
+    baseType.name !== "String" &&
+    baseType.name !== "Bytes"
+  ) {
+    throw new Error(
+      `${entityName}.id field must have type ID, String, or Bytes`
+    );
   }
 
   return <IDField>{

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -24,6 +24,8 @@
     "node-fetch": "^2.6.7",
     "picocolors": "^1.0.0",
     "prettier": "^2.6.2",
+    "prompts": "^2.4.2",
+    "rimraf": "^4.1.2",
     "yaml": "^2.1.1"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "@types/node": "^18.7.8",
     "@types/node-fetch": "2",
     "@types/prettier": "^2.7.1",
+    "@types/prompts": "^2.4.2",
     "jest": "^29.3.1",
     "tsconfig-replace-paths": "^0.0.11",
     "typescript": "^4.5.5"

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -8,10 +8,10 @@
     "dist/src"
   ],
   "bin": {
-    "create-ponder": "dist/src/bin/create-ponder"
+    "create-ponder": "dist/src/bin/create-ponder.js"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && tsconfig-replace-paths --src . && mv dist/src/bin/create-ponder.js dist/src/bin/create-ponder",
+    "build": "rm -rf dist && tsc && tsconfig-replace-paths --src .",
     "test": "$npm_execpath build && export $(grep -v '^#' .env.local | xargs) && jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/create-ponder/src/bin/create-ponder.ts
+++ b/packages/create-ponder/src/bin/create-ponder.ts
@@ -36,11 +36,13 @@ const createPonder = async () => {
     process.exit(0);
   }
 
+  const { fromEtherscan, fromSubgraphId, fromSubgraphRepo } = options;
+
   // Validate CLI options.
   if (
-    (options.fromSubgraphId && options.fromSubgraphRepo) ||
-    (options.fromSubgraphId && options.fromEtherscan) ||
-    (options.fromSubgraphRepo && options.fromEtherscan)
+    (fromSubgraphId && fromSubgraphRepo) ||
+    (fromSubgraphId && fromEtherscan) ||
+    (fromSubgraphRepo && fromEtherscan)
   ) {
     throw new Error(
       `Cannot specify more than one "--from" option:\n  --from-subgraph\n  --from-etherscan-id\n  --from-etherscan-repo`
@@ -54,13 +56,20 @@ const createPonder = async () => {
     initial: "my-app",
   });
 
+  // Get template from options if provided.
   let template: Template | undefined = undefined;
+  if (fromEtherscan) {
+    template = { kind: TemplateKind.ETHERSCAN, link: fromEtherscan };
+  }
+  if (fromSubgraphId) {
+    template = { kind: TemplateKind.SUBGRAPH_ID, id: fromSubgraphId };
+  }
+  if (fromSubgraphRepo) {
+    template = { kind: TemplateKind.SUBGRAPH_REPO, path: fromSubgraphRepo };
+  }
 
-  if (
-    !options.fromSubgraphId &&
-    !options.fromSubgraphRepo &&
-    !options.fromEtherscan
-  ) {
+  // Get template from prompts if not provided.
+  if (!fromSubgraphId && !fromSubgraphRepo && !fromEtherscan) {
     const { template: templateKind } = await prompts({
       type: "select",
       name: "template",

--- a/packages/create-ponder/src/bin/create-ponder.ts
+++ b/packages/create-ponder/src/bin/create-ponder.ts
@@ -17,7 +17,7 @@ const createPonder = async () => {
     .help()
     .option("--dir [path]", "Path to directory for generated project")
     .option("--from-subgraph-id [id]", "Subgraph deployment ID")
-    .option("--from-subgraph-path [path]", "Path to subgraph repository")
+    .option("--from-subgraph-repo [path]", "Path to subgraph repository")
     .option("--from-etherscan [url]", "Link to etherscan contract page")
     .option("--etherscan-api-key [key]", "Etherscan API key");
 
@@ -27,7 +27,7 @@ const createPonder = async () => {
     help?: boolean;
     dir?: string;
     fromSubgraphId?: string;
-    fromSubgraphPath?: string;
+    fromSubgraphRepo?: string;
     fromEtherscan?: string;
     etherscanApiKey?: string;
   };
@@ -38,12 +38,12 @@ const createPonder = async () => {
 
   // Validate CLI options.
   if (
-    (options.fromSubgraphId && options.fromSubgraphPath) ||
+    (options.fromSubgraphId && options.fromSubgraphRepo) ||
     (options.fromSubgraphId && options.fromEtherscan) ||
-    (options.fromSubgraphPath && options.fromEtherscan)
+    (options.fromSubgraphRepo && options.fromEtherscan)
   ) {
     throw new Error(
-      `Cannot specify more than one "--from" option:\n  --from-subgraph\n  --from-etherscan-id\n  --from-etherscan-path`
+      `Cannot specify more than one "--from" option:\n  --from-subgraph\n  --from-etherscan-id\n  --from-etherscan-repo`
     );
   }
 
@@ -58,7 +58,7 @@ const createPonder = async () => {
 
   if (
     !options.fromSubgraphId &&
-    !options.fromSubgraphPath &&
+    !options.fromSubgraphRepo &&
     !options.fromEtherscan
   ) {
     const { template: templateKind } = await prompts({

--- a/packages/create-ponder/src/bin/create-ponder.ts
+++ b/packages/create-ponder/src/bin/create-ponder.ts
@@ -3,55 +3,117 @@
 
 import { cac } from "cac";
 import path from "node:path";
+import prompts from "prompts";
+
+import { CreatePonderOptions, Template, TemplateKind } from "@/common";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import packageJson from "../../../package.json";
+import { run } from "../index";
 
-const cli = cac(packageJson.name)
-  .version(packageJson.version)
-  .usage("[options]")
-  .help()
-  .option("--dir [path]", "Path to directory for generated project")
-  .option("--from-subgraph [path]", "Path to subgraph directory")
-  .option("--from-etherscan [url]", "Link to etherscan contract page")
-  .option("--etherscan-api-key [key]", "Etherscan API key");
+const createPonder = async () => {
+  const cli = cac(packageJson.name)
+    .version(packageJson.version)
+    .usage("[options]")
+    .help()
+    .option("--dir [path]", "Path to directory for generated project")
+    .option("--from-subgraph-id [id]", "Subgraph deployment ID")
+    .option("--from-subgraph-path [path]", "Path to subgraph repository")
+    .option("--from-etherscan [url]", "Link to etherscan contract page")
+    .option("--etherscan-api-key [key]", "Etherscan API key");
 
-const parsed = cli.parse(process.argv);
+  const parsed = cli.parse(process.argv);
 
-const options = parsed.options as {
-  help?: boolean;
-  dir?: string;
-  fromSubgraph?: string;
-  fromEtherscan?: string;
-  etherscanApiKey?: string;
+  const options = parsed.options as {
+    help?: boolean;
+    dir?: string;
+    fromSubgraphId?: string;
+    fromSubgraphPath?: string;
+    fromEtherscan?: string;
+    etherscanApiKey?: string;
+  };
+
+  if (options.help) {
+    process.exit(0);
+  }
+
+  // Validate CLI options.
+  if (
+    (options.fromSubgraphId && options.fromSubgraphPath) ||
+    (options.fromSubgraphId && options.fromEtherscan) ||
+    (options.fromSubgraphPath && options.fromEtherscan)
+  ) {
+    throw new Error(
+      `Cannot specify more than one "--from" option:\n  --from-subgraph\n  --from-etherscan-id\n  --from-etherscan-path`
+    );
+  }
+
+  const { projectName } = await prompts({
+    type: "text",
+    name: "projectName",
+    message: "What is your project named?",
+    initial: "my-app",
+  });
+
+  let template: Template | undefined = undefined;
+
+  if (
+    !options.fromSubgraphId &&
+    !options.fromSubgraphPath &&
+    !options.fromEtherscan
+  ) {
+    const { template: templateKind } = await prompts({
+      type: "select",
+      name: "template",
+      message: "Would you like to use a template for this project?",
+      choices: [
+        { title: "None" },
+        { title: "Etherscan contract link" },
+        { title: "Subgraph ID" },
+        { title: "Subgraph repository" },
+      ],
+    });
+
+    if (templateKind === TemplateKind.ETHERSCAN) {
+      const { link } = await prompts({
+        type: "text",
+        name: "link",
+        message: "Enter an Etherscan contract link",
+        initial: "https://etherscan.io/address/0x97...",
+      });
+      template = { kind: TemplateKind.ETHERSCAN, link };
+    }
+
+    if (templateKind === TemplateKind.SUBGRAPH_ID) {
+      const { id } = await prompts({
+        type: "text",
+        name: "id",
+        message: "Enter a subgraph deployment ID",
+        initial: "QmNus...",
+      });
+      template = { kind: TemplateKind.SUBGRAPH_ID, id };
+    }
+
+    if (templateKind === TemplateKind.SUBGRAPH_REPO) {
+      const { path } = await prompts({
+        type: "text",
+        name: "path",
+        message: "Enter a path to a subgraph repository",
+        initial: "../subgraph",
+      });
+      template = { kind: TemplateKind.SUBGRAPH_REPO, path };
+    }
+  }
+
+  const validatedOptions: CreatePonderOptions = {
+    projectName,
+    rootDir: path.resolve(".", options.dir ? options.dir : projectName),
+    template,
+    etherscanApiKey: options.etherscanApiKey,
+  };
+
+  await run(validatedOptions);
 };
 
-if (options.help) {
-  process.exit(0);
-}
-
-// Validate CLI options.
-if (options.fromSubgraph && options.fromEtherscan) {
-  throw new Error(`Cannot specify more than one "--from" option:
---from-subgraph
---from-etherscan
-`);
-}
-
-export interface CreatePonderOptions {
-  ponderRootDir: string;
-  fromSubgraph?: string;
-  fromEtherscan?: string;
-  etherscanApiKey?: string;
-}
-
-const validatedOptions: CreatePonderOptions = {
-  // Default `dir` to "ponder".
-  ponderRootDir: path.resolve(".", options.dir ? options.dir : "ponder"),
-  fromSubgraph: options.fromSubgraph,
-  fromEtherscan: options.fromEtherscan,
-  etherscanApiKey: options.etherscanApiKey,
-};
-
-require("../index").run(validatedOptions);
+createPonder();

--- a/packages/create-ponder/src/bin/create-ponder.ts
+++ b/packages/create-ponder/src/bin/create-ponder.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 import { cac } from "cac";
 import path from "node:path";
 import prompts from "prompts";

--- a/packages/create-ponder/src/common.ts
+++ b/packages/create-ponder/src/common.ts
@@ -1,0 +1,27 @@
+export enum TemplateKind {
+  NONE,
+  ETHERSCAN,
+  SUBGRAPH_ID,
+  SUBGRAPH_REPO,
+}
+
+export type Template =
+  | {
+      kind: TemplateKind.ETHERSCAN;
+      link: string;
+    }
+  | {
+      kind: TemplateKind.SUBGRAPH_ID;
+      id: string;
+    }
+  | {
+      kind: TemplateKind.SUBGRAPH_REPO;
+      path: string;
+    };
+
+export interface CreatePonderOptions {
+  rootDir: string;
+  projectName: string;
+  template?: Template;
+  etherscanApiKey?: string;
+}

--- a/packages/create-ponder/src/helpers/git.ts
+++ b/packages/create-ponder/src/helpers/git.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-empty */
+import { execSync } from "child_process";
+import path from "path";
+import rimraf from "rimraf";
+
+// File adapted from next.js
+// https://github.dev/vercel/next.js/blob/9ad1f321b7902542acd2be041fb2f15f023a0ed9/packages/create-next-app/helpers/git.ts
+
+function isInGitRepository(): boolean {
+  try {
+    execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+function isInMercurialRepository(): boolean {
+  try {
+    execSync("hg --cwd . root", { stdio: "ignore" });
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+export function tryGitInit(root: string): boolean {
+  let didInit = false;
+  try {
+    execSync("git --version", { stdio: "ignore" });
+    if (isInGitRepository() || isInMercurialRepository()) {
+      return false;
+    }
+
+    execSync("git init", { stdio: "ignore" });
+    didInit = true;
+
+    execSync("git checkout -b main", { stdio: "ignore" });
+
+    execSync("git add -A", { stdio: "ignore" });
+    execSync('git commit -m "chore: initial commit from create-ponder"', {
+      stdio: "ignore",
+    });
+    return true;
+  } catch (e) {
+    if (didInit) {
+      try {
+        rimraf.sync(path.join(root, ".git"));
+      } catch (_) {}
+    }
+    return false;
+  }
+}

--- a/packages/create-ponder/src/helpers/validateGraphProtocolSource.ts
+++ b/packages/create-ponder/src/helpers/validateGraphProtocolSource.ts
@@ -15,7 +15,7 @@ export type GraphSource = {
     entities: string[]; // Corresponds to entities by name defined in schema.graphql
     abis: {
       name: string;
-      file: string;
+      file: any;
     }[];
     eventHandlers?: {
       event: string;

--- a/packages/create-ponder/src/helpers/wait.ts
+++ b/packages/create-ponder/src/helpers/wait.ts
@@ -1,0 +1,2 @@
+export const wait = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -9,7 +9,8 @@ import type { CreatePonderOptions } from "@/bin/create-ponder";
 import { detect } from "@/helpers/detectPackageManager";
 import { fromBasic } from "@/templates/basic";
 import { fromEtherscan } from "@/templates/etherscan";
-import { fromSubgraph } from "@/templates/subgraph";
+// import { fromSubgraph } from "@/templates/subgraph";
+import { fromSubgraph } from "@/templates/hosted-service";
 
 export type PonderNetwork = {
   name: string;
@@ -46,7 +47,7 @@ export const run = async (
   let ponderConfig: PartialPonderConfig;
   if (options.fromSubgraph) {
     console.log(pico.cyan("[create-ponder] ") + `Bootstrapping from subgraph`);
-    ponderConfig = fromSubgraph(options);
+    ponderConfig = await fromSubgraph(options);
   } else if (options.fromEtherscan) {
     console.log(pico.cyan("[create-ponder] ") + `Bootstrapping from Etherscan`);
     ponderConfig = await fromEtherscan(options);

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -48,14 +48,12 @@ export const run = async (
   let ponderConfig: PartialPonderConfig;
 
   console.log(
-    `Creating a new Ponder app in ${pico.bold(pico.green(rootDir))}.`
+    `\nCreating a new Ponder app in ${pico.bold(pico.green(rootDir))}.`
   );
 
   switch (options.template?.kind) {
     case TemplateKind.ETHERSCAN: {
-      console.log(
-        `\nUsing template: ${pico.green("Etherscan contract link")}.`
-      );
+      console.log(`\nUsing ${pico.cyan("Etherscan contract link")} template.`);
       ponderConfig = await fromEtherscan({
         rootDir,
         etherscanLink: options.template.link,
@@ -64,7 +62,7 @@ export const run = async (
       break;
     }
     case TemplateKind.SUBGRAPH_ID: {
-      console.log(`\nUsing template: ${pico.green("Subgraph ID")}.`);
+      console.log(`\nUsing ${pico.cyan("Subgraph ID")} template.`);
       ponderConfig = await fromSubgraphId({
         rootDir,
         subgraphId: options.template.id,
@@ -72,7 +70,7 @@ export const run = async (
       break;
     }
     case TemplateKind.SUBGRAPH_REPO: {
-      console.log(`\nUsing template: ${pico.cyan("Subgraph repository")}.`);
+      console.log(`\nUsing ${pico.cyan("Subgraph repository")} template.`);
 
       ponderConfig = fromSubgraphRepo({
         rootDir,

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -5,12 +5,13 @@ import path from "node:path";
 import pico from "picocolors";
 import prettier from "prettier";
 
-import type { CreatePonderOptions } from "@/bin/create-ponder";
+import { CreatePonderOptions, TemplateKind } from "@/common";
 import { detect } from "@/helpers/detectPackageManager";
+import { tryGitInit } from "@/helpers/git";
 import { fromBasic } from "@/templates/basic";
 import { fromEtherscan } from "@/templates/etherscan";
-// import { fromSubgraph } from "@/templates/subgraph";
-import { fromSubgraph } from "@/templates/hosted-service";
+import { fromSubgraphId } from "@/templates/subgraphId";
+import { fromSubgraphRepo } from "@/templates/subgraphRepo";
 
 export type PonderNetwork = {
   name: string;
@@ -38,26 +39,56 @@ export const run = async (
   options: CreatePonderOptions,
   overrides: { installCommand?: string } = {}
 ) => {
-  const { ponderRootDir } = options;
+  const { rootDir } = options;
 
   // Create required directories.
-  mkdirSync(path.join(ponderRootDir, "abis"), { recursive: true });
-  mkdirSync(path.join(ponderRootDir, "src"), { recursive: true });
+  mkdirSync(path.join(rootDir, "abis"), { recursive: true });
+  mkdirSync(path.join(rootDir, "src"), { recursive: true });
 
   let ponderConfig: PartialPonderConfig;
-  if (options.fromSubgraph) {
-    console.log(pico.cyan("[create-ponder] ") + `Bootstrapping from subgraph`);
-    ponderConfig = await fromSubgraph(options);
-  } else if (options.fromEtherscan) {
-    console.log(pico.cyan("[create-ponder] ") + `Bootstrapping from Etherscan`);
-    ponderConfig = await fromEtherscan(options);
-  } else {
-    ponderConfig = fromBasic(options);
+
+  console.log(
+    `Creating a new Ponder app in ${pico.bold(pico.green(rootDir))}.`
+  );
+
+  switch (options.template?.kind) {
+    case TemplateKind.ETHERSCAN: {
+      console.log(
+        `\nUsing template: ${pico.green("Etherscan contract link")}.`
+      );
+      ponderConfig = await fromEtherscan({
+        rootDir,
+        etherscanLink: options.template.link,
+        etherscanApiKey: options.etherscanApiKey,
+      });
+      break;
+    }
+    case TemplateKind.SUBGRAPH_ID: {
+      console.log(`\nUsing template: ${pico.green("Subgraph ID")}.`);
+      ponderConfig = await fromSubgraphId({
+        rootDir,
+        subgraphId: options.template.id,
+      });
+      break;
+    }
+    case TemplateKind.SUBGRAPH_REPO: {
+      console.log(`\nUsing template: ${pico.cyan("Subgraph repository")}.`);
+
+      ponderConfig = fromSubgraphRepo({
+        rootDir,
+        subgraphPath: options.template.path,
+      });
+      break;
+    }
+    default: {
+      ponderConfig = fromBasic({ rootDir });
+      break;
+    }
   }
 
   // Write the handler ts files.
   ponderConfig.contracts.forEach((contract) => {
-    const abi = readFileSync(path.join(ponderRootDir, contract.abi), {
+    const abi = readFileSync(path.join(rootDir, contract.abi), {
       encoding: "utf-8",
     });
     const abiInterface = new ethers.utils.Interface(abi);
@@ -80,7 +111,7 @@ export const run = async (
     `;
 
     writeFileSync(
-      path.join(ponderRootDir, `./src/${contract.name}.ts`),
+      path.join(rootDir, `./src/${contract.name}.ts`),
       prettier.format(handlerFileContents, { parser: "typescript" })
     );
   });
@@ -99,7 +130,7 @@ export const run = async (
   `;
 
   writeFileSync(
-    path.join(ponderRootDir, "ponder.config.ts"),
+    path.join(rootDir, "ponder.config.ts"),
     prettier.format(finalPonderConfig, { parser: "babel" })
   );
 
@@ -110,7 +141,7 @@ export const run = async (
   const envLocal = `${uniqueChainIds.map(
     (chainId) => `PONDER_RPC_URL_${chainId}=""\n`
   )}`;
-  writeFileSync(path.join(ponderRootDir, ".env.local"), envLocal);
+  writeFileSync(path.join(rootDir, ".env.local"), envLocal);
 
   // Write the package.json file.
   const packageJson = `
@@ -134,7 +165,7 @@ export const run = async (
     }
   `;
   writeFileSync(
-    path.join(ponderRootDir, "package.json"),
+    path.join(rootDir, "package.json"),
     prettier.format(packageJson, { parser: "json" })
   );
 
@@ -153,13 +184,13 @@ export const run = async (
     }
   `;
   writeFileSync(
-    path.join(ponderRootDir, "tsconfig.json"),
+    path.join(rootDir, "tsconfig.json"),
     prettier.format(tsConfig, { parser: "json" })
   );
 
   // Write the .gitignore file.
   writeFileSync(
-    path.join(ponderRootDir, ".gitignore"),
+    path.join(rootDir, ".gitignore"),
     `node_modules/\n.DS_Store\n\n.env.local\n.ponder/\ngenerated/`
   );
 
@@ -168,30 +199,29 @@ export const run = async (
     packageManager === "npm" ? `${packageManager} run` : packageManager;
 
   // Install packages.
-  console.log(
-    pico.cyan("[create-ponder] ") + `Installing with ${packageManager}`
-  );
+  console.log(pico.bold(`\nInstalling with ${packageManager}.`));
 
   const installCommand = overrides.installCommand
     ? overrides.installCommand
     : `${packageManager} install`;
 
   execSync(installCommand, {
-    cwd: ponderRootDir,
+    cwd: rootDir,
     stdio: "inherit",
   });
+
+  // Intialize git repository
+  tryGitInit(rootDir);
+  console.log(`\nInitialized a git repository.`);
 
   // Run codegen.
-  console.log(pico.cyan("[create-ponder] ") + `Generating types`);
-
   execSync(`${runCommand} --silent codegen --silent`, {
-    cwd: ponderRootDir,
+    cwd: rootDir,
     stdio: "inherit",
   });
+  console.log(`\nGenerated types.`);
 
   console.log(
-    pico.cyan("[create-ponder] ") +
-      pico.green("Done! ") +
-      `To get started run ${pico.yellow(`${runCommand} dev`)}`
+    pico.green("\nSuccess! ") + `Created ${options.projectName} at ${rootDir}`
   );
 };

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -209,6 +209,7 @@ export const run = async (
   });
 
   // Intialize git repository
+  process.chdir(rootDir);
   tryGitInit(rootDir);
   console.log(`\nInitialized a git repository.`);
 

--- a/packages/create-ponder/src/templates/basic.ts
+++ b/packages/create-ponder/src/templates/basic.ts
@@ -1,17 +1,14 @@
 import { writeFileSync } from "node:fs";
 import path from "node:path";
 import prettier from "prettier";
-import type { PartialPonderConfig } from "src/index";
 
-import type { CreatePonderOptions } from "@/bin/create-ponder";
+import type { PartialPonderConfig } from "@/index";
 
-export const fromBasic = (options: CreatePonderOptions) => {
-  const { ponderRootDir } = options;
-
+export const fromBasic = ({ rootDir }: { rootDir: string }) => {
   const abiFileContents = `[]`;
 
   const abiRelativePath = "./abis/ExampleContract.json";
-  const abiAbsolutePath = path.join(ponderRootDir, abiRelativePath);
+  const abiAbsolutePath = path.join(rootDir, abiRelativePath);
   writeFileSync(abiAbsolutePath, abiFileContents);
 
   const schemaGraphqlFileContents = `
@@ -27,7 +24,7 @@ export const fromBasic = (options: CreatePonderOptions) => {
   `;
 
   // Generate the schema.graphql file.
-  const ponderSchemaFilePath = path.join(ponderRootDir, "schema.graphql");
+  const ponderSchemaFilePath = path.join(rootDir, "schema.graphql");
   writeFileSync(
     ponderSchemaFilePath,
     prettier.format(schemaGraphqlFileContents, { parser: "graphql" })

--- a/packages/create-ponder/src/templates/etherscan.ts
+++ b/packages/create-ponder/src/templates/etherscan.ts
@@ -7,8 +7,7 @@ import type { PartialPonderConfig } from "src/index";
 
 import type { CreatePonderOptions } from "@/bin/create-ponder";
 import { getNetworkByEtherscanHostname } from "@/helpers/getEtherscanChainId";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+import { wait } from "@/helpers/wait";
 
 export const fromEtherscan = async (options: CreatePonderOptions) => {
   const { ponderRootDir } = options;
@@ -31,13 +30,13 @@ export const fromEtherscan = async (options: CreatePonderOptions) => {
 
   if (!apiKey) {
     console.log("(1/2) Waiting 5 seconds for Etherscan API rate limit");
-    await delay(5000);
+    await wait(5000);
   }
   const blockNumber = await getTxBlockNumber(txHash, apiUrl, apiKey);
 
   if (!apiKey) {
     console.log("(2/2) Waiting 5 seconds for Etherscan API rate limit");
-    await delay(5000);
+    await wait(5000);
   }
   const { abi, contractName } = await getContractAbiAndName(
     contractAddress,

--- a/packages/create-ponder/src/templates/hosted-service.ts
+++ b/packages/create-ponder/src/templates/hosted-service.ts
@@ -1,0 +1,105 @@
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import fetch from "node-fetch";
+import prettier from "prettier";
+import type {
+  PartialPonderConfig,
+  PonderContract,
+  PonderNetwork,
+} from "src/index";
+import { parse } from "yaml";
+
+import type { CreatePonderOptions } from "@/bin/create-ponder";
+import {
+  getGraphProtocolChainId,
+  subgraphYamlFileNames,
+} from "@/helpers/getGraphProtocolChainId";
+import { validateGraphProtocolSource } from "@/helpers/validateGraphProtocolSource";
+import { wait } from "@/helpers/wait";
+
+const fetchIpfsFile = async (cid: string) => {
+  const url = `https://ipfs.network.thegraph.com/api/v0/cat?arg=${cid}`;
+  const response = await fetch(url);
+  const contentRaw = await response.text();
+  return contentRaw;
+};
+
+export const fromSubgraph = async (options: CreatePonderOptions) => {
+  if (!options.fromSubgraph) {
+    throw new Error(`Internal error: fromSubgraph undefined`);
+  }
+
+  const { ponderRootDir } = options;
+  const subgraphId = path.resolve(options.fromSubgraph);
+  const manifestCid = "Qmd4tEQqAgLUV5SVBp2D92436N2PL8tD4svUz2XYcucKfM";
+
+  const ponderNetworks: PonderNetwork[] = [];
+  let ponderContracts: PonderContract[] = [];
+
+  // Fetch the manifest file.
+  const manifestRaw = await fetchIpfsFile(manifestCid);
+  const manifest = parse(manifestRaw);
+
+  // Fetch and write the schema.graphql file.
+  const schemaCid = manifest.schema.file["/"].slice(6);
+  const schemaRaw = await fetchIpfsFile(schemaCid);
+  const ponderSchemaFilePath = path.join(ponderRootDir, "schema.graphql");
+  writeFileSync(
+    ponderSchemaFilePath,
+    prettier.format(schemaRaw, { parser: "graphql" })
+  );
+
+  const dataSources = (manifest.dataSources as unknown[]).map(
+    validateGraphProtocolSource
+  );
+
+  // Fetch and write all referenced ABIs.
+  const abiFiles = dataSources
+    .map((source) => source.mapping.abis)
+    .flat()
+    .filter(
+      (source, idx, arr) => arr.findIndex((s) => s.name === source.name) === idx
+    );
+  await Promise.all(
+    abiFiles.map(async (abi) => {
+      const abiContent = await fetchIpfsFile(abi.file["/"].slice(6));
+      const abiPath = path.join(ponderRootDir, `./abis/${abi.name}.json`);
+      writeFileSync(abiPath, prettier.format(abiContent, { parser: "json" }));
+    })
+  );
+
+  // Build the ponder sources.
+  ponderContracts = dataSources.map((source) => {
+    const network = source.network || "mainnet";
+    const chainId = getGraphProtocolChainId(network);
+    if (!chainId || chainId === -1) {
+      throw new Error(`Unhandled network name: ${network}`);
+    }
+
+    if (!ponderNetworks.map((n) => n.name).includes(network)) {
+      ponderNetworks.push({
+        name: network,
+        chainId: chainId,
+        rpcUrl: `process.env.PONDER_RPC_URL_${chainId}`,
+      });
+    }
+
+    const abiRelativePath = `./abis/${source.source.abi}.json`;
+
+    return <PonderContract>{
+      name: source.name,
+      network: network,
+      address: source.source.address,
+      abi: abiRelativePath,
+      startBlock: source.source.startBlock,
+    };
+  });
+
+  // Build the partial ponder config.
+  const ponderConfig: PartialPonderConfig = {
+    networks: ponderNetworks,
+    contracts: ponderContracts,
+  };
+
+  return ponderConfig;
+};

--- a/packages/create-ponder/src/templates/subgraphRepo.ts
+++ b/packages/create-ponder/src/templates/subgraphRepo.ts
@@ -1,26 +1,26 @@
 import { copyFileSync, readFileSync } from "node:fs";
 import path from "node:path";
-import type {
-  PartialPonderConfig,
-  PonderContract,
-  PonderNetwork,
-} from "src/index";
 import { parse } from "yaml";
 
-import type { CreatePonderOptions } from "@/bin/create-ponder";
 import {
   getGraphProtocolChainId,
   subgraphYamlFileNames,
 } from "@/helpers/getGraphProtocolChainId";
 import { validateGraphProtocolSource } from "@/helpers/validateGraphProtocolSource";
+import type {
+  PartialPonderConfig,
+  PonderContract,
+  PonderNetwork,
+} from "@/index";
 
-export const fromSubgraph = (options: CreatePonderOptions) => {
-  if (!options.fromSubgraph) {
-    throw new Error(`Internal error: fromSubgraph undefined`);
-  }
-
-  const { ponderRootDir } = options;
-  const subgraphRootDir = path.resolve(options.fromSubgraph);
+export const fromSubgraphRepo = ({
+  rootDir,
+  subgraphPath,
+}: {
+  rootDir: string;
+  subgraphPath: string;
+}) => {
+  const subgraphRootDir = path.resolve(subgraphPath);
 
   const ponderNetworks: PonderNetwork[] = [];
   let ponderContracts: PonderContract[] = [];
@@ -56,7 +56,7 @@ export const fromSubgraph = (options: CreatePonderOptions) => {
     subgraphRootDirPath,
     subgraphYaml.schema.file
   );
-  const ponderSchemaFilePath = path.join(ponderRootDir, "schema.graphql");
+  const ponderSchemaFilePath = path.join(rootDir, "schema.graphql");
   copyFileSync(subgraphSchemaFilePath, ponderSchemaFilePath);
 
   // Build the ponder sources. Also copy over the ABI files for each source.
@@ -89,10 +89,7 @@ export const fromSubgraph = (options: CreatePonderOptions) => {
       const abiFileName = path.basename(abiPath);
 
       const ponderAbiRelativePath = `./abis/${abiFileName}`;
-      const ponderAbiAbsolutePath = path.join(
-        ponderRootDir,
-        ponderAbiRelativePath
-      );
+      const ponderAbiAbsolutePath = path.join(rootDir, ponderAbiRelativePath);
 
       copyFileSync(abiAbsolutePath, ponderAbiAbsolutePath);
 

--- a/packages/create-ponder/test/main.test.ts
+++ b/packages/create-ponder/test/main.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -7,9 +8,13 @@ import { run } from "@/index";
 const tmpDir = "../../tmp";
 
 describe("create-ponder", () => {
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   describe("from etherscan", () => {
     describe("mainnet (ethfs)", () => {
-      const rootDir = path.join(tmpDir, "create-ponder-tests-mainnet");
+      const rootDir = path.join(tmpDir, randomUUID());
 
       beforeAll(async () => {
         await run(
@@ -26,10 +31,6 @@ describe("create-ponder", () => {
               'export npm_config_LOCKFILE=false ; pnpm --silent --filter "." install',
           }
         );
-      });
-
-      afterAll(() => {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
       });
 
       it("creates project files and directories", async () => {
@@ -79,7 +80,7 @@ describe("create-ponder", () => {
     });
 
     describe("goerli (collector)", () => {
-      const rootDir = path.join(tmpDir, "create-ponder-tests-goerli");
+      const rootDir = path.join(tmpDir, randomUUID());
 
       beforeAll(async () => {
         await run(
@@ -96,10 +97,6 @@ describe("create-ponder", () => {
               'export npm_config_LOCKFILE=false ; pnpm --silent --filter "." install',
           }
         );
-      });
-
-      afterAll(() => {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
       });
 
       it("creates project files and directories", async () => {
@@ -145,6 +142,78 @@ describe("create-ponder", () => {
       it("creates src files", async () => {
         const src = fs.readdirSync(path.join(rootDir, "src"));
         expect(src.sort()).toEqual(["Collector.ts"].sort());
+      });
+    });
+  });
+
+  describe("from subgraph id", () => {
+    describe("arbitrum (sentiment)", () => {
+      const rootDir = path.join(tmpDir, randomUUID());
+
+      beforeAll(async () => {
+        await run(
+          {
+            projectName: "sentiment",
+            rootDir,
+            template: {
+              kind: TemplateKind.SUBGRAPH_ID,
+              id: "Qmd4tEQqAgLUV5SVBp2D92436N2PL8tD4svUz2XYcucKfM",
+            },
+          },
+          {
+            installCommand:
+              'export npm_config_LOCKFILE=false ; pnpm --silent --filter "." install',
+          }
+        );
+      });
+
+      it("creates project files and directories", async () => {
+        const root = fs.readdirSync(rootDir);
+        expect(root.sort()).toEqual(
+          [
+            ".env.local",
+            ".gitignore",
+            ".ponder",
+            "abis",
+            "generated",
+            "src",
+            "node_modules",
+            "package.json",
+            "ponder.config.ts",
+            "schema.graphql",
+            "tsconfig.json",
+          ].sort()
+        );
+      });
+
+      it("downloads abi", async () => {
+        const abiString = fs.readFileSync(
+          path.join(rootDir, `abis/LToken.json`),
+          { encoding: "utf8" }
+        );
+        const abi = JSON.parse(abiString);
+
+        expect(abi.length).toBeGreaterThan(0);
+      });
+
+      it("creates codegen files", async () => {
+        const generated = fs.readdirSync(path.join(rootDir, "generated"));
+        expect(generated.sort()).toEqual(
+          ["index.ts", "app.ts", "contracts", "schema.graphql"].sort()
+        );
+        const contracts = fs.readdirSync(
+          path.join(rootDir, "generated/contracts")
+        );
+        expect(contracts.sort()).toEqual(
+          ["LETH.ts", "LFRAX.ts", "LUSDC.ts", "LUSDT.ts"].sort()
+        );
+      });
+
+      it("creates src files", async () => {
+        const src = fs.readdirSync(path.join(rootDir, "src"));
+        expect(src.sort()).toEqual(
+          ["LETH.ts", "LFRAX.ts", "LUSDC.ts", "LUSDT.ts"].sort()
+        );
       });
     });
   });

--- a/packages/create-ponder/test/main.test.ts
+++ b/packages/create-ponder/test/main.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { run } from "../src/index";
+import { TemplateKind } from "@/common";
+import { run } from "@/index";
 
 const tmpDir = "../../tmp";
 
@@ -13,9 +14,12 @@ describe("create-ponder", () => {
       beforeAll(async () => {
         await run(
           {
-            ponderRootDir: rootDir,
-            fromEtherscan:
-              "https://etherscan.io/address/0x9746fD0A77829E12F8A9DBe70D7a322412325B91", // ethfs
+            projectName: "ethfs",
+            rootDir,
+            template: {
+              kind: TemplateKind.ETHERSCAN,
+              link: "https://etherscan.io/address/0x9746fD0A77829E12F8A9DBe70D7a322412325B91", // ethfs
+            },
           },
           {
             installCommand:
@@ -80,9 +84,12 @@ describe("create-ponder", () => {
       beforeAll(async () => {
         await run(
           {
-            ponderRootDir: rootDir,
-            fromEtherscan:
-              "https://goerli.etherscan.io/address/0xc638f625aC0369d56D55106affbD5b83872Db971", // faucet
+            projectName: "goerli-faucet",
+            rootDir,
+            template: {
+              kind: TemplateKind.ETHERSCAN,
+              link: "https://goerli.etherscan.io/address/0xc638f625aC0369d56D55106affbD5b83872Db971", // faucet
+            },
           },
           {
             installCommand:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,7 @@ importers:
       '@types/node': ^18.7.8
       '@types/node-fetch': '2'
       '@types/prettier': ^2.7.1
+      '@types/prompts': ^2.4.2
       cac: ^6.7.14
       ethers: ^5.6.9
       execa: '5'
@@ -178,6 +179,8 @@ importers:
       node-fetch: ^2.6.7
       picocolors: ^1.0.0
       prettier: ^2.6.2
+      prompts: ^2.4.2
+      rimraf: ^4.1.2
       tsconfig-replace-paths: ^0.0.11
       typescript: ^4.5.5
       yaml: ^2.1.1
@@ -190,6 +193,8 @@ importers:
       node-fetch: 2.6.7
       picocolors: 1.0.0
       prettier: 2.6.2
+      prompts: 2.4.2
+      rimraf: 4.1.2
       yaml: 2.1.1
     devDependencies:
       '@ponder/core': link:../core
@@ -197,6 +202,7 @@ importers:
       '@types/node': 18.7.8
       '@types/node-fetch': 2.6.2
       '@types/prettier': 2.7.1
+      '@types/prompts': 2.4.2
       jest: 29.3.1_@types+node@18.7.8
       tsconfig-replace-paths: 0.0.11
       typescript: 4.8.4
@@ -1971,6 +1977,13 @@ packages:
 
   /@types/prettier/2.7.1:
     resolution: {integrity: sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==}
+    dev: true
+
+  /@types/prompts/2.4.2:
+    resolution: {integrity: sha512-TwNx7qsjvRIUv/BCx583tqF5IINEVjCNqg9ofKHRlSoUHE62WBHrem4B1HGXcIrG511v29d1kJ9a/t2Esz7MIg==}
+    dependencies:
+      '@types/node': 18.7.8
+      kleur: 3.0.3
     dev: true
 
   /@types/prop-types/15.7.5:
@@ -5536,7 +5549,6 @@ packages:
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: true
 
   /kleur/4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -6966,7 +6978,6 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-    dev: true
 
   /prop-types/15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -7322,6 +7333,12 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rimraf/4.1.2:
+    resolution: {integrity: sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: false
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -7514,7 +7531,6 @@ packages:
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
 
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}


### PR DESCRIPTION
This PR adds a new option `--from-subgraph-id` to `create-ponder`. This options accepts a subgraph deployment ID (which is the IPFS CID of the deployment's `subgraph.yaml`) as an argument and bootstraps a new ponder project for that subgraph.