### PR TITLE
Update default block range limit calculations & handle `"Log response size exceeded"` errors

### DIFF
--- a/.changeset/cool-berries-press.md
+++ b/.changeset/cool-berries-press.md
@@ -1,0 +1,7 @@
+---
+"@ponder/core": patch
+---
+
+Updated default block range limit logic to take the RPC provider (currently handles Quicknode and Alchemy) and chain ID into account. For example, contracts on Arbitrum and Optimism now use a default block range of `50_000`, while contracts on mainnet use `2_000`.
+
+Added logic to handle `"Log response size exceeded."` errors from Alchemy. Ponder will now re-enqueue failed backfill tasks using the suggested block range present in the response. Also handled a similar error from Quicknode, though this error should only occur if the user overrides the `blockLimit` argument to something greater than `10_000`.

--- a/.changeset/weak-bees-push.md
+++ b/.changeset/weak-bees-push.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where the frontfill would happen multiple times for the same network

--- a/packages/core/src/backfill/BackfillService.ts
+++ b/packages/core/src/backfill/BackfillService.ts
@@ -109,32 +109,15 @@ export class BackfillService extends Emittery<BackfillServiceEvents> {
 
     for (const blockInterval of requiredBlockIntervals) {
       const [startBlock, endBlock] = blockInterval;
+
       let fromBlock = startBlock;
-      let toBlock = Math.min(fromBlock + contract.blockLimit, endBlock);
+      let toBlock = Math.min(fromBlock + contract.blockLimit - 1, endBlock);
 
-      // Handle special case for a one block range. Probably shouldn't need this.
-      if (fromBlock === toBlock) {
-        logBackfillQueue.push({
-          contractAddresses: [contract.address],
-          fromBlock,
-          toBlock,
-        });
-        this.emit("logTasksAdded", {
-          contract: contract.name,
-          count: 1,
-        });
-        continue;
-      }
-
-      while (fromBlock < endBlock) {
-        logBackfillQueue.push({
-          contractAddresses: [contract.address],
-          fromBlock,
-          toBlock,
-        });
+      while (fromBlock <= endBlock) {
+        logBackfillQueue.push({ fromBlock, toBlock });
 
         fromBlock = toBlock + 1;
-        toBlock = Math.min(fromBlock + contract.blockLimit, endBlock);
+        toBlock = Math.min(fromBlock + contract.blockLimit - 1, endBlock);
         this.emit("logTasksAdded", {
           contract: contract.name,
           count: 1,

--- a/packages/core/src/backfill/BackfillService.ts
+++ b/packages/core/src/backfill/BackfillService.ts
@@ -114,7 +114,7 @@ export class BackfillService extends Emittery<BackfillServiceEvents> {
       let toBlock = Math.min(fromBlock + contract.blockLimit - 1, endBlock);
 
       while (fromBlock <= endBlock) {
-        logBackfillQueue.push({ fromBlock, toBlock });
+        logBackfillQueue.push({ fromBlock, toBlock, isRetry: false });
 
         fromBlock = toBlock + 1;
         toBlock = Math.min(fromBlock + contract.blockLimit - 1, endBlock);

--- a/packages/core/src/backfill/logBackfillQueue.ts
+++ b/packages/core/src/backfill/logBackfillQueue.ts
@@ -1,5 +1,5 @@
 import fastq from "fastq";
-import { Hash } from "viem";
+import { Hash, HttpRequestError, InvalidParamsRpcError } from "viem";
 
 import { MessageKind } from "@/common/LoggerService";
 import { parseLogs } from "@/common/types";
@@ -11,6 +11,7 @@ import type { BlockBackfillQueue } from "./blockBackfillQueue";
 export type LogBackfillTask = {
   fromBlock: number;
   toBlock: number;
+  isRetry: boolean;
 };
 
 export type LogBackfillWorkerContext = {
@@ -32,14 +33,62 @@ export const createLogBackfillQueue = ({
     10 // TODO: Make this configurable
   );
 
-  queue.error((err, task) => {
-    if (err) {
-      backfillService.emit("logTaskFailed", {
-        contract: contract.name,
-        error: err,
+  queue.error((error, task) => {
+    if (!error) return;
+
+    // Handle Alchemy error message.
+    if (
+      error instanceof InvalidParamsRpcError &&
+      error.details.startsWith("Log response size exceeded.")
+    ) {
+      const safe = error.details.split("this block range should work: ")[1];
+      const safeStart = Number(safe.split(", ")[0].slice(1));
+      const safeEnd = Number(safe.split(", ")[1].slice(0, -1));
+
+      queue.unshift({
+        fromBlock: safeStart,
+        toBlock: safeEnd,
+        isRetry: true,
       });
-      queue.unshift(task);
+      queue.unshift({
+        fromBlock: safeEnd + 1,
+        toBlock: task.toBlock,
+        isRetry: true,
+      });
+
+      return;
     }
+
+    // Handle Quicknode block range limit error (should never happen).
+    if (
+      error instanceof HttpRequestError &&
+      error.details.includes(
+        "eth_getLogs and eth_newFilter are limited to a 10,000 blocks range"
+      )
+    ) {
+      const midpoint = Math.floor(
+        (task.toBlock - task.fromBlock) / 2 + task.fromBlock
+      );
+
+      queue.unshift({
+        fromBlock: task.fromBlock,
+        toBlock: midpoint,
+        isRetry: true,
+      });
+      queue.unshift({
+        fromBlock: midpoint + 1,
+        toBlock: task.toBlock,
+        isRetry: true,
+      });
+
+      return;
+    }
+
+    backfillService.emit("logTaskFailed", {
+      contract: contract.name,
+      error,
+    });
+    queue.unshift(task);
   });
 
   return queue;
@@ -47,7 +96,7 @@ export const createLogBackfillQueue = ({
 
 async function logBackfillWorker(
   this: LogBackfillWorkerContext,
-  { fromBlock, toBlock }: LogBackfillTask
+  { fromBlock, toBlock, isRetry }: LogBackfillTask
 ) {
   const { backfillService, contract, blockBackfillQueue } = this;
   const { client } = contract.network;
@@ -122,11 +171,18 @@ async function logBackfillWorker(
   }
 
   requiredBlockHashes.forEach((blockHash) => {
-    blockBackfillQueue.push({
+    const task = {
       blockHash,
       requiredTxHashes: txHashesByBlockHash[blockHash],
       onSuccess,
-    });
+    };
+
+    // If this is a retry, put the block tasks at the front of the queue.
+    if (isRetry) {
+      blockBackfillQueue.unshift(task);
+    } else {
+      blockBackfillQueue.push(task);
+    }
   });
 
   backfillService.emit("blockTasksAdded", {

--- a/packages/core/src/frontfill/FrontfillService.ts
+++ b/packages/core/src/frontfill/FrontfillService.ts
@@ -54,9 +54,11 @@ export class FrontfillService extends Emittery<FrontfillServiceEvents> {
       (contract) => contract.endBlock === undefined && contract.isIndexed
     );
 
-    const uniqueLiveNetworks = liveContracts
-      .map((c) => c.network)
-      .filter((value, index, self) => self.indexOf(value) === index);
+    const uniqueLiveNetworks = [
+      ...new Map(
+        liveContracts.map((c) => [c.network.name, c.network])
+      ).values(),
+    ];
 
     await Promise.all(
       uniqueLiveNetworks.map(async (network) => {

--- a/packages/core/test/BackfillService.test.ts
+++ b/packages/core/test/BackfillService.test.ts
@@ -63,7 +63,7 @@ describe("BackfillService", () => {
 
     await backfillService.backfill();
 
-    expect(logTaskCount).toBe(5);
+    expect(logTaskCount).toBe(6);
     expect(blockTaskCount).toBe(51);
 
     await expectEvents(eventIterator, [
@@ -71,7 +71,7 @@ describe("BackfillService", () => {
         name: "contractStarted",
         value: { contract: "USDC", cacheRate: 0 },
       },
-      ...Array(5).fill({
+      ...Array(6).fill({
         name: "logTasksAdded",
         value: { count: 1 },
       }),

--- a/packages/core/test/utils/expectEvents.ts
+++ b/packages/core/test/utils/expectEvents.ts
@@ -13,7 +13,9 @@ export async function expectEvents<Events extends Record<string, any>>(
 
     if (result === undefined) {
       throw new Error(
-        `Did not receive event: ("${String(expected[index].name)}")`
+        `Did not receive event "${String(
+          expected[index].name
+        )}" at index ${index}`
       );
     }
 


### PR DESCRIPTION
Fixes #84 

Should make some progress towards #116 but does not fix