### PR TITLE
Improve schema types

### DIFF
--- a/.changeset/pretty-readers-report.md
+++ b/.changeset/pretty-readers-report.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Updated Subgraph templates to automatically convert ID to String.

--- a/.changeset/pretty-readers-report.md
+++ b/.changeset/pretty-readers-report.md
@@ -2,4 +2,4 @@
 "create-ponder": patch
 ---
 
-Updated Subgraph templates to automatically convert ID to String.
+Updated Subgraph templates to automatically convert `ID` to `String` and `BigDecimal` to `Float`.

--- a/.changeset/thin-lies-lie.md
+++ b/.changeset/thin-lies-lie.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Removed support for `ID` type in `schema.graphql`. Use `String`, `Int`, `BigInt`, or `Bytes` instead.
+Removed support for `ID` type in `schema.graphql`. Use `String`, `Int`, `BigInt`, or `Bytes` instead. Also removed support for `BigDecimal`, use `Float` instead.

--- a/.changeset/thin-lies-lie.md
+++ b/.changeset/thin-lies-lie.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Removed support for `ID` type in `schema.graphql`. Use `String`, `Int`, `BigInt`, or `Bytes` instead.

--- a/docs/pages/api-reference/schema-graphql.mdx
+++ b/docs/pages/api-reference/schema-graphql.mdx
@@ -8,19 +8,13 @@ import { Callout } from "nextra-theme-docs";
 
 Ponder currently supports a subset of the Graph Protocol schema definition language. Please [reference the Graph's documentation](https://thegraph.com/docs/en/developing/creating-a-subgraph/#the-graph-ql-schema) for more detailed documentation.
 
-<Callout type="warning">
-  In a future release, Ponder will likely deprecate the Graph Protocol schema
-  definition language in favor of a Ponder-native approach. Avoid using new &
-  advanced Graph Protocol features.
-</Callout>
-
 ## Supported features
 
 - Event handlers
 - `@entity` type directive
 - `@derivedFrom` field directive
 - Optional and required fields
-- Built-in scalar types (`Bytes`, `BigInt`, `BigDecimal`)
+- Built-in scalar types (`Bytes`, `BigInt`)
 
 ## Unsupported features
 

--- a/docs/pages/guides.mdx
+++ b/docs/pages/guides.mdx
@@ -4,4 +4,6 @@ description: "Table of contents for Ponder guides"
 
 # Guides
 
+[Design your schema →](/guides/design-your-schema)
+
 [Deploy to production →](/guides/production)

--- a/docs/pages/guides/_meta.json
+++ b/docs/pages/guides/_meta.json
@@ -1,3 +1,4 @@
 {
+  "design-your-schema": "Design your schema",
   "production": "Deploy to production"
 }

--- a/docs/pages/guides/design-your-schema.mdx
+++ b/docs/pages/guides/design-your-schema.mdx
@@ -1,0 +1,118 @@
+---
+description: "A guide to defining a Ponder schema"
+---
+
+import { Callout } from "nextra-theme-docs";
+
+# Design your schema
+
+Your project's `schema.graphql` file determines the shape of the data served by the GraphQL API.
+
+## Entity types
+
+Entity types are marked with the `@entity` directive. Internally, Ponder will create a database table for each entity type you define. Your event handler functions are responsible for creating and updating entities, which will then be served by the GraphQL API.
+
+```graphql filename="schema.graphql"
+type Account @entity {
+  id: String! # Could also be Int!, Bytes!, or BigInt!
+  # ...
+}
+```
+
+### The `id` field
+
+Every entity type _must_ have an `id` field typed as `String!`, `Int!`,
+`Bytes!` or `BigInt!`. The `id` field serves as a unique identifier for each
+instance of this entity.
+
+## Field types
+
+### Scalars
+
+In GraphQL, scalar types represent the "leaves" of a query, and each one corresponds to a JavaScript primitive data type.
+
+| type      | description                                 | example               | TypeScript type |
+| :-------- | :------------------------------------------ | :-------------------- | :-------------- |
+| `Boolean` | `true` or `false`                           | `true`                | `boolean`       |
+| `String`  | A UTF‐8 character sequence                  | `vitalik.eth`         | `string`        |
+| `Bytes`   | A UTF‐8 character sequence with `0x` prefix | `0xA5d28ee12f`        | `0x${string}`   |
+| `Int`     | A signed 32‐bit integer                     | `1679337733`, `-5`    | `number`        |
+| `Float`   | A signed floating-point value               | `17.79`               | `number`        |
+| `BigInt`  | An unsigned integer (solidity `uint256`)    | `7770000000000000000` | `bigint`        |
+
+Here's an example of how each might be used.
+
+```graphql filename="schema.graphql"
+type Account @entity {
+  id: Bytes! # Ethereum address
+  daiBalance: BigInt! # Token balance with 18 decimals
+  totalUsdValue: Float! # Dollars and cents
+  lastActiveAt: Int! # Unix timestamp
+  isAdmin: Boolean! # Boolean permission
+  graffiti: String! # Text message
+}
+```
+
+### Enums
+
+Enumeration types are a special kind of scalar that is restricted to a particular set of allowed values.
+
+```graphql filename="schema.graphql"
+enum Color {
+  ORANGE
+  BLACK
+  WHITE
+}
+
+type Cat @entity {
+  id: String!
+  color: Color!
+}
+```
+
+Fields that use an enum type are stored and served as a string.
+
+```ts filename="src/index.ts"
+await Cat.insert({
+  id: "Fluffy",
+  color: "ORANGE"
+});
+```
+
+### Lists
+
+Ponder also supports lists of scalars and enums. Lists should only be used for small collections of data, and should not be used to define a [relationship](/guides/design-your-schema#one-to-one-relationships) between entities.
+
+```graphql filename="schema.graphql"
+enum Color {
+  ORANGE
+  BLACK
+  WHITE
+}
+
+type FancyCat @entity {
+  id: String!
+  colors: [Color!]!
+}
+```
+
+```ts filename="src/index.ts"
+await FancyCat.insert({
+  id: "Fluffy",
+  colors: ["BLACK", "WHITE"]
+});
+```
+
+<Callout type="warning">
+  **Avoid nullable list elements.** Unless you have a good reason not to, it's
+  strongly recommended to mark list elements as non-null. Good: `[Color!]!`,
+  bad: `[Color]!`.
+</Callout>
+
+### One-to-one relationships
+
+TODO
+
+### One-to-many relationships
+
+TODO

--- a/docs/pages/guides/design-your-schema.mdx
+++ b/docs/pages/guides/design-your-schema.mdx
@@ -55,13 +55,14 @@ type Account @entity {
 
 ### Enums
 
-Enumeration types are a special kind of scalar that is restricted to a particular set of allowed values.
+Enumeration types are a special kind of scalar that is restricted to a particular set of allowed values. Fields that use an enum type are stored and served as a string.
+
+<div className="code-columns">
 
 ```graphql filename="schema.graphql"
 enum Color {
   ORANGE
   BLACK
-  WHITE
 }
 
 type Cat @entity {
@@ -70,8 +71,6 @@ type Cat @entity {
 }
 ```
 
-Fields that use an enum type are stored and served as a string.
-
 ```ts filename="src/index.ts"
 await Cat.insert({
   id: "Fluffy",
@@ -79,29 +78,36 @@ await Cat.insert({
 });
 ```
 
-### Lists
+</div>
 
-Ponder also supports lists of scalars and enums. Lists should only be used for small collections of data, and should not be used to define a [relationship](/guides/design-your-schema#one-to-one-relationships) between entities.
+### Basic lists
+
+Ponder also supports lists of scalars and enums. Lists should only be used for small collections or sets of data, and should not be used to define [relationships](/guides/design-your-schema#one-to-one-relationships) between entities.
+
+<div className="code-columns">
 
 ```graphql filename="schema.graphql"
 enum Color {
   ORANGE
   BLACK
-  WHITE
 }
 
 type FancyCat @entity {
   id: String!
   colors: [Color!]!
+  favoriteNumbers: [Int!]!
 }
 ```
 
 ```ts filename="src/index.ts"
 await FancyCat.insert({
   id: "Fluffy",
-  colors: ["BLACK", "WHITE"]
+  colors: ["ORANGE", "BLACK"],
+  favoriteNumbers: [7, 420, 69]
 });
 ```
+
+</div>
 
 <Callout type="warning">
   **Avoid nullable list elements.** Unless you have a good reason not to, it's
@@ -111,8 +117,157 @@ await FancyCat.insert({
 
 ### One-to-one relationships
 
-TODO
+One-to-one relationships are modeled by setting the type of a field to another entity type. Suppose every `Dog` has one owner that is a `Person`. When inserting a `Dog` entity, the `owner` field is set to the `id` of a `Person` entity. This establishes the relationship.
+
+<div className="code-columns">
+
+```graphql filename="schema.graphql"
+type Dog @entity {
+  id: String!
+  owner: Person!
+}
+
+type Person @entity {
+  id: String!
+  age: Int!
+}
+```
+
+```ts filename="src/index.ts"
+await Person.insert({
+  id: "Bob"
+  age: 22,
+});
+
+await Dog.insert({
+  id: "Chip",
+  owner: "Bob"
+});
+```
+
+</div>
+
+Now, you can use GraphQL to query for information about a `Dog`'s owner.
+
+<div className="code-columns">
+
+{/* prettier-ignore */}
+```graphql filename="Query"
+query {
+  dog(id: "Chip") {
+    id
+    owner {
+      age
+    }
+  }
+}
+```
+
+{/* prettier-ignore */}
+```json filename="Result"
+{
+  "dog": {
+    "id": "Chip",
+    "owner": {
+      "age": 22,
+    },
+  },
+}
+```
+
+</div>
 
 ### One-to-many relationships
 
-TODO
+Now, suppose a `Person` can have many dogs. The `@derivedFrom` directive can be used to define a **reverse lookup** between two entities. In this case, we can add a `dogs` field on `Person` with the type `[Dog!]! @derivedFrom(field: "owner")`.
+
+<div className="code-columns">
+
+```graphql filename="schema.graphql"
+type Dog @entity {
+  id: String!
+  owner: Person!
+}
+
+type Person @entity {
+  id: String!
+  dogs: [Dog!]! @derivedFrom(field: "owner")
+}
+```
+
+```ts filename="src/index.ts"
+await Person.insert({
+  id: "Bob"
+});
+
+await Dog.insert({
+  id: "Chip",
+  owner: "Bob"
+});
+
+await Dog.insert({
+  id: "Spike",
+  owner: "Bob"
+});
+```
+
+</div>
+
+Now, any `Dog` entities with `owner: "Bob"` will be present in Bob's `Person.dogs` field.
+
+<div className="code-columns">
+
+{/* prettier-ignore */}
+```graphql filename="Query"
+query {
+  person(id: "Bob") {
+    dogs {
+      id
+    }
+  }
+}
+```
+
+{/* prettier-ignore */}
+```json filename="Result"
+{
+  "person": {
+    "dogs": [
+      { "id": "Chip" },
+      { "id": "Spike" },
+    ]
+  },
+}
+```
+
+</div>
+
+Note that the `dogs` field on `Person` cannot be accessed directly within event handlers. Fields marked with the `@derivedFrom` directive are **virtual**, meaning they are only present when querying entities via the GraphQL API.
+
+<div className="code-columns">
+
+```ts filename="src/index.ts"
+await Person.insert({
+  id: "Bob"
+  dogs: ["Chip", "Bob"] // WRONG, will throw an error.
+});
+```
+
+```ts filename="src/index.ts"
+const bob = await Person.get("Bob");
+// {
+//   id: "Bob"
+// }
+```
+
+</div>
+
+## Schema design tips
+
+### Entities should generally be nouns
+
+Blockchain events describe an action that has taken place (a verb). Event handler funtions are most effective when they convert events into the nouns that represent the current state of your application. For example, prefer modeling an ERC721 collection using `Account` and `Token` entities rather than `TransferEvent` entities. (Unless you need the full transfer history of every account).
+
+### Use relationship types generously
+
+Your schema will be more flexible and powerful if it accurately models the logical relationships in your application's domain. Don't use the [basic list type](/guides/design-your-schema#lists) to store entity IDs or to model relationships.

--- a/docs/style.css
+++ b/docs/style.css
@@ -39,6 +39,24 @@
   background: #2e2e2e;
 }
 
+/* CODE COLUMNS STYLES */
+
+.code-columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0rem 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.code-columns div {
+  flex: 1;
+  margin-top: 0rem;
+}
+
+.code-columns div pre {
+  height: calc(100% - 1rem);
+}
+
 /* EXCALIDRAW DIAGRAM STYLES */
 
 .excalidraw {

--- a/examples/art-gobblers/schema.graphql
+++ b/examples/art-gobblers/schema.graphql
@@ -1,4 +1,4 @@
 type GobbledArt @entity {
-  id: ID! # gobblerId
+  id: String! # gobblerId
   user: String! # user
 }

--- a/examples/ethfs/schema.graphql
+++ b/examples/ethfs/schema.graphql
@@ -1,5 +1,5 @@
 type File @entity {
-  id: ID!
+  id: String!
   name: String!
   size: Int!
   contents: String!

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -237,6 +237,10 @@ export class Ponder {
   }
 
   private registerUiHandlers() {
+    this.resources.errors.on("handlerError", ({ error }) => {
+      this.resources.logger.logMessage(MessageKind.ERROR, error.message);
+    });
+
     this.frontfillService.on("networkConnected", (e) => {
       this.uiService.ui.networks.push(e.network);
     });

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -185,7 +185,7 @@ export class Ponder {
 
       this.serverService.reload({ graphqlSchema });
 
-      await this.resources.entityStore.load(schema);
+      await this.resources.entityStore.load({ schema });
       this.eventHandlerService.resetEventQueue({ schema });
       await this.eventHandlerService.processEvents();
     });

--- a/packages/core/src/codegen/CodegenService.ts
+++ b/packages/core/src/codegen/CodegenService.ts
@@ -12,12 +12,7 @@ import { buildEntityTypes } from "./buildEntityTypes";
 import { buildEventTypes } from "./buildEventTypes";
 import { formatPrettier } from "./utils";
 
-type CodegenServiceEvents = {
-  handlerError: { error: Error };
-  handlerErrorCleared: undefined;
-};
-
-export class CodegenService extends Emittery<CodegenServiceEvents> {
+export class CodegenService extends Emittery {
   resources: Resources;
 
   constructor({ resources }: { resources: Resources }) {

--- a/packages/core/src/codegen/buildEntityTypes.ts
+++ b/packages/core/src/codegen/buildEntityTypes.ts
@@ -14,86 +14,93 @@ const gqlScalarToTsType: Record<string, string | undefined> = {
 export const buildEntityTypes = (entities: Entity[]) => {
   const entityModelTypes = entities
     .map((entity) => {
-      return `
-   export type ${entity.name}Instance = {
-    ${entity.fields
-      .map((field) => {
-        switch (field.kind) {
-          case FieldKind.SCALAR: {
-            const scalarTsType = gqlScalarToTsType[field.scalarTypeName];
-            if (!scalarTsType) {
-              throw new Error(
-                `TypeScript type not found for scalar: ${field.scalarTypeName}`
-              );
-            }
+      let idType = "string";
 
-            return `${field.name}${field.notNull ? "" : "?"}: ${scalarTsType};`;
-          }
-          case FieldKind.ENUM: {
-            return `${field.name}${field.notNull ? "" : "?"}: ${field.enumValues
-              .map((val) => `"${val}"`)
-              .join(" | ")};`;
-          }
-          case FieldKind.LIST: {
-            // This is trash
-            let tsBaseType: string;
-            if (
-              Object.keys(gqlScalarToTsType).includes(
-                field.baseGqlType.toString()
-              )
-            ) {
-              const scalarTypeName = field.baseGqlType.toString();
-              const scalarTsType = gqlScalarToTsType[scalarTypeName];
-              if (!scalarTsType) {
-                throw new Error(
-                  `TypeScript type not found for scalar: ${scalarTypeName}`
-                );
+      const instanceType = `export type ${entity.name}Instance = {
+        ${entity.fields
+          .map((field) => {
+            switch (field.kind) {
+              case FieldKind.SCALAR: {
+                const scalarTsType = gqlScalarToTsType[field.scalarTypeName];
+                if (!scalarTsType) {
+                  throw new Error(
+                    `TypeScript type not found for scalar: ${field.scalarTypeName}`
+                  );
+                }
+                if (field.name === "id") idType = scalarTsType;
+
+                return `${field.name}${
+                  field.notNull ? "" : "?"
+                }: ${scalarTsType};`;
               }
-              tsBaseType = scalarTsType;
-            } else if (
-              // @ts-ignore
-              field.baseGqlType.astNode?.kind === Kind.ENUM_TYPE_DEFINITION
-            ) {
-              // @ts-ignore
-              const enumValues = (field.baseGqlType.astNode?.values || []).map(
-                // @ts-ignore
-                (v) => v.name.value
-              );
-              // @ts-ignore
-              tsBaseType = `(${enumValues.map((v) => `"${v}"`).join(" | ")})`;
-            } else {
-              throw new Error(
-                `Unable to generate type for field: ${field.name}`
-              );
+              case FieldKind.ENUM: {
+                return `${field.name}${
+                  field.notNull ? "" : "?"
+                }: ${field.enumValues.map((val) => `"${val}"`).join(" | ")};`;
+              }
+              case FieldKind.LIST: {
+                // This is trash
+                let tsBaseType: string;
+                if (
+                  Object.keys(gqlScalarToTsType).includes(
+                    field.baseGqlType.toString()
+                  )
+                ) {
+                  const scalarTypeName = field.baseGqlType.toString();
+                  const scalarTsType = gqlScalarToTsType[scalarTypeName];
+                  if (!scalarTsType) {
+                    throw new Error(
+                      `TypeScript type not found for scalar: ${scalarTypeName}`
+                    );
+                  }
+                  tsBaseType = scalarTsType;
+                } else if (
+                  // @ts-ignore
+                  field.baseGqlType.astNode?.kind === Kind.ENUM_TYPE_DEFINITION
+                ) {
+                  const enumValues = // @ts-ignore
+                    (field.baseGqlType.astNode?.values || []).map(
+                      // @ts-ignore
+                      (v) => v.name.value
+                    );
+                  tsBaseType = `(${enumValues
+                    // @ts-ignore
+                    .map((v) => `"${v}"`)
+                    .join(" | ")})`;
+                } else {
+                  throw new Error(
+                    `Unable to generate type for field: ${field.name}`
+                  );
+                }
+
+                if (!field.isListElementNotNull) {
+                  tsBaseType = `(${tsBaseType} | null)`;
+                }
+
+                return `${field.name}${
+                  field.notNull ? "" : "?"
+                }: ${tsBaseType}[];`;
+              }
+              case FieldKind.RELATIONSHIP: {
+                return `${field.name}: string;`;
+              }
             }
+          })
+          .join("")}
+        };`;
 
-            if (!field.isListElementNotNull) {
-              tsBaseType = `(${tsBaseType} | null)`;
-            }
+      const modelType = `
+        export type ${entity.name}Model = {
+          get: (id: ${idType}) => Promise<${entity.name}Instance | null>;
+          insert: (id: ${idType}, obj: Omit<${entity.name}Instance, "id">) => Promise<${entity.name}Instance>;
+          update: (id: ${idType}, obj: Partial<Omit<${entity.name}Instance, "id">>) =>
+            Promise<${entity.name}Instance>;
+          delete: (id: ${idType}) => Promise<boolean>;
+          upsert: (id: ${idType}, obj: Omit<${entity.name}Instance, "id">) => Promise<${entity.name}Instance>;
+        };
+      `;
 
-            return `${field.name}${field.notNull ? "" : "?"}: ${tsBaseType}[];`;
-          }
-          case FieldKind.RELATIONSHIP: {
-            return `${field.name}: string;`;
-          }
-        }
-      })
-      .join("")}
-  };
-
-  export type ${entity.name}Model = {
-    get: (id: string) => Promise<${entity.name}Instance | null>;
-    insert: (id: string, obj: Omit<${entity.name}Instance, "id">) => Promise<${
-        entity.name
-      }Instance>;
-    update: (id: string, obj: Partial<Omit<${entity.name}Instance, "id">>) =>
-      Promise<${entity.name}Instance>;
-    delete: (id: string) => Promise<boolean>;
-    upsert: (id: string, obj: Omit<${entity.name}Instance, "id">) => Promise<${
-        entity.name
-      }Instance>;
-  };
-    `;
+      return instanceType + modelType;
     })
     .join("");
 

--- a/packages/core/src/common/ErrorService.ts
+++ b/packages/core/src/common/ErrorService.ts
@@ -1,16 +1,16 @@
 import Emittery from "emittery";
 
 type ErrorServiceEvents = {
-  handlerError: { context: string; error: Error };
+  handlerError: { error: Error };
   handlerErrorCleared: undefined;
 };
 
 export class ErrorService extends Emittery<ErrorServiceEvents> {
   isHandlerError = false;
 
-  submitHandlerError({ context, error }: { context: string; error: Error }) {
+  submitHandlerError({ error }: { error: Error }) {
     this.isHandlerError = true;
-    this.emit("handlerError", { context, error });
+    this.emit("handlerError", { error });
   }
 
   clearHandlerError() {

--- a/packages/core/src/database/entity/entityStore.ts
+++ b/packages/core/src/database/entity/entityStore.ts
@@ -28,39 +28,42 @@ type MaybePromise<T> = T | Promise<T>;
 export interface EntityStore {
   schema?: Schema;
 
-  load(schema: Schema): MaybePromise<void>;
+  load(arg: { schema: Schema }): MaybePromise<void>;
   reset(): MaybePromise<void>;
   teardown(): MaybePromise<void>;
 
-  getEntity(entityId: string, id: string): MaybePromise<Entity | null>;
+  getEntity(arg: {
+    entityName: string;
+    id: string | number;
+  }): MaybePromise<Entity | null>;
 
-  insertEntity(
-    entityId: string,
-    id: string,
-    instance: Entity
-  ): MaybePromise<Entity>;
+  insertEntity(arg: {
+    entityName: string;
+    id: string | number;
+    instance: Entity;
+  }): MaybePromise<Entity>;
 
-  upsertEntity(
-    entityId: string,
-    id: string,
-    instance: Entity
-  ): MaybePromise<Entity>;
+  upsertEntity(arg: {
+    entityName: string;
+    id: string | number;
+    instance: Entity;
+  }): MaybePromise<Entity>;
 
-  updateEntity(
-    entityId: string,
-    id: string,
-    instance: Partial<Entity>
-  ): MaybePromise<Entity>;
+  updateEntity(arg: {
+    entityName: string;
+    id: string | number;
+    instance: Partial<Entity>;
+  }): MaybePromise<Entity>;
 
-  deleteEntity(entityId: string, id: string): MaybePromise<boolean>;
+  deleteEntity(arg: {
+    entityName: string;
+    id: string | number;
+  }): MaybePromise<boolean>;
 
-  getEntities(entityId: string, filter?: EntityFilter): MaybePromise<Entity[]>;
-
-  getEntityDerivedField(
-    entityId: string,
-    id: string,
-    derivedFieldName: string
-  ): MaybePromise<unknown[]>;
+  getEntities(arg: {
+    entityName: string;
+    filter?: EntityFilter;
+  }): MaybePromise<Entity[]>;
 }
 
 export const buildEntityStore = ({

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -139,6 +139,10 @@ export class PostgresEntityStore implements EntityStore {
               .map((v) => `'${v}'`)
               .join(", ")})) ${notNull}`;
           }
+          case FieldKind.LIST: {
+            const notNull = field.notNull ? "NOT NULL" : "";
+            return `"${field.name}" TEXT ${notNull}`;
+          }
           default: {
             return field.migrateUpStatement;
           }

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -111,7 +111,6 @@ export class PostgresEntityStore implements EntityStore {
       Int: "integer",
       String: "text",
       BigInt: "numeric(78)", // Store BigInts as numerics large enough for Solidity's MAX_INT (2**256 - 1).
-      BigDecimal: "numeric(78)",
       Bytes: "text",
     };
 

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -130,6 +130,15 @@ export class PostgresEntityStore implements EntityStore {
             const pk = field.name === "id" ? "PRIMARY KEY" : "";
             return `"${field.name}" ${type} ${notNull} ${pk}`;
           }
+          case FieldKind.ENUM: {
+            const notNull = field.notNull ? "NOT NULL" : "";
+
+            return `"${field.name}" TEXT CHECK ("${
+              field.name
+            }" IN (${field.enumValues
+              .map((v) => `'${v}'`)
+              .join(", ")})) ${notNull}`;
+          }
           default: {
             return field.migrateUpStatement;
           }

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { Pool } from "pg";
 
 import {
-  DerivedField,
   Entity,
   EnumField,
   FieldKind,
@@ -21,35 +21,26 @@ import {
 export class PostgresEntityStore implements EntityStore {
   pool: Pool;
   schema?: Schema;
+  instanceId?: string;
 
   constructor({ pool }: { pool: Pool }) {
     this.pool = pool;
   }
 
-  errorWrapper = <T extends Array<any>, U>(fn: (...args: T) => U) => {
-    return (...args: T): U => {
-      if (!this.schema) {
-        throw new Error(
-          `EntityStore has not been initialized with a schema yet`
-        );
-      }
-
-      // No need to wrap this in an error handler the way its done in
-      // the SqliteEntityStore.
-      return fn(...args);
-    };
-  };
-
-  async load(newSchema: Schema) {
+  async load({ schema: newSchema }: { schema: Schema }) {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
 
       if (this.schema) {
         for (const entity of this.schema.entities) {
-          await client.query(`DROP TABLE IF EXISTS "${entity.id}"`);
+          await client.query(
+            `DROP TABLE IF EXISTS "${entity.name}_${this.instanceId}"`
+          );
         }
       }
+
+      this.instanceId = randomUUID();
 
       for (const entity of newSchema.entities) {
         const createTableStatement = this.getCreateTableStatement(entity);
@@ -73,11 +64,18 @@ export class PostgresEntityStore implements EntityStore {
     try {
       await client.query("BEGIN");
       for (const entity of this.schema.entities) {
-        await client.query(`DROP TABLE IF EXISTS "${entity.id}"`);
+        await client.query(
+          `DROP TABLE IF EXISTS "${entity.name}_${this.instanceId}"`
+        );
+      }
 
+      this.instanceId = randomUUID();
+
+      for (const entity of this.schema.entities) {
         const createTableStatement = this.getCreateTableStatement(entity);
         await client.query(createTableStatement);
       }
+
       await client.query("COMMIT");
     } catch (error) {
       await client.query("ROLLBACK");
@@ -94,7 +92,9 @@ export class PostgresEntityStore implements EntityStore {
     try {
       await client.query("BEGIN");
       for (const entity of this.schema.entities) {
-        await client.query(`DROP TABLE IF EXISTS "${entity.id}"`);
+        await client.query(
+          `DROP TABLE IF EXISTS "${entity.name}_${this.instanceId}"`
+        );
       }
       await client.query("COMMIT");
     } catch (error) {
@@ -151,204 +151,215 @@ export class PostgresEntityStore implements EntityStore {
         }
       });
 
-    return `CREATE TABLE "${entity.id}" (${columnStatements.join(", ")})`;
+    const tableName = `${entity.name}_${this.instanceId}`;
+    return `CREATE TABLE "${tableName}" (${columnStatements.join(", ")})`;
   }
 
-  getEntity = this.errorWrapper(async (entityId: string, id: string) => {
-    const statement = `SELECT "${entityId}".* FROM "${entityId}" WHERE "${entityId}"."id" = $1`;
+  getEntity = async ({
+    entityName,
+    id,
+  }: {
+    entityName: string;
+    id: string;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
+
+    const statement = `SELECT "${tableName}".* FROM "${tableName}" WHERE "${tableName}"."id" = $1`;
     const { rows, rowCount } = await this.pool.query(statement, [id]);
 
     if (rowCount === 0) return null;
-    return this.deserialize(entityId, rows[0]);
-  });
+    return this.deserialize({ entityName, instance: rows[0] });
+  };
 
-  insertEntity = this.errorWrapper(
-    async (entityId: string, id: string, instance: Record<string, unknown>) => {
-      // If `instance.id` is defined, replace it with the id passed as a parameter.
-      // Should also log a warning here.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      instance.id = id;
+  insertEntity = async ({
+    entityName,
+    id,
+    instance,
+  }: {
+    entityName: string;
+    id: string;
+    instance: Record<string, unknown>;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
 
-      const pairs = getColumnValuePairs(instance);
+    // If `instance.id` is defined, replace it with the id passed as a parameter.
+    // Should also log a warning here.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    instance.id = id;
 
-      const insertValues = pairs.map(({ value }) => value);
-      const insertFragment = `(${pairs
-        .map(({ column }) => column)
-        .join(", ")}) VALUES (${insertValues
-        .map((_, idx) => `$${idx + 1}`)
-        .join(", ")})`;
+    const pairs = getColumnValuePairs(instance);
 
-      const statement = `INSERT INTO "${entityId}" ${insertFragment} RETURNING *`;
-      const { rows } = await this.pool.query(statement, insertValues);
+    const insertValues = pairs.map(({ value }) => value);
+    const insertFragment = `(${pairs
+      .map(({ column }) => column)
+      .join(", ")}) VALUES (${insertValues
+      .map((_, idx) => `$${idx + 1}`)
+      .join(", ")})`;
 
-      return this.deserialize(entityId, rows[0]);
-    }
-  );
+    const statement = `INSERT INTO "${tableName}" ${insertFragment} RETURNING *`;
+    const { rows } = await this.pool.query(statement, insertValues);
 
-  updateEntity = this.errorWrapper(
-    async (entityId: string, id: string, instance: Record<string, unknown>) => {
-      const pairs = getColumnValuePairs(instance);
+    return this.deserialize({ entityName, instance: rows[0] });
+  };
 
-      const updatePairs = pairs.filter(({ column }) => column !== "id");
-      const updateValues = updatePairs.map(({ value }) => value);
-      const updateFragment = updatePairs
-        .map(({ column }, idx) => `${column} = $${idx + 1}`)
-        .join(", ");
+  updateEntity = async ({
+    entityName,
+    id,
+    instance,
+  }: {
+    entityName: string;
+    id: string;
+    instance: Record<string, unknown>;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
 
-      const statement = `UPDATE "${entityId}" SET ${updateFragment} WHERE "id" = $${
-        updatePairs.length + 1
-      } RETURNING *`;
-      updateValues.push(id);
-      const { rows } = await this.pool.query(statement, updateValues);
+    const pairs = getColumnValuePairs(instance);
 
-      return this.deserialize(entityId, rows[0]);
-    }
-  );
+    const updatePairs = pairs.filter(({ column }) => column !== "id");
+    const updateValues = updatePairs.map(({ value }) => value);
+    const updateFragment = updatePairs
+      .map(({ column }, idx) => `${column} = $${idx + 1}`)
+      .join(", ");
 
-  upsertEntity = this.errorWrapper(
-    async (entityId: string, id: string, instance: Record<string, unknown>) => {
-      // If `instance.id` is defined, replace it with the id passed as a parameter.
-      // Should also log a warning here.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      instance.id = id;
+    const statement = `UPDATE "${tableName}" SET ${updateFragment} WHERE "id" = $${
+      updatePairs.length + 1
+    } RETURNING *`;
+    updateValues.push(id);
+    const { rows } = await this.pool.query(statement, updateValues);
 
-      const pairs = getColumnValuePairs(instance);
+    return this.deserialize({ entityName, instance: rows[0] });
+  };
 
-      const insertValues = pairs.map(({ value }) => value);
-      const insertFragment = `(${pairs
-        .map(({ column }) => column)
-        .join(", ")}) VALUES (${insertValues
-        .map((_, idx) => `$${idx + 1}`)
-        .join(", ")})`;
+  upsertEntity = async ({
+    entityName,
+    id,
+    instance,
+  }: {
+    entityName: string;
+    id: string;
+    instance: Record<string, unknown>;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
 
-      const updatePairs = pairs.filter(({ column }) => column !== "id");
-      const updateValues = updatePairs.map(({ value }) => value);
-      const updateFragment = updatePairs
-        .map(
-          ({ column }, idx) => `${column} = $${idx + 1 + insertValues.length}`
-        )
-        .join(", ");
+    // If `instance.id` is defined, replace it with the id passed as a parameter.
+    // Should also log a warning here.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    instance.id = id;
 
-      const statement = `INSERT INTO "${entityId}" ${insertFragment} ON CONFLICT("id") DO UPDATE SET ${updateFragment} RETURNING *`;
-      const { rows } = await this.pool.query(statement, [
-        ...insertValues,
-        ...updateValues,
-      ]);
+    const pairs = getColumnValuePairs(instance);
 
-      return this.deserialize(entityId, rows[0]);
-    }
-  );
+    const insertValues = pairs.map(({ value }) => value);
+    const insertFragment = `(${pairs
+      .map(({ column }) => column)
+      .join(", ")}) VALUES (${insertValues
+      .map((_, idx) => `$${idx + 1}`)
+      .join(", ")})`;
 
-  deleteEntity = this.errorWrapper(async (entityId: string, id: string) => {
-    const statement = `DELETE FROM "${entityId}" WHERE "id" = $1`;
+    const updatePairs = pairs.filter(({ column }) => column !== "id");
+    const updateValues = updatePairs.map(({ value }) => value);
+    const updateFragment = updatePairs
+      .map(({ column }, idx) => `${column} = $${idx + 1 + insertValues.length}`)
+      .join(", ");
+
+    const statement = `INSERT INTO "${tableName}" ${insertFragment} ON CONFLICT("id") DO UPDATE SET ${updateFragment} RETURNING *`;
+    const { rows } = await this.pool.query(statement, [
+      ...insertValues,
+      ...updateValues,
+    ]);
+
+    return this.deserialize({ entityName, instance: rows[0] });
+  };
+
+  deleteEntity = async ({
+    entityName,
+    id,
+  }: {
+    entityName: string;
+    id: string;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
+
+    const statement = `DELETE FROM "${tableName}" WHERE "id" = $1`;
     const { rowCount } = await this.pool.query(statement, [id]);
 
     return rowCount === 1;
-  });
+  };
 
-  getEntities = this.errorWrapper(
-    async (entityId: string, filter?: EntityFilter) => {
-      const where = filter?.where;
-      const first = filter?.first;
-      const skip = filter?.skip;
-      const orderBy = filter?.orderBy;
-      const orderDirection = filter?.orderDirection;
+  getEntities = async ({
+    entityName,
+    filter,
+  }: {
+    entityName: string;
+    filter?: EntityFilter;
+  }) => {
+    const tableName = `${entityName}_${this.instanceId}`;
 
-      const fragments = [];
+    const where = filter?.where;
+    const first = filter?.first;
+    const skip = filter?.skip;
+    const orderBy = filter?.orderBy;
+    const orderDirection = filter?.orderDirection;
 
-      if (where) {
-        const whereFragments = Object.entries(where).map(([field, value]) => {
-          const [fieldName, rawFilterType] = field.split(/_(.*)/s);
-          // This is a hack to handle the "" operator, which the regex above doesn't handle
-          const filterType = rawFilterType === undefined ? "" : rawFilterType;
-          const sqlSymbols = sqlSymbolsForFilterType[filterType];
-          if (!sqlSymbols) {
-            throw new Error(
-              `SQL operators not found for filter type: ${filterType}`
-            );
-          }
+    const fragments = [];
 
-          const whereValue = getWhereValue(value, sqlSymbols);
-
-          return `"${fieldName}" ${whereValue}`;
-        });
-
-        fragments.push(`WHERE ${whereFragments.join(" AND ")}`);
-      }
-
-      if (orderBy) {
-        fragments.push(`ORDER BY "${orderBy}"`);
-      }
-
-      if (orderDirection) {
-        fragments.push(`${orderDirection}`);
-      }
-
-      if (first) {
-        fragments.push(`LIMIT ${first}`);
-      }
-
-      if (skip) {
-        fragments.push(`OFFSET ${skip}`);
-      }
-
-      const statement = `SELECT * FROM "${entityId}" ${fragments.join(" ")}`;
-      const { rows } = await this.pool.query(statement);
-
-      return rows.map((instance) => this.deserialize(entityId, instance));
-    }
-  );
-
-  getEntityDerivedField = this.errorWrapper(
-    async (entityId: string, instanceId: string, derivedFieldName: string) => {
-      const entity = this.schema?.entities.find((e) => e.id === entityId);
-      if (!entity) {
-        throw new Error(`Entity not found in schema for ID: ${entityId}`);
-      }
-
-      const derivedField = entity.fields.find(
-        (field): field is DerivedField =>
-          field.kind === FieldKind.DERIVED && field.name === derivedFieldName
-      );
-
-      if (!derivedField) {
-        throw new Error(
-          `Derived field not found: ${entity.name}.${derivedFieldName}`
-        );
-      }
-
-      const derivedFromEntity = this.schema?.entities.find(
-        (e) => e.name === derivedField.derivedFromEntityName
-      );
-      if (!derivedFromEntity) {
-        throw new Error(
-          `Entity not found in schema for name: ${derivedField.derivedFromEntityName}`
-        );
-      }
-
-      const derivedFieldInstances = await this.getEntities(
-        derivedFromEntity.id,
-        {
-          where: {
-            [derivedField.derivedFromFieldName]: instanceId,
-          },
+    if (where) {
+      const whereFragments = Object.entries(where).map(([field, value]) => {
+        const [fieldName, rawFilterType] = field.split(/_(.*)/s);
+        // This is a hack to handle the "" operator, which the regex above doesn't handle
+        const filterType = rawFilterType === undefined ? "" : rawFilterType;
+        const sqlSymbols = sqlSymbolsForFilterType[filterType];
+        if (!sqlSymbols) {
+          throw new Error(
+            `SQL operators not found for filter type: ${filterType}`
+          );
         }
-      );
 
-      return derivedFieldInstances;
+        const whereValue = getWhereValue(value, sqlSymbols);
+
+        return `"${fieldName}" ${whereValue}`;
+      });
+
+      fragments.push(`WHERE ${whereFragments.join(" AND ")}`);
     }
-  );
 
-  deserialize = (entityId: string, instance: Record<string, unknown>) => {
+    if (orderBy) {
+      fragments.push(`ORDER BY "${orderBy}"`);
+    }
+
+    if (orderDirection) {
+      fragments.push(`${orderDirection}`);
+    }
+
+    if (first) {
+      fragments.push(`LIMIT ${first}`);
+    }
+
+    if (skip) {
+      fragments.push(`OFFSET ${skip}`);
+    }
+
+    const statement = `SELECT * FROM "${tableName}" ${fragments.join(" ")}`;
+    const { rows } = await this.pool.query(statement);
+
+    return rows.map((instance) => this.deserialize({ entityName, instance }));
+  };
+
+  deserialize = ({
+    entityName,
+    instance,
+  }: {
+    entityName: string;
+    instance: Record<string, unknown>;
+  }) => {
     if (!this.schema) {
       throw new Error(`EntityStore has not been initialized with a schema yet`);
     }
 
-    const entity = this.schema?.entities.find((e) => e.id === entityId);
+    const entity = this.schema?.entities.find((e) => e.name === entityName);
     if (!entity) {
-      throw new Error(`Entity not found in schema for ID: ${entityId}`);
+      throw new Error(`Entity not found in schema for ID: ${entityName}`);
     }
 
     const deserializedInstance = { ...instance };

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -143,8 +143,10 @@ export class PostgresEntityStore implements EntityStore {
             const notNull = field.notNull ? "NOT NULL" : "";
             return `"${field.name}" TEXT ${notNull}`;
           }
-          default: {
-            return field.migrateUpStatement;
+          case FieldKind.RELATIONSHIP: {
+            const type = gqlScalarToSqlType[field.relatedEntityIdType.name];
+            const notNull = field.notNull ? "NOT NULL" : "";
+            return `"${field.name}" ${type} ${notNull}`;
           }
         }
       });

--- a/packages/core/src/database/entity/postgresEntityStore.ts
+++ b/packages/core/src/database/entity/postgresEntityStore.ts
@@ -110,8 +110,8 @@ export class PostgresEntityStore implements EntityStore {
       Boolean: "integer",
       Int: "integer",
       String: "text",
-      BigInt: "text",
-      BigDecimal: "text",
+      BigInt: "numeric(78)", // Store BigInts as numerics large enough for Solidity's MAX_INT (2**256 - 1).
+      BigDecimal: "numeric(78)",
       Bytes: "text",
     };
 

--- a/packages/core/src/database/entity/sqliteEntityStore.ts
+++ b/packages/core/src/database/entity/sqliteEntityStore.ts
@@ -94,6 +94,10 @@ export class SqliteEntityStore implements EntityStore {
               .map((v) => `'${v}'`)
               .join(", ")})) ${notNull}`;
           }
+          case FieldKind.LIST: {
+            const notNull = field.notNull ? "NOT NULL" : "";
+            return `"${field.name}" TEXT ${notNull}`;
+          }
           default: {
             return field.migrateUpStatement;
           }

--- a/packages/core/src/database/entity/sqliteEntityStore.ts
+++ b/packages/core/src/database/entity/sqliteEntityStore.ts
@@ -98,8 +98,10 @@ export class SqliteEntityStore implements EntityStore {
             const notNull = field.notNull ? "NOT NULL" : "";
             return `"${field.name}" TEXT ${notNull}`;
           }
-          default: {
-            return field.migrateUpStatement;
+          case FieldKind.RELATIONSHIP: {
+            const type = gqlScalarToSqlType[field.relatedEntityIdType.name];
+            const notNull = field.notNull ? "NOT NULL" : "";
+            return `"${field.name}" ${type} ${notNull}`;
           }
         }
       });

--- a/packages/core/src/database/entity/sqliteEntityStore.ts
+++ b/packages/core/src/database/entity/sqliteEntityStore.ts
@@ -79,7 +79,6 @@ export class SqliteEntityStore implements EntityStore {
       Int: "integer",
       String: "text",
       BigInt: "text",
-      BigDecimal: "text",
       Bytes: "text",
     };
 
@@ -286,7 +285,7 @@ export class SqliteEntityStore implements EntityStore {
       // Bigints are stored as strings in SQLite. This means when trying to
       // order by a bigint field, the values are sorted as strings. This
       // fixes the issue by casting them as REAL for the purposes of sorting.
-      if (["BigInt", "BigDecimal"].includes(orderByField.scalarTypeName)) {
+      if (orderByField.scalarTypeName === "BigInt") {
         fragments.push(`ORDER BY CAST("${orderBy}" AS REAL)`);
       } else {
         fragments.push(`ORDER BY "${orderBy}"`);

--- a/packages/core/src/database/entity/sqliteEntityStore.ts
+++ b/packages/core/src/database/entity/sqliteEntityStore.ts
@@ -85,6 +85,15 @@ export class SqliteEntityStore implements EntityStore {
             const pk = field.name === "id" ? "PRIMARY KEY" : "";
             return `"${field.name}" ${type} ${notNull} ${pk}`;
           }
+          case FieldKind.ENUM: {
+            const notNull = field.notNull ? "NOT NULL" : "";
+
+            return `"${field.name}" TEXT CHECK ("${
+              field.name
+            }" IN (${field.enumValues
+              .map((v) => `'${v}'`)
+              .join(", ")})) ${notNull}`;
+          }
           default: {
             return field.migrateUpStatement;
           }

--- a/packages/core/src/database/entity/utils.ts
+++ b/packages/core/src/database/entity/utils.ts
@@ -106,6 +106,8 @@ export const getColumnValuePairs = (instance: Record<string, unknown>) => {
       let persistedValue: number | string | null;
       if (typeof value === "boolean") {
         persistedValue = value ? 1 : 0;
+      } else if (typeof value === "bigint") {
+        persistedValue = value.toString();
       } else if (typeof value === "undefined") {
         persistedValue = null;
       } else if (Array.isArray(value)) {

--- a/packages/core/src/handlers/EventHandlerService.ts
+++ b/packages/core/src/handlers/EventHandlerService.ts
@@ -147,18 +147,23 @@ export class EventHandlerService extends Emittery<EventHandlerServiceEvents> {
     // Build entity models for event handler context.
     const entityModels: Record<string, unknown> = {};
     schema.entities.forEach((entity) => {
-      const { id: entityId, name: entityName } = entity;
+      const entityName = entity.name;
 
       entityModels[entityName] = {
-        get: (id: string) => this.resources.entityStore.getEntity(entityId, id),
+        get: (id: string) =>
+          this.resources.entityStore.getEntity({ entityName, id }),
         delete: (id: string) =>
-          this.resources.entityStore.deleteEntity(entityId, id),
-        insert: (id: string, obj: Record<string, unknown>) =>
-          this.resources.entityStore.insertEntity(entityId, id, obj),
-        update: (id: string, obj: Record<string, unknown>) =>
-          this.resources.entityStore.updateEntity(entityId, id, obj),
-        upsert: (id: string, obj: Record<string, unknown>) =>
-          this.resources.entityStore.upsertEntity(entityId, id, obj),
+          this.resources.entityStore.deleteEntity({ entityName, id }),
+        insert: (id: string, instance: Record<string, unknown>) =>
+          this.resources.entityStore.insertEntity({
+            entityName,
+            id,
+            instance,
+          }),
+        update: (id: string, instance: Record<string, unknown>) =>
+          this.resources.entityStore.updateEntity({ entityName, id, instance }),
+        upsert: (id: string, instance: Record<string, unknown>) =>
+          this.resources.entityStore.upsertEntity({ entityName, id, instance }),
       };
     });
 

--- a/packages/core/src/handlers/EventHandlerService.ts
+++ b/packages/core/src/handlers/EventHandlerService.ts
@@ -2,7 +2,6 @@ import Emittery from "emittery";
 import { decodeEventLog, encodeEventTopics, Hex } from "viem";
 
 import { createQueue, Queue, Worker } from "@/common/createQueue";
-import { MessageKind } from "@/common/LoggerService";
 import type { Log } from "@/common/types";
 import { Resources } from "@/Ponder";
 import { Handlers } from "@/reload/readHandlers";
@@ -268,14 +267,12 @@ export class EventHandlerService extends Emittery<EventHandlerServiceEvents> {
         const error = error_ as Error;
         const result = getStackTraceAndCodeFrame(error, this.resources.options);
         if (result) {
-          error.stack = `${result.stackTrace}\n` + result.codeFrame;
+          error.message =
+            `${error.message}\n` + `${result.stackTrace}\n` + result.codeFrame;
         }
 
         // TODO: Use the task arg to provide context to the user about the error.
-        this.resources.logger.logMessage(
-          MessageKind.ERROR,
-          "running event handlers" + ": " + error.message + `\n` + error.stack
-        );
+        this.resources.errors.submitHandlerError({ error });
       }
 
       this.emit("taskCompleted", { timestamp: Number(block.timestamp) });

--- a/packages/core/src/reload/ReloadService.ts
+++ b/packages/core/src/reload/ReloadService.ts
@@ -82,11 +82,10 @@ export class ReloadService extends Emittery<ReloadServiceEvents> {
         logger: this.resources.logger,
       });
       this.emit("newHandlers", { handlers });
-    } catch (error) {
-      this.resources.errors.submitHandlerError({
-        context: "building event handlers",
-        error: error as Error,
-      });
+    } catch (error_) {
+      const error = error_ as Error;
+      error.message = "Building event handlers: " + error.message;
+      this.resources.errors.submitHandlerError({ error });
     }
   }
 
@@ -99,11 +98,11 @@ export class ReloadService extends Emittery<ReloadServiceEvents> {
       const graphqlSchema = buildGqlSchema(schema);
       this.emit("newSchema", { schema, graphqlSchema });
       return { schema, graphqlSchema };
-    } catch (error) {
-      this.resources.errors.submitHandlerError({
-        context: "building schema",
-        error: error as Error,
-      });
+    } catch (error_) {
+      const error = error_ as Error;
+      error.message = "Building schema: " + error.message;
+      error.stack = "";
+      this.resources.errors.submitHandlerError({ error });
     }
   }
 

--- a/packages/core/src/reload/readGraphqlSchema.ts
+++ b/packages/core/src/reload/readGraphqlSchema.ts
@@ -3,13 +3,12 @@ import { readFileSync } from "node:fs";
 
 import { PonderOptions } from "@/config/options";
 
-const schemaHeader = `
+export const schemaHeader = `
 "Directs the executor to process this type as a Ponder entity."
 directive @entity(immutable: Boolean = false) on OBJECT
 
 "Creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
-
 
 scalar BigDecimal
 scalar Bytes

--- a/packages/core/src/reload/readGraphqlSchema.ts
+++ b/packages/core/src/reload/readGraphqlSchema.ts
@@ -10,7 +10,6 @@ directive @entity(immutable: Boolean = false) on OBJECT
 "Creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
 
-scalar BigDecimal
 scalar Bytes
 scalar BigInt
 `;

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -13,7 +13,6 @@ import {
   Kind,
   StringValueNode,
 } from "graphql";
-import { randomUUID } from "node:crypto";
 
 import {
   DerivedField,
@@ -49,9 +48,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
       `Custom scalars are not supported: ${userDefinedScalars[0]}`
     );
   }
-
-  // The `id` field is used as a table name prefix in the EntityStore to avoid entity table name collisions.
-  const instanceId = randomUUID();
 
   const entities = gqlEntityTypes.map((entity) => {
     const entityName = entity.name;
@@ -243,7 +239,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
     });
 
     return <Entity>{
-      id: `${entityName}_${instanceId}`,
       name: entityName,
       gqlType: entity,
       isImmutable: entityIsImmutable,
@@ -253,7 +248,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
   });
 
   const schema: Schema = {
-    instanceId,
     entities,
   };
 

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -124,6 +124,31 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
         );
       }
 
+      // Handle list types.
+      if (isList) {
+        if (scalarBaseType) {
+          return <ListField>{
+            name: fieldName,
+            kind: FieldKind.LIST,
+            baseGqlType: scalarBaseType,
+            originalFieldType,
+            notNull: isNotNull,
+            isListElementNotNull,
+          };
+        }
+
+        if (enumBaseType) {
+          return <ListField>{
+            name: fieldName,
+            kind: FieldKind.LIST,
+            baseGqlType: enumBaseType,
+            originalFieldType,
+            notNull: isNotNull,
+            isListElementNotNull,
+          };
+        }
+      }
+
       // Handle scalar types.
       if (scalarBaseType) {
         const baseType = scalarBaseType;
@@ -143,7 +168,7 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
           }
         }
 
-        const field: ScalarField = {
+        return <ScalarField>{
           name: fieldName,
           kind: FieldKind.SCALAR,
           notNull: isNotNull,
@@ -151,7 +176,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
           scalarTypeName: fieldTypeName,
           scalarGqlType: baseType,
         };
-        return field;
       }
 
       // Handle enum types.
@@ -167,29 +191,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
           notNull: isNotNull,
           enumValues,
         };
-      }
-
-      // Handle list types.
-      if (isList) {
-        if (scalarBaseType) {
-          return getListField(
-            fieldName,
-            scalarBaseType,
-            originalFieldType,
-            isNotNull,
-            isListElementNotNull
-          );
-        }
-
-        if (enumBaseType) {
-          return getListField(
-            fieldName,
-            enumBaseType,
-            originalFieldType,
-            isNotNull,
-            isListElementNotNull
-          );
-        }
       }
 
       throw new Error(`Unhandled field type: ${fieldTypeName}`);
@@ -216,30 +217,6 @@ export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
   };
 
   return schema;
-};
-
-const getListField = (
-  fieldName: string,
-  baseType: GraphQLEnumType | GraphQLScalarType,
-  originalFieldType: TypeNode,
-  isNotNull: boolean,
-  isListElementNotNull: boolean
-) => {
-  let migrateUpStatement = `"${fieldName}" TEXT`;
-  if (isNotNull) {
-    migrateUpStatement += " NOT NULL";
-  }
-
-  return <ListField>{
-    name: fieldName,
-    kind: FieldKind.LIST,
-    baseGqlType: baseType,
-    originalFieldType,
-    notNull: isNotNull,
-    migrateUpStatement,
-    sqlType: "text", // JSON
-    isListElementNotNull,
-  };
 };
 
 const getRelationshipField = (

--- a/packages/core/src/schema/buildSchema.ts
+++ b/packages/core/src/schema/buildSchema.ts
@@ -32,10 +32,8 @@ const gqlScalarTypeByName: Record<string, GraphQLScalarType | undefined> = {
   Float: GraphQLFloat,
   String: GraphQLString,
   Boolean: GraphQLBoolean,
-  // Custom scalars all use String.
   BigInt: GraphQLString,
   Bytes: GraphQLString,
-  BigDecimal: GraphQLString,
 };
 
 export const buildSchema = (graphqlSchema: GraphQLSchema): Schema => {
@@ -319,7 +317,7 @@ const getUserDefinedScalarTypes = (schema: GraphQLSchema) => {
     (type) =>
       !!type.astNode &&
       type.astNode.kind === Kind.SCALAR_TYPE_DEFINITION &&
-      !["BigInt", "BigDecimal", "Bytes"].includes(type.name)
+      !["BigInt", "Bytes"].includes(type.name)
   ) as GraphQLScalarType[];
 };
 

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -8,7 +8,6 @@ import type {
 } from "graphql";
 
 export enum FieldKind {
-  ID,
   SCALAR,
   ENUM,
   LIST,
@@ -16,24 +15,13 @@ export enum FieldKind {
   DERIVED,
 }
 
-export type IDField = {
-  name: string;
-  kind: FieldKind.ID;
-  baseGqlType: GraphQLScalarType;
-  originalFieldType: TypeNode;
-  notNull: boolean;
-  migrateUpStatement: string;
-  sqlType: string;
-};
-
 export type ScalarField = {
   name: string;
   kind: FieldKind.SCALAR;
-  baseGqlType: GraphQLScalarType;
-  originalFieldType: TypeNode;
   notNull: boolean;
-  migrateUpStatement: string;
-  sqlType: string;
+  originalFieldType: TypeNode;
+  scalarTypeName: string;
+  scalarGqlType: GraphQLScalarType;
 };
 
 export type EnumField = {
@@ -80,7 +68,6 @@ export type DerivedField = {
 };
 
 export type Field =
-  | IDField
   | ScalarField
   | EnumField
   | ListField

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -27,11 +27,9 @@ export type ScalarField = {
 export type EnumField = {
   name: string;
   kind: FieldKind.ENUM;
-  baseGqlType: GraphQLEnumType;
-  originalFieldType: TypeNode;
   notNull: boolean;
-  migrateUpStatement: string;
-  sqlType: string;
+  originalFieldType: TypeNode;
+  enumGqlType: GraphQLEnumType;
   enumValues: string[];
 };
 

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -39,8 +39,6 @@ export type ListField = {
   baseGqlType: GraphQLInputType;
   originalFieldType: TypeNode;
   notNull: boolean;
-  migrateUpStatement: string;
-  sqlType: "text";
   isListElementNotNull: boolean;
 };
 

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -70,7 +70,6 @@ export type Field =
   | DerivedField;
 
 export type Entity = {
-  id: string;
   name: string;
   gqlType: GraphQLObjectType;
   isImmutable: boolean;
@@ -79,6 +78,5 @@ export type Entity = {
 };
 
 export type Schema = {
-  instanceId: string;
   entities: Entity[];
 };

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -48,9 +48,8 @@ export type RelationshipField = {
   baseGqlType: GraphQLInputObjectType;
   originalFieldType: TypeNode;
   notNull: boolean;
-  migrateUpStatement: string;
-  sqlType: string;
-  relatedEntityId: string;
+  relatedEntityName: string;
+  relatedEntityIdType: GraphQLScalarType;
 };
 
 export type DerivedField = {

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -55,10 +55,10 @@ export const buildEntityType = (
               // @ts-ignore
               const relatedInstanceId = parent[field.name];
 
-              return await store.getEntity(
-                field.relatedEntityId,
-                relatedInstanceId
-              );
+              return await store.getEntity({
+                entityName: field.relatedEntityName,
+                id: relatedInstanceId,
+              });
             };
 
             fieldConfigMap[field.name] = {
@@ -83,11 +83,14 @@ export const buildEntityType = (
               // @ts-ignore
               const entityId = parent.id;
 
-              return await store.getEntityDerivedField(
-                entity.id,
-                entityId,
-                field.name
-              );
+              return await store.getEntities({
+                entityName: field.derivedFromEntityName,
+                filter: {
+                  where: {
+                    [field.derivedFromFieldName]: entityId,
+                  },
+                },
+              });
             };
 
             fieldConfigMap[field.name] = {

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -96,6 +96,14 @@ export const buildEntityType = (
             };
             break;
           }
+          case FieldKind.SCALAR: {
+            fieldConfigMap[field.name] = {
+              type: field.notNull
+                ? new GraphQLNonNull(field.scalarGqlType)
+                : field.scalarGqlType,
+            };
+            break;
+          }
           default: {
             fieldConfigMap[field.name] = {
               type: field.notNull

--- a/packages/core/src/server/graphql/buildEntityType.ts
+++ b/packages/core/src/server/graphql/buildEntityType.ts
@@ -24,6 +24,22 @@ export const buildEntityType = (
       // Build resolvers for relationship fields on the entity.
       entity.fields.forEach((field) => {
         switch (field.kind) {
+          case FieldKind.SCALAR: {
+            fieldConfigMap[field.name] = {
+              type: field.notNull
+                ? new GraphQLNonNull(field.scalarGqlType)
+                : field.scalarGqlType,
+            };
+            break;
+          }
+          case FieldKind.ENUM: {
+            fieldConfigMap[field.name] = {
+              type: field.notNull
+                ? new GraphQLNonNull(field.enumGqlType)
+                : field.enumGqlType,
+            };
+            break;
+          }
           case FieldKind.RELATIONSHIP: {
             const resolver: GraphQLFieldResolver<Source, Context> = async (
               parent,
@@ -93,22 +109,6 @@ export const buildEntityType = (
             );
             fieldConfigMap[field.name] = {
               type: field.notNull ? new GraphQLNonNull(listType) : listType,
-            };
-            break;
-          }
-          case FieldKind.SCALAR: {
-            fieldConfigMap[field.name] = {
-              type: field.notNull
-                ? new GraphQLNonNull(field.scalarGqlType)
-                : field.scalarGqlType,
-            };
-            break;
-          }
-          default: {
-            fieldConfigMap[field.name] = {
-              type: field.notNull
-                ? new GraphQLNonNull(field.baseGqlType)
-                : field.baseGqlType,
             };
             break;
           }

--- a/packages/core/src/server/graphql/buildPluralField.ts
+++ b/packages/core/src/server/graphql/buildPluralField.ts
@@ -96,12 +96,12 @@ const buildPluralField = (
       case FieldKind.ENUM: {
         // Enum fields => universal, singular
         operators.universal.forEach((suffix) => {
-          filterFields[`${field.name}${suffix}`] = { type: field.baseGqlType };
+          filterFields[`${field.name}${suffix}`] = { type: field.enumGqlType };
         });
 
         operators.singular.forEach((suffix) => {
           filterFields[`${field.name}${suffix}`] = {
-            type: new GraphQLList(field.baseGqlType),
+            type: new GraphQLList(field.enumGqlType),
           };
         });
         break;

--- a/packages/core/src/server/graphql/buildPluralField.ts
+++ b/packages/core/src/server/graphql/buildPluralField.ts
@@ -161,7 +161,7 @@ const buildPluralField = (
 
     const filter = args;
 
-    return await store.getEntities(entity.id, filter);
+    return await store.getEntities({ entityName: entity.name, filter });
   };
 
   return {

--- a/packages/core/src/server/graphql/buildPluralField.ts
+++ b/packages/core/src/server/graphql/buildPluralField.ts
@@ -62,48 +62,31 @@ const buildPluralField = (
 
   entity.fields.forEach((field) => {
     switch (field.kind) {
-      case FieldKind.ID: {
-        // ID fields => universal, singular, numeric
-        operators.universal.forEach((suffix) => {
-          filterFields[`${field.name}${suffix}`] = { type: field.baseGqlType };
-        });
-
-        operators.singular.forEach((suffix) => {
-          filterFields[`${field.name}${suffix}`] = {
-            type: new GraphQLList(field.baseGqlType),
-          };
-        });
-
-        operators.numeric.forEach((suffix) => {
-          filterFields[`${field.name}${suffix}`] = {
-            type: field.baseGqlType,
-          };
-        });
-        break;
-      }
       case FieldKind.SCALAR: {
         // Scalar fields => universal, singular, numeric OR string depending on base type
         // Note: Booleans => universal and singular only.
         operators.universal.forEach((suffix) => {
-          filterFields[`${field.name}${suffix}`] = { type: field.baseGqlType };
+          filterFields[`${field.name}${suffix}`] = {
+            type: field.scalarGqlType,
+          };
         });
 
         operators.numeric.forEach((suffix) => {
           filterFields[`${field.name}${suffix}`] = {
-            type: field.baseGqlType,
+            type: field.scalarGqlType,
           };
         });
 
         operators.singular.forEach((suffix) => {
           filterFields[`${field.name}${suffix}`] = {
-            type: new GraphQLList(field.baseGqlType),
+            type: new GraphQLList(field.scalarGqlType),
           };
         });
 
-        if (["String"].includes(field.baseGqlType.name)) {
+        if (["String"].includes(field.scalarGqlType.name)) {
           operators.string.forEach((suffix) => {
             filterFields[`${field.name}${suffix}`] = {
-              type: field.baseGqlType,
+              type: field.scalarGqlType,
             };
           });
         }

--- a/packages/core/src/server/graphql/buildSingularField.ts
+++ b/packages/core/src/server/graphql/buildSingularField.ts
@@ -25,7 +25,10 @@ const buildSingularField = (
 
     if (!id) return null;
 
-    const entityInstance = await store.getEntity(entity.name, id);
+    const entityInstance = await store.getEntity({
+      entityName: entity.name,
+      id,
+    });
 
     // // Build resolvers for relationship fields on the entity.
     // entity.fields

--- a/packages/core/test/Ponder/art-gobblers.test.ts
+++ b/packages/core/test/Ponder/art-gobblers.test.ts
@@ -129,6 +129,7 @@ describe("art-gobblers", () => {
         }
       `);
 
+      expect(tokens.length).toBeGreaterThan(0);
       for (const token of tokens) {
         expect(typeof token.id).toBe("string");
       }
@@ -141,6 +142,7 @@ describe("art-gobblers", () => {
         }
       `);
 
+      expect(tokens.length).toBeGreaterThan(0);
       expect(tokens.map((t: any) => Number(t.id))).toMatchObject(
         tokens
           .map((t: any) => Number(t.id))
@@ -155,6 +157,7 @@ describe("art-gobblers", () => {
         }
       `);
 
+      expect(tokens.length).toBeGreaterThan(0);
       expect(tokens.map((t: any) => Number(t.id))).toMatchObject(
         tokens
           .map((t: any) => Number(t.id))

--- a/packages/core/test/Ponder/art-gobblers.test.ts
+++ b/packages/core/test/Ponder/art-gobblers.test.ts
@@ -1,0 +1,165 @@
+import { rmSync } from "node:fs";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { buildOptions } from "@/config/options";
+import { buildPonderConfig } from "@/config/ponderConfig";
+import { Ponder } from "@/Ponder";
+
+import { testClient } from "../utils/clients";
+import { getFreePort } from "../utils/getFreePort";
+
+beforeAll(async () => {
+  await testClient.reset({
+    blockNumber: BigInt(parseInt(process.env.ANVIL_BLOCK_NUMBER!)),
+    jsonRpcUrl: process.env.ANVIL_FORK_URL,
+  });
+});
+
+describe("art-gobblers", () => {
+  let ponder: Ponder;
+
+  beforeAll(async () => {
+    rmSync("./test/Ponder/art-gobblers/.ponder", {
+      recursive: true,
+      force: true,
+    });
+    rmSync("./test/Ponder/art-gobblers/generated", {
+      recursive: true,
+      force: true,
+    });
+    process.env.PORT = (await getFreePort()).toString();
+
+    const options = buildOptions({
+      rootDir: "./test/Ponder/art-gobblers",
+      configFile: "ponder.config.ts",
+      logType: "start",
+      silent: false,
+    });
+    const config = await buildPonderConfig(options);
+
+    ponder = new Ponder({ options, config });
+
+    await ponder.start();
+  });
+
+  afterAll(async () => {
+    await ponder.kill();
+  });
+
+  describe("backfill", () => {
+    test("inserts backfill data into the cache store", async () => {
+      const logs = await ponder.resources.cacheStore.getLogs({
+        contractAddress:
+          "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769".toLowerCase(),
+        fromBlockTimestamp: 0,
+        toBlockTimestamp: 1667247995, // mainnet 15870420
+      });
+
+      expect(logs).toHaveLength(651);
+
+      for (const log of logs) {
+        const block = await ponder.resources.cacheStore.getBlock(log.blockHash);
+        expect(block).toBeTruthy();
+
+        const transaction = await ponder.resources.cacheStore.getTransaction(
+          log.transactionHash
+        );
+        expect(transaction).toBeTruthy();
+      }
+    });
+  });
+
+  describe("event processing", () => {
+    test("inserts data into the entity store", async () => {
+      const accounts = await ponder.resources.entityStore.getEntities({
+        entityName: "Account",
+      });
+      expect(accounts.length).toBe(316);
+
+      const tokens = await ponder.resources.entityStore.getEntities({
+        entityName: "Token",
+      });
+      expect(tokens.length).toBe(273);
+    });
+  });
+
+  describe("graphql", () => {
+    let gql: (query: string) => Promise<any>;
+
+    beforeAll(() => {
+      const app = request(ponder.serverService.app);
+
+      gql = async (query) => {
+        const response = await app
+          .post("/graphql")
+          .send({ query: `query { ${query} }` });
+
+        expect(response.body.errors).toBe(undefined);
+        expect(response.statusCode).toBe(200);
+
+        return response.body.data;
+      };
+    });
+
+    test("serves data", async () => {
+      const { accounts, tokens } = await gql(`
+        accounts {
+          id
+          tokens {
+            id
+          }
+        }
+        tokens {
+          id
+          owner {
+            id
+          }
+        }
+      `);
+
+      expect(accounts).toHaveLength(316);
+      expect(tokens).toHaveLength(273);
+    });
+
+    test("returns bigint ids as string", async () => {
+      const { tokens } = await gql(`
+        tokens {
+          id
+        }
+      `);
+
+      for (const token of tokens) {
+        expect(typeof token.id).toBe("string");
+      }
+    });
+
+    test("orders asc on bigint fields", async () => {
+      const { tokens } = await gql(`
+        tokens(orderBy: "id", orderDirection: "asc") {
+          id
+        }
+      `);
+
+      expect(tokens.map((t: any) => Number(t.id))).toMatchObject(
+        tokens
+          .map((t: any) => Number(t.id))
+          .sort((a: number, b: number) => a - b)
+      );
+    });
+
+    test("orders desc on bigint fields", async () => {
+      const { tokens } = await gql(`
+        tokens(orderBy: "id", orderDirection: "desc") {
+          id
+        }
+      `);
+
+      expect(tokens.map((t: any) => Number(t.id))).toMatchObject(
+        tokens
+          .map((t: any) => Number(t.id))
+          .sort((a: number, b: number) => b - a)
+      );
+    });
+  });
+});

--- a/packages/core/test/Ponder/art-gobblers/ArtGobblers.json
+++ b/packages/core/test/Ponder/art-gobblers/ArtGobblers.json
@@ -1,0 +1,989 @@
+[
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "_merkleRoot", "type": "bytes32" },
+      { "internalType": "uint256", "name": "_mintStart", "type": "uint256" },
+      { "internalType": "contract Goo", "name": "_goo", "type": "address" },
+      { "internalType": "contract Pages", "name": "_pages", "type": "address" },
+      { "internalType": "address", "name": "_team", "type": "address" },
+      { "internalType": "address", "name": "_community", "type": "address" },
+      {
+        "internalType": "contract RandProvider",
+        "name": "_randProvider",
+        "type": "address"
+      },
+      { "internalType": "string", "name": "_baseUri", "type": "string" },
+      { "internalType": "string", "name": "_unrevealedUri", "type": "string" },
+      {
+        "internalType": "bytes32",
+        "name": "_provenanceHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "AlreadyClaimed", "type": "error" },
+  { "inputs": [], "name": "Cannibalism", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "name": "CannotBurnLegendary",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "cost", "type": "uint256" }
+    ],
+    "name": "InsufficientGobblerAmount",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidProof", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gobblersLeft", "type": "uint256" }
+    ],
+    "name": "LegendaryAuctionNotStarted",
+    "type": "error"
+  },
+  { "inputs": [], "name": "MintStartPending", "type": "error" },
+  { "inputs": [], "name": "NoRemainingLegendaryGobblers", "type": "error" },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalRemainingToBeRevealed",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotEnoughRemainingToBeRevealed",
+    "type": "error"
+  },
+  { "inputs": [], "name": "NotRandProvider", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "OwnerMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "currentPrice", "type": "uint256" }
+    ],
+    "name": "PriceExceededMax",
+    "type": "error"
+  },
+  { "inputs": [], "name": "RequestTooEarly", "type": "error" },
+  { "inputs": [], "name": "ReserveImbalance", "type": "error" },
+  { "inputs": [], "name": "RevealsPending", "type": "error" },
+  { "inputs": [], "name": "SeedPending", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "caller", "type": "address" }
+    ],
+    "name": "UnauthorizedCaller",
+    "type": "error"
+  },
+  { "inputs": [], "name": "ZeroToBeRevealed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "gobblerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "nft",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "ArtGobbled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "gobblerId",
+        "type": "uint256"
+      }
+    ],
+    "name": "GobblerClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "gobblerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "GobblerPurchased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "numGobblers",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lastRevealedId",
+        "type": "uint256"
+      }
+    ],
+    "name": "GobblersRevealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newGooBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "GooBalanceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "gobblerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "burnedGobblerIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "LegendaryGobblerMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract RandProvider",
+        "name": "newRandProvider",
+        "type": "address"
+      }
+    ],
+    "name": "RandProviderUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "randomness",
+        "type": "uint256"
+      }
+    ],
+    "name": "RandomnessFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "toBeRevealed",
+        "type": "uint256"
+      }
+    ],
+    "name": "RandomnessRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lastMintedGobblerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "numGobblersEach",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReservedGobblersMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_URI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FIRST_LEGENDARY_GOBBLER_ID",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LEGENDARY_AUCTION_INTERVAL",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LEGENDARY_GOBBLER_INITIAL_START_PRICE",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LEGENDARY_SUPPLY",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_MINTABLE",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_SUPPLY",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINTLIST_SUPPLY",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PROVENANCE_HASH",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RESERVED_SUPPLY",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UNREVEALED_URI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "", "type": "bytes32" },
+      { "internalType": "uint256", "name": "randomness", "type": "uint256" }
+    ],
+    "name": "acceptRandomSeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gooAmount", "type": "uint256" }
+    ],
+    "name": "addGoo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "id", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "gooAmount", "type": "uint256" }
+    ],
+    "name": "burnGooForPages",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32[]", "name": "proof", "type": "bytes32[]" }
+    ],
+    "name": "claimGobbler",
+    "outputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "community",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentNonLegendaryId",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "getApproved",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "getCopiesOfArtGobbledByGobbler",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "getGobblerData",
+    "outputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint64", "name": "idx", "type": "uint64" },
+      { "internalType": "uint32", "name": "emissionMultiple", "type": "uint32" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "name": "getGobblerEmissionMultiple",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "int256", "name": "sold", "type": "int256" }],
+    "name": "getTargetSaleTime",
+    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "getUserData",
+    "outputs": [
+      { "internalType": "uint32", "name": "gobblersOwned", "type": "uint32" },
+      {
+        "internalType": "uint32",
+        "name": "emissionMultiple",
+        "type": "uint32"
+      },
+      { "internalType": "uint128", "name": "lastBalance", "type": "uint128" },
+      { "internalType": "uint64", "name": "lastTimestamp", "type": "uint64" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "getUserEmissionMultiple",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "int256", "name": "timeSinceStart", "type": "int256" },
+      { "internalType": "uint256", "name": "sold", "type": "uint256" }
+    ],
+    "name": "getVRGDAPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" },
+      { "internalType": "address", "name": "nft", "type": "address" },
+      { "internalType": "uint256", "name": "id", "type": "uint256" },
+      { "internalType": "bool", "name": "isERC1155", "type": "bool" }
+    ],
+    "name": "gobble",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gobblerPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gobblerRevealsData",
+    "outputs": [
+      { "internalType": "uint64", "name": "randomSeed", "type": "uint64" },
+      {
+        "internalType": "uint64",
+        "name": "nextRevealTimestamp",
+        "type": "uint64"
+      },
+      { "internalType": "uint64", "name": "lastRevealedId", "type": "uint64" },
+      { "internalType": "uint56", "name": "toBeRevealed", "type": "uint56" },
+      { "internalType": "bool", "name": "waitingForSeed", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "goo",
+    "outputs": [
+      { "internalType": "contract Goo", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "gooBalance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "hasClaimedMintlistGobbler",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "legendaryGobblerAuctionData",
+    "outputs": [
+      { "internalType": "uint128", "name": "startPrice", "type": "uint128" },
+      { "internalType": "uint128", "name": "numSold", "type": "uint128" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "legendaryGobblerPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "maxPrice", "type": "uint256" },
+      { "internalType": "bool", "name": "useVirtualBalance", "type": "bool" }
+    ],
+    "name": "mintFromGoo",
+    "outputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256[]", "name": "gobblerIds", "type": "uint256[]" }
+    ],
+    "name": "mintLegendaryGobbler",
+    "outputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "numGobblersEach",
+        "type": "uint256"
+      }
+    ],
+    "name": "mintReservedGobblers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lastMintedGobblerId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintStart",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "numMintedForReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "numMintedFromGoo",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256[]", "name": "", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "", "type": "uint256[]" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [{ "internalType": "bytes4", "name": "", "type": "bytes4" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [{ "internalType": "bytes4", "name": "", "type": "bytes4" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "id", "type": "uint256" }],
+    "name": "ownerOf",
+    "outputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pages",
+    "outputs": [
+      { "internalType": "contract Pages", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "randProvider",
+    "outputs": [
+      { "internalType": "contract RandProvider", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gooAmount", "type": "uint256" }
+    ],
+    "name": "removeGoo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "requestRandomSeed",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "numGobblers", "type": "uint256" }
+    ],
+    "name": "revealGobblers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "id", "type": "uint256" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "id", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "operator", "type": "address" },
+      { "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
+    ],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "targetPrice",
+    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "team",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "gobblerId", "type": "uint256" }
+    ],
+    "name": "tokenURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "id", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract RandProvider",
+        "name": "newRandProvider",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeRandProvider",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/core/test/Ponder/art-gobblers/ponder.config.ts
+++ b/packages/core/test/Ponder/art-gobblers/ponder.config.ts
@@ -1,0 +1,15 @@
+import ArtGobblersAbi from "./ArtGobblers.json";
+
+export const config = {
+  networks: [{ name: "mainnet", chainId: 1, rpcUrl: "http://127.0.0.1:8545" }],
+  contracts: [
+    {
+      name: "ArtGobblers",
+      network: "mainnet",
+      abi: ArtGobblersAbi,
+      address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+      startBlock: 15870400,
+      endBlock: 15870420, // 20 blocks!
+    },
+  ],
+};

--- a/packages/core/test/Ponder/art-gobblers/schema.graphql
+++ b/packages/core/test/Ponder/art-gobblers/schema.graphql
@@ -1,0 +1,10 @@
+type Account @entity {
+  id: String!
+  tokens: [Token!]! @derivedFrom(field: "owner")
+}
+
+type Token @entity {
+  id: BigInt!
+  claimedBy: Account
+  owner: Account!
+}

--- a/packages/core/test/Ponder/art-gobblers/src/index.ts
+++ b/packages/core/test/Ponder/art-gobblers/src/index.ts
@@ -1,0 +1,11 @@
+import { ponder } from "@/generated";
+
+ponder.on("ArtGobblers:Transfer", async ({ event, context }) => {
+  await context.entities.Account.upsert(event.params.from, {});
+
+  await context.entities.Account.upsert(event.params.to, {});
+
+  await context.entities.Token.upsert(event.params.id, {
+    owner: event.params.to,
+  });
+});

--- a/packages/core/test/Ponder/art-gobblers/src/nested/file.ts
+++ b/packages/core/test/Ponder/art-gobblers/src/nested/file.ts
@@ -1,0 +1,10 @@
+import { ponder } from "@/generated";
+
+ponder.on("ArtGobblers:GobblerClaimed", async ({ event, context }) => {
+  await context.entities.Account.upsert(event.params.user, {});
+
+  await context.entities.Token.upsert(event.params.gobblerId, {
+    owner: event.params.user,
+    claimedBy: event.params.user,
+  });
+});

--- a/packages/core/test/Ponder/art-gobblers/tsconfig.json
+++ b/packages/core/test/Ponder/art-gobblers/tsconfig.json
@@ -7,5 +7,6 @@
       "@ponder/core": ["../../../../core"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": []
 }

--- a/packages/core/test/Ponder/art-gobblers/tsconfig.json
+++ b/packages/core/test/Ponder/art-gobblers/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/packages/core/test/Ponder/art-gobblers/tsconfig.json
+++ b/packages/core/test/Ponder/art-gobblers/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "@/generated": ["./generated/index.ts"],
-      "@ponder/core": ["../../../"]
+      "@ponder/core": ["../../../../core"]
     }
   },
   "include": ["src"]

--- a/packages/core/test/Ponder/art-gobblers/tsconfig.json
+++ b/packages/core/test/Ponder/art-gobblers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/generated": ["./generated/index.ts"],
+      "@ponder/core": ["../../../"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/core/test/Ponder/ens.test.ts
+++ b/packages/core/test/Ponder/ens.test.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
   });
 });
 
-describe("Ponder", () => {
+describe("ens", () => {
   let ponder: Ponder;
 
   beforeAll(async () => {

--- a/packages/core/test/Ponder/ens.test.ts
+++ b/packages/core/test/Ponder/ens.test.ts
@@ -28,7 +28,7 @@ describe("Ponder", () => {
       rootDir: "./test/Ponder/ens",
       configFile: "ponder.config.ts",
       logType: "start",
-      silent: true,
+      silent: false,
     });
     const config = await buildPonderConfig(options);
 
@@ -71,9 +71,9 @@ describe("Ponder", () => {
       );
       expect(entity).toBeDefined();
 
-      const ensNfts = await ponder.resources.entityStore.getEntities(
-        entity!.id
-      );
+      const ensNfts = await ponder.resources.entityStore.getEntities({
+        entityName: "EnsNft",
+      });
       expect(ensNfts.length).toBe(58);
     });
   });

--- a/packages/core/test/Ponder/ens/schema.graphql
+++ b/packages/core/test/Ponder/ens/schema.graphql
@@ -1,5 +1,5 @@
 type EnsNft @entity {
-  id: ID!
+  id: String!
   labelHash: String!
   owner: Account!
   transferredAt: Int!
@@ -8,7 +8,7 @@ type EnsNft @entity {
 }
 
 type Account @entity {
-  id: ID!
+  id: String!
   tokens: [EnsNft!]! @derivedFrom(field: "owner")
   lastActive: Int!
 }

--- a/packages/core/test/Ponder/ens/src/index.ts
+++ b/packages/core/test/Ponder/ens/src/index.ts
@@ -1,4 +1,4 @@
-import { ponder } from "../generated";
+import { ponder } from "@/generated";
 
 ponder.on(
   "BaseRegistrarImplementation:Transfer",

--- a/packages/core/test/Ponder/ens/tsconfig.json
+++ b/packages/core/test/Ponder/ens/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "extends": "../../../tsconfig.json",
     "baseUrl": ".",
     "paths": {
       "@/generated": ["./generated/index.ts"],

--- a/packages/core/test/Ponder/ens/tsconfig.json
+++ b/packages/core/test/Ponder/ens/tsconfig.json
@@ -7,5 +7,6 @@
       "@ponder/core": ["../../../../core"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": []
 }

--- a/packages/core/test/Ponder/ens/tsconfig.json
+++ b/packages/core/test/Ponder/ens/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "@/generated": ["./generated/index.ts"],
-      "@ponder/core": ["../../../"]
+      "@ponder/core": ["../../../../core"]
     }
   },
   "include": ["src"]

--- a/packages/core/test/Ponder/ens/tsconfig.json
+++ b/packages/core/test/Ponder/ens/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/generated": ["./generated/index.ts"],
+      "@ponder/core": ["../../../"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/core/test/schema/main.test.ts
+++ b/packages/core/test/schema/main.test.ts
@@ -3,124 +3,173 @@ import { describe, expect, test } from "vitest";
 
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/buildSchema";
-import { FieldKind, ScalarField } from "@/schema/types";
+import { EnumField, FieldKind, ScalarField } from "@/schema/types";
 
 const buildGraphqlSchema = (source: string) => {
   return _buildGraphqlSchema(schemaHeader + source);
 };
 
-describe("ID field type", () => {
-  test("ID", () => {
-    const graphqlSchema = buildGraphqlSchema(`
-      type Entity @entity {
-        id: ID!
-      }
-    `);
+describe("scalar fields", () => {
+  describe("id field", () => {
+    test("ID", () => {
+      const graphqlSchema = buildGraphqlSchema(`
+        type Entity @entity {
+          id: ID!
+        }
+      `);
 
-    expect(() => buildSchema(graphqlSchema))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Entity.id field must be a String, BigInt, Int, or Bytes."
-    `);
+      expect(() => buildSchema(graphqlSchema))
+        .toThrowErrorMatchingInlineSnapshot(`
+        "Entity.id field must be a String, BigInt, Int, or Bytes."
+      `);
+    });
+
+    test("String", () => {
+      const graphqlSchema = buildGraphqlSchema(`
+        type Entity @entity {
+          id: String!
+        }
+      `);
+
+      const schema = buildSchema(graphqlSchema);
+      const entity = schema.entities.find((e) => e.name === "Entity");
+      const idField = entity?.fields.find(
+        (f): f is ScalarField => f.name === "id"
+      );
+      expect(idField?.kind).toBe(FieldKind.SCALAR);
+      expect(idField?.scalarTypeName).toBe("String");
+      expect(idField?.scalarGqlType.toString()).toBe("String");
+    });
+
+    test("Int", () => {
+      const graphqlSchema = buildGraphqlSchema(`
+        type Entity @entity {
+          id: Int!
+        }
+      `);
+
+      const schema = buildSchema(graphqlSchema);
+      const entity = schema.entities.find((e) => e.name === "Entity");
+      const idField = entity?.fields.find(
+        (f): f is ScalarField => f.name === "id"
+      );
+      expect(idField?.kind).toBe(FieldKind.SCALAR);
+      expect(idField?.scalarTypeName).toBe("Int");
+      expect(idField?.scalarGqlType.toString()).toBe("Int");
+    });
+
+    test("BigInt", () => {
+      const graphqlSchema = buildGraphqlSchema(`
+        type Entity @entity {
+          id: BigInt!
+        }
+      `);
+
+      const schema = buildSchema(graphqlSchema);
+      const entity = schema.entities.find((e) => e.name === "Entity");
+      const idField = entity?.fields.find(
+        (f): f is ScalarField => f.name === "id"
+      );
+      expect(idField?.kind).toBe(FieldKind.SCALAR);
+      expect(idField?.scalarTypeName).toBe("BigInt");
+      expect(idField?.scalarGqlType.toString()).toBe("String");
+    });
+
+    test("Bytes", () => {
+      const graphqlSchema = buildGraphqlSchema(`
+        type Entity @entity {
+          id: Bytes!
+        }
+      `);
+
+      const schema = buildSchema(graphqlSchema);
+      const entity = schema.entities.find((e) => e.name === "Entity");
+      const idField = entity?.fields.find(
+        (f): f is ScalarField => f.name === "id"
+      );
+      expect(idField?.kind).toBe(FieldKind.SCALAR);
+      expect(idField?.scalarTypeName).toBe("Bytes");
+      expect(idField?.scalarGqlType.toString()).toBe("String");
+    });
   });
 
-  test("String", () => {
+  test("non-null", () => {
     const graphqlSchema = buildGraphqlSchema(`
       type Entity @entity {
         id: String!
+        bigInt: BigInt
+        bytes: Bytes
+        nonNullBigInt: BigInt!
+        nonNullBytes: Bytes!
       }
     `);
 
     const schema = buildSchema(graphqlSchema);
+
     const entity = schema.entities.find((e) => e.name === "Entity");
-    const idField = entity?.fields.find(
-      (f): f is ScalarField => f.name === "id"
-    );
-    expect(idField?.kind).toBe(FieldKind.SCALAR);
-    expect(idField?.scalarTypeName).toBe("String");
-    expect(idField?.scalarGqlType.toString()).toBe("String");
-  });
+    expect(entity).toBeDefined();
 
-  test("Int", () => {
-    const graphqlSchema = buildGraphqlSchema(`
-      type Entity @entity {
-        id: Int!
-      }
-    `);
+    const bigIntField = entity?.fieldByName["bigInt"];
+    expect(bigIntField).toBeDefined();
+    expect(bigIntField?.notNull).toBe(false);
 
-    const schema = buildSchema(graphqlSchema);
-    const entity = schema.entities.find((e) => e.name === "Entity");
-    const idField = entity?.fields.find(
-      (f): f is ScalarField => f.name === "id"
-    );
-    expect(idField?.kind).toBe(FieldKind.SCALAR);
-    expect(idField?.scalarTypeName).toBe("Int");
-    expect(idField?.scalarGqlType.toString()).toBe("Int");
-  });
+    const bytesField = entity?.fieldByName["bytes"];
+    expect(bytesField).toBeDefined();
+    expect(bytesField?.notNull).toBe(false);
 
-  test("BigInt", () => {
-    const graphqlSchema = buildGraphqlSchema(`
-      type Entity @entity {
-        id: BigInt!
-      }
-    `);
+    const nonNullBigIntField = entity?.fieldByName["nonNullBigInt"];
+    expect(nonNullBigIntField).toBeDefined();
+    expect(nonNullBigIntField?.notNull).toBe(true);
 
-    const schema = buildSchema(graphqlSchema);
-    const entity = schema.entities.find((e) => e.name === "Entity");
-    const idField = entity?.fields.find(
-      (f): f is ScalarField => f.name === "id"
-    );
-    expect(idField?.kind).toBe(FieldKind.SCALAR);
-    expect(idField?.scalarTypeName).toBe("BigInt");
-    expect(idField?.scalarGqlType.toString()).toBe("String");
-  });
-
-  test("Bytes", () => {
-    const graphqlSchema = buildGraphqlSchema(`
-      type Entity @entity {
-        id: Bytes!
-      }
-    `);
-
-    const schema = buildSchema(graphqlSchema);
-    const entity = schema.entities.find((e) => e.name === "Entity");
-    const idField = entity?.fields.find(
-      (f): f is ScalarField => f.name === "id"
-    );
-    expect(idField?.kind).toBe(FieldKind.SCALAR);
-    expect(idField?.scalarTypeName).toBe("Bytes");
-    expect(idField?.scalarGqlType.toString()).toBe("String");
+    const nonNullBytesField = entity?.fieldByName["nonNullBytes"];
+    expect(nonNullBytesField).toBeDefined();
+    expect(nonNullBytesField?.notNull).toBe(true);
   });
 });
 
-test("BigInt and Bytes scalar types are supported", () => {
-  const graphqlSchema = buildGraphqlSchema(`
-    type Entity @entity {
-      id: String!
-      bigInt: BigInt
-      bytes: Bytes
-      nonNullBigInt: BigInt!
-      nonNullBytes: Bytes!
-    }
-  `);
+describe("enum fields", () => {
+  test("single enum", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      enum SingleEnum {
+        VALUE
+      }
 
-  const schema = buildSchema(graphqlSchema);
+      type Entity @entity {
+        enum: SingleEnum
+      }
+    `);
 
-  const entity = schema.entities.find((e) => e.name === "Entity");
-  expect(entity).toBeDefined();
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const enumField = entity?.fields.find(
+      (f): f is EnumField => f.name === "enum"
+    );
+    expect(enumField?.kind).toBe(FieldKind.ENUM);
+    expect(enumField?.notNull).toBe(false);
+    expect(enumField?.enumGqlType.toString()).toBe("SingleEnum");
+    expect(enumField?.enumValues).toMatchObject(["VALUE"]);
+  });
 
-  const bigIntField = entity?.fieldByName["bigInt"];
-  expect(bigIntField).toBeDefined();
-  expect(bigIntField?.notNull).toBe(false);
+  test("multiple enum", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      enum MultipleEnum {
+        VALUE
+        ANOTHER_VALUE
+      }
 
-  const bytesField = entity?.fieldByName["bytes"];
-  expect(bytesField).toBeDefined();
-  expect(bytesField?.notNull).toBe(false);
+      type Entity @entity {
+        enum: MultipleEnum!
+      }
+    `);
 
-  const nonNullBigIntField = entity?.fieldByName["nonNullBigInt"];
-  expect(nonNullBigIntField).toBeDefined();
-  expect(nonNullBigIntField?.notNull).toBe(true);
-
-  const nonNullBytesField = entity?.fieldByName["nonNullBytes"];
-  expect(nonNullBytesField).toBeDefined();
-  expect(nonNullBytesField?.notNull).toBe(true);
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const enumField = entity?.fields.find(
+      (f): f is EnumField => f.name === "enum"
+    );
+    expect(enumField?.kind).toBe(FieldKind.ENUM);
+    expect(enumField?.notNull).toBe(true);
+    expect(enumField?.enumGqlType.toString()).toBe("MultipleEnum");
+    expect(enumField?.enumValues).toMatchObject(["VALUE", "ANOTHER_VALUE"]);
+  });
 });

--- a/packages/core/test/schema/main.test.ts
+++ b/packages/core/test/schema/main.test.ts
@@ -1,9 +1,19 @@
-import { buildSchema as _buildGraphqlSchema } from "graphql";
+import {
+  buildSchema as _buildGraphqlSchema,
+  GraphQLInt,
+  GraphQLString,
+} from "graphql";
 import { describe, expect, test } from "vitest";
 
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/buildSchema";
-import { EnumField, FieldKind, ListField, ScalarField } from "@/schema/types";
+import {
+  EnumField,
+  FieldKind,
+  ListField,
+  RelationshipField,
+  ScalarField,
+} from "@/schema/types";
 
 const buildGraphqlSchema = (source: string) => {
   return _buildGraphqlSchema(schemaHeader + source);
@@ -260,5 +270,117 @@ describe("list fields", () => {
     expect(listField?.notNull).toBe(false);
     expect(listField?.isListElementNotNull).toBe(false);
     expect(listField?.baseGqlType.toString()).toBe("MultipleEnum");
+  });
+});
+
+describe("relationship fields", () => {
+  test("related entity has String id", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        relatedEntity: RelatedEntity!
+      }
+
+      type RelatedEntity @entity {
+        id: String!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const relationshipField = entity?.fields.find(
+      (f): f is RelationshipField => f.name === "relatedEntity"
+    );
+    expect(relationshipField?.kind).toBe(FieldKind.RELATIONSHIP);
+    expect(relationshipField?.notNull).toBe(true);
+    expect(relationshipField?.relatedEntityName).toBe("RelatedEntity");
+    expect(relationshipField?.relatedEntityIdType).toBe(GraphQLString);
+  });
+
+  test("related entity has Int id", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        relatedEntity: RelatedEntity!
+      }
+
+      type RelatedEntity @entity {
+        id: Int!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const relationshipField = entity?.fields.find(
+      (f): f is RelationshipField => f.name === "relatedEntity"
+    );
+    expect(relationshipField?.kind).toBe(FieldKind.RELATIONSHIP);
+    expect(relationshipField?.notNull).toBe(true);
+    expect(relationshipField?.relatedEntityName).toBe("RelatedEntity");
+    expect(relationshipField?.relatedEntityIdType).toBe(GraphQLInt);
+  });
+
+  test("related entity has BigInt id", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        relatedEntity: RelatedEntity!
+      }
+
+      type RelatedEntity @entity {
+        id: BigInt!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const relationshipField = entity?.fields.find(
+      (f): f is RelationshipField => f.name === "relatedEntity"
+    );
+    expect(relationshipField?.kind).toBe(FieldKind.RELATIONSHIP);
+    expect(relationshipField?.notNull).toBe(true);
+    expect(relationshipField?.relatedEntityName).toBe("RelatedEntity");
+    expect(relationshipField?.relatedEntityIdType).toBe(GraphQLString);
+  });
+
+  test("related entity has Bytes id", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        relatedEntity: RelatedEntity!
+      }
+
+      type RelatedEntity @entity {
+        id: Bytes!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const relationshipField = entity?.fields.find(
+      (f): f is RelationshipField => f.name === "relatedEntity"
+    );
+    expect(relationshipField?.kind).toBe(FieldKind.RELATIONSHIP);
+    expect(relationshipField?.notNull).toBe(true);
+    expect(relationshipField?.relatedEntityName).toBe("RelatedEntity");
+    expect(relationshipField?.relatedEntityIdType).toBe(GraphQLString);
+  });
+
+  test("related entity is nullable", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        relatedEntity: RelatedEntity
+      }
+
+      type RelatedEntity @entity {
+        id: Bytes!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const relationshipField = entity?.fields.find(
+      (f): f is RelationshipField => f.name === "relatedEntity"
+    );
+    expect(relationshipField?.kind).toBe(FieldKind.RELATIONSHIP);
+    expect(relationshipField?.notNull).toBe(false);
+    expect(relationshipField?.relatedEntityName).toBe("RelatedEntity");
+    expect(relationshipField?.relatedEntityIdType).toBe(GraphQLString);
   });
 });

--- a/packages/core/test/schema/main.test.ts
+++ b/packages/core/test/schema/main.test.ts
@@ -1,0 +1,126 @@
+import { buildSchema as _buildGraphqlSchema } from "graphql";
+import { describe, expect, test } from "vitest";
+
+import { schemaHeader } from "@/reload/readGraphqlSchema";
+import { buildSchema } from "@/schema/buildSchema";
+import { FieldKind, ScalarField } from "@/schema/types";
+
+const buildGraphqlSchema = (source: string) => {
+  return _buildGraphqlSchema(schemaHeader + source);
+};
+
+describe("ID field type", () => {
+  test("ID", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        id: ID!
+      }
+    `);
+
+    expect(() => buildSchema(graphqlSchema))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Entity.id field must be a String, BigInt, Int, or Bytes."
+    `);
+  });
+
+  test("String", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        id: String!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const idField = entity?.fields.find(
+      (f): f is ScalarField => f.name === "id"
+    );
+    expect(idField?.kind).toBe(FieldKind.SCALAR);
+    expect(idField?.scalarTypeName).toBe("String");
+    expect(idField?.scalarGqlType.toString()).toBe("String");
+  });
+
+  test("Int", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        id: Int!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const idField = entity?.fields.find(
+      (f): f is ScalarField => f.name === "id"
+    );
+    expect(idField?.kind).toBe(FieldKind.SCALAR);
+    expect(idField?.scalarTypeName).toBe("Int");
+    expect(idField?.scalarGqlType.toString()).toBe("Int");
+  });
+
+  test("BigInt", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        id: BigInt!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const idField = entity?.fields.find(
+      (f): f is ScalarField => f.name === "id"
+    );
+    expect(idField?.kind).toBe(FieldKind.SCALAR);
+    expect(idField?.scalarTypeName).toBe("BigInt");
+    expect(idField?.scalarGqlType.toString()).toBe("String");
+  });
+
+  test("Bytes", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      type Entity @entity {
+        id: Bytes!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const entity = schema.entities.find((e) => e.name === "Entity");
+    const idField = entity?.fields.find(
+      (f): f is ScalarField => f.name === "id"
+    );
+    expect(idField?.kind).toBe(FieldKind.SCALAR);
+    expect(idField?.scalarTypeName).toBe("Bytes");
+    expect(idField?.scalarGqlType.toString()).toBe("String");
+  });
+});
+
+test("BigInt and Bytes scalar types are supported", () => {
+  const graphqlSchema = buildGraphqlSchema(`
+    type Entity @entity {
+      id: String!
+      bigInt: BigInt
+      bytes: Bytes
+      nonNullBigInt: BigInt!
+      nonNullBytes: Bytes!
+    }
+  `);
+
+  const schema = buildSchema(graphqlSchema);
+
+  const entity = schema.entities.find((e) => e.name === "Entity");
+  expect(entity).toBeDefined();
+
+  const bigIntField = entity?.fieldByName["bigInt"];
+  expect(bigIntField).toBeDefined();
+  expect(bigIntField?.notNull).toBe(false);
+
+  const bytesField = entity?.fieldByName["bytes"];
+  expect(bytesField).toBeDefined();
+  expect(bytesField?.notNull).toBe(false);
+
+  const nonNullBigIntField = entity?.fieldByName["nonNullBigInt"];
+  expect(nonNullBigIntField).toBeDefined();
+  expect(nonNullBigIntField?.notNull).toBe(true);
+
+  const nonNullBytesField = entity?.fieldByName["nonNullBytes"];
+  expect(nonNullBytesField).toBeDefined();
+  expect(nonNullBytesField?.notNull).toBe(true);
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src", "test"],
-  "exclude": ["node_modules", "test/Ponder/**/src/**/*"]
+  "exclude": ["node_modules", "test/**/Ponder/ens/**/*"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src", "test"],
-  "exclude": ["node_modules", "test/**/Ponder/ens/**/*"]
+  "exclude": ["node_modules"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src", "test"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test/**/src/*", "test/**/generated/*"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src", "test"],
-  "exclude": ["node_modules", "test/Ponder"]
+  "exclude": ["node_modules", "test/Ponder/**/src/**/*"]
 }

--- a/packages/create-ponder/src/templates/basic.ts
+++ b/packages/create-ponder/src/templates/basic.ts
@@ -13,7 +13,7 @@ export const fromBasic = ({ rootDir }: { rootDir: string }) => {
 
   const schemaGraphqlFileContents = `
     type ExampleToken @entity {
-      id: ID!
+      id: String!
       tokenId: Int!
       trait: TokenTrait!
     }

--- a/packages/create-ponder/src/templates/etherscan.ts
+++ b/packages/create-ponder/src/templates/etherscan.ts
@@ -53,7 +53,7 @@ export const fromEtherscan = async ({
 
   const schemaGraphqlFileContents = `
     type ExampleEntity @entity {
-      id: ID!
+      id: String!
       name: String!
     }
   `;

--- a/packages/create-ponder/src/templates/subgraphId.ts
+++ b/packages/create-ponder/src/templates/subgraphId.ts
@@ -36,10 +36,11 @@ export const fromSubgraphId = async ({
   // Fetch and write the schema.graphql file.
   const schemaCid = manifest.schema.file["/"].slice(6);
   const schemaRaw = await fetchIpfsFile(schemaCid);
+  const schemaCleaned = schemaRaw.replaceAll(": ID!", ": String!");
   const ponderSchemaFilePath = path.join(rootDir, "schema.graphql");
   writeFileSync(
     ponderSchemaFilePath,
-    prettier.format(schemaRaw, { parser: "graphql" })
+    prettier.format(schemaCleaned, { parser: "graphql" })
   );
 
   const dataSources = (manifest.dataSources as unknown[]).map(

--- a/packages/create-ponder/src/templates/subgraphId.ts
+++ b/packages/create-ponder/src/templates/subgraphId.ts
@@ -36,7 +36,9 @@ export const fromSubgraphId = async ({
   // Fetch and write the schema.graphql file.
   const schemaCid = manifest.schema.file["/"].slice(6);
   const schemaRaw = await fetchIpfsFile(schemaCid);
-  const schemaCleaned = schemaRaw.replaceAll(": ID!", ": String!");
+  const schemaCleaned = schemaRaw
+    .replaceAll(": ID!", ": String!")
+    .replaceAll("BigDecimal", "Float");
   const ponderSchemaFilePath = path.join(rootDir, "schema.graphql");
   writeFileSync(
     ponderSchemaFilePath,

--- a/packages/create-ponder/src/templates/subgraphRepo.ts
+++ b/packages/create-ponder/src/templates/subgraphRepo.ts
@@ -59,7 +59,9 @@ export const fromSubgraphRepo = ({
       encoding: "utf-8",
     }
   );
-  const schemaCleaned = schemaRaw.replaceAll(": ID!", ": String!");
+  const schemaCleaned = schemaRaw
+    .replaceAll(": ID!", ": String!")
+    .replaceAll("BigDecimal", "Float");
   writeFileSync(
     path.join(rootDir, "schema.graphql"),
     prettier.format(schemaCleaned, { parser: "graphql" })

--- a/packages/create-ponder/src/templates/subgraphRepo.ts
+++ b/packages/create-ponder/src/templates/subgraphRepo.ts
@@ -1,5 +1,6 @@
-import { copyFileSync, readFileSync } from "node:fs";
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import prettier from "prettier";
 import { parse } from "yaml";
 
 import {
@@ -52,12 +53,17 @@ export const fromSubgraphRepo = ({
   const subgraphYaml = parse(subgraphYamlRaw);
 
   // Copy over the schema.graphql file.
-  const subgraphSchemaFilePath = path.join(
-    subgraphRootDirPath,
-    subgraphYaml.schema.file
+  const schemaRaw = readFileSync(
+    path.join(subgraphRootDirPath, subgraphYaml.schema.file),
+    {
+      encoding: "utf-8",
+    }
   );
-  const ponderSchemaFilePath = path.join(rootDir, "schema.graphql");
-  copyFileSync(subgraphSchemaFilePath, ponderSchemaFilePath);
+  const schemaCleaned = schemaRaw.replaceAll(": ID!", ": String!");
+  writeFileSync(
+    path.join(rootDir, "schema.graphql"),
+    prettier.format(schemaCleaned, { parser: "graphql" })
+  );
 
   // Build the ponder sources. Also copy over the ABI files for each source.
   ponderContracts = (subgraphYaml.dataSources as unknown[])

--- a/packages/create-ponder/test/main.test.ts
+++ b/packages/create-ponder/test/main.test.ts
@@ -188,5 +188,62 @@ describe("create-ponder", () => {
         );
       });
     });
+
+    describe("usdc", () => {
+      const rootDir = path.join(tmpDir, randomUUID());
+
+      beforeAll(async () => {
+        await run(
+          {
+            projectName: "usdc",
+            rootDir,
+            template: {
+              kind: TemplateKind.SUBGRAPH_ID,
+              id: "QmU5V3jy56KnFbxX2uZagvMwocYZASzy1inX828W2XWtTd",
+            },
+          },
+          {
+            installCommand:
+              'export npm_config_LOCKFILE=false ; pnpm --silent --filter "." install',
+          }
+        );
+      });
+
+      test("creates project files and directories", async () => {
+        const root = fs.readdirSync(rootDir);
+        expect(root).toContain(".env.local");
+        expect(root).toContain(".gitignore");
+        expect(root).toContain("abis");
+        expect(root).toContain("generated");
+        expect(root).toContain("src");
+        expect(root).toContain("node_modules");
+        expect(root).toContain("package.json");
+        expect(root).toContain("ponder.config.ts");
+        expect(root).toContain("schema.graphql");
+        expect(root).toContain("tsconfig.json");
+      });
+
+      test("downloads abi", async () => {
+        const abiString = fs.readFileSync(
+          path.join(rootDir, `abis/FiatTokenV1.json`),
+          { encoding: "utf8" }
+        );
+        const abi = JSON.parse(abiString);
+
+        expect(abi.length).toBeGreaterThan(0);
+      });
+
+      test("creates codegen files", async () => {
+        const generated = fs.readdirSync(path.join(rootDir, "generated"));
+        expect(generated.sort()).toEqual(
+          ["index.ts", "app.ts", "schema.graphql"].sort()
+        );
+      });
+
+      test("creates src files", async () => {
+        const src = fs.readdirSync(path.join(rootDir, "src"));
+        expect(src).toEqual(["FiatTokenV1.ts"]);
+      });
+    });
   });
 });


### PR DESCRIPTION
- Remove support for `ID` type in `schema.graphql` (use `String`, `Int`, `BigInt`, or `Bytes`)
- Added tests for schema parsing
- Fixed bug where `BigInt`s were not sorting properly