### PR TITLE
Add `"setup"` event

### DIFF
--- a/.changeset/yellow-fireants-occur.md
+++ b/.changeset/yellow-fireants-occur.md
@@ -1,0 +1,20 @@
+---
+"@ponder/core": patch
+---
+
+Added support for a "setup" event which is processed before all log events. The "setup" event handler argument only includes `context` (no `event` property). Example:
+
+```ts
+import { ponder } from "@/generated";
+
+ponder.on("setup", async ({ context }) => {
+  const { MyEntity } = context.entities;
+
+  const setupData = await fetch("https://...");
+
+  await MyEntity.create({
+    id: setupData.id,
+    data: { ...setupData }
+  });
+});
+```

--- a/docs/pages/api-reference/event-handlers.mdx
+++ b/docs/pages/api-reference/event-handlers.mdx
@@ -1,12 +1,16 @@
 ---
-description: "API reference for Ponder event handler event"
+description: "API reference for Ponder event handlers"
 ---
 
 import { Callout } from "nextra-theme-docs";
 
 # Event handler API
 
-Event handler functions can be registered within any `ts` file inside the `src/` directory. The Ponder engine will then run these handler functions against blockchain data as specified in `ponder.config.ts`
+Event handlers are user-defined functions that process blockchain data. They can be registered within any `.ts` file inside the `src/` directory. There are two kinds of events: **log events** and the **`"setup"` event**.
+
+## Log events
+
+Log events correspond to a smart contract event log that has occurred. The Ponder engine fetches event logs for all contracts defined in `ponder.config.ts`, then passes that data to the corresponding handler function.
 
 ```ts filename="src/index.ts"
 import { ponder } from "@/generated";
@@ -16,30 +20,23 @@ ponder.on("ContractName:EventName", async ({ event, context }) => {
   const { entities, contracts } = context;
 
   // ...
-  return;
 });
 ```
 
 ### Options
 
-| name                                      | kk                                                                  |
-| :---------------------------------------- | :------------------------------------------------------------------ |
-| [`event`](/api-reference/event#event)     | Event-specific data (event parameters, log, block, and transaction) |
-| [`context`](/api-reference/event#context) | Global resources (entity objects, read-only contract objects)       |
+| name                                               | description                                                      |
+| :------------------------------------------------- | :--------------------------------------------------------------- |
+| [`event`](/api-reference/event-handlers#event)     | Event-specific data (log arguments, log, block, and transaction) |
+| [`context`](/api-reference/event-handlers#context) | Global resources (entity objects, read-only contract objects)    |
 
-### Returns
-
-Ponder does not use the value returned by event handler functions.
-
-`Promise<unknown> | unknown`
-
-## `event`
-
-This object contains the event parameters, the transaction that produced the event log, and the block containing that transaction. `Log`, `Block`, and `Transaction` are similar to the corresponding types from [viem](https://viem.sh), but are adapted to represent only the finalized blockchain state.
+<Callout type="info">
+  The value returned by event handler functions is ignored.
+</Callout>
 
 ### `Event`
 
-The event being handled.
+The `event` object contains the log arguments, the transaction that produced the log, and the block containing that transaction. `Log`, `Block`, and `Transaction` are similar to the corresponding types from [viem](https://viem.sh), but are adapted to represent only the finalized blockchain state.
 
 ```ts
 type Event = {
@@ -53,9 +50,9 @@ type Event = {
 };
 ```
 
-### `Log`
+#### `Log`
 
-The raw event log object.
+The raw log object.
 
 ```ts
 type Log = {
@@ -86,9 +83,9 @@ type Log = {
 };
 ```
 
-### `Block`
+#### `Block`
 
-The block containing the transaction that emitted this event log.
+The block containing the transaction that emitted this log.
 
 ```ts
 type Block = {
@@ -125,9 +122,9 @@ type Block = {
 };
 ```
 
-### `Transaction`
+#### `Transaction`
 
-The transaction that emitted this event log.
+The transaction that emitted this log.
 
 ```ts
 type Transaction = {
@@ -162,7 +159,7 @@ type Transaction = {
 };
 ```
 
-## `context`
+### `Context`
 
 This object contains a CRUD interface for the entities defined in `schema.graphql`, and a read-only contract object for each contract specified in `ponder.config.ts`.
 
@@ -175,13 +172,13 @@ type Context = {
 };
 ```
 
-### `Entity`
+#### `Entity`
 
 These objects are used to create, read, update, and delete entity instances. `context.entities` contains an `Entity` object for each entity type defined in `schema.graphql`.
 
 See [Create & update entities](/guides/create-update-entities) for a complete API reference.
 
-### `ReadOnlyContract`
+#### `ReadOnlyContract`
 
 <Callout type="warning">
   **Avoid using contract calls.** Reading data directly from contracts is slow
@@ -192,3 +189,23 @@ See [Create & update entities](/guides/create-update-entities) for a complete AP
 `ReadOnlyContract` objects are used to read data directly from a contract. These objects have a method for each read-only function present in the contract's ABI (functions with state mutability of `"pure"` or `"view"`). `context.contracts` contains a `ReadOnlyContract` object for each contract defined in [ponder.config.ts](/api-reference/ponder-config#contracts).
 
 By default, contract calls use the `eth_call` RPC method with `blockTag` set to the block timestamp of the event being handled (aka `event.block.timestamp`). Sometimes, you may need to read the contract at a different block height, such as the contract deployment block number or `"latest"`.
+
+## The `"setup"` event
+
+You can also define a handler for a special event called `"setup"` that runs before all other event handlers.
+
+```ts filename="src/index.ts"
+import { ponder } from "@/generated";
+
+ponder.on("setup", async ({ context }) => {
+  const { entities, contracts } = context;
+
+  // ...
+});
+```
+
+### Options
+
+| name                                               | description                                                   |
+| :------------------------------------------------- | :------------------------------------------------------------ |
+| [`context`](/api-reference/event-handlers#context) | Global resources (entity objects, read-only contract objects) |

--- a/docs/pages/api-reference/ponder-config.mdx
+++ b/docs/pages/api-reference/ponder-config.mdx
@@ -61,9 +61,9 @@ See [Deploy to production](/guides/production) for more details.
 
 ### Options
 
-| field                      |   type   |                                                                                        |
-| :------------------------- | :------: | :------------------------------------------------------------------------------------- |
-| **maxHealthcheckDuration** | `number` | **Default: `4 * 60`**. Maximum number of seconds to wait before responding as healthy. |
+| field                      |   type   |                                                                                                                                                                                                                                  |
+| :------------------------- | :------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **maxHealthcheckDuration** | `number` | **Default: `4 * 60`**. Maximum number of seconds to wait for event processing to be complete before responding as healthy. If event processing takes longer than this amount of time, the GraphQL API may serve incomplete data. |
 
 ## Examples
 

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -337,7 +337,7 @@ export class Ponder {
       this.uiService.ui.handlersCurrent += 1;
     });
     this.eventHandlerService.on("taskCompleted", ({ timestamp }) => {
-      this.uiService.ui.handlersToTimestamp = timestamp;
+      if (timestamp) this.uiService.ui.handlersToTimestamp = timestamp;
       this.uiService.render();
     });
 

--- a/packages/core/src/codegen/buildEventTypes.ts
+++ b/packages/core/src/codegen/buildEventTypes.ts
@@ -3,22 +3,21 @@ import { AbiEvent } from "abitype";
 import type { Contract } from "@/config/contracts";
 
 export const buildEventTypes = (contracts: Contract[]) => {
-  const allHandlers = contracts
-    .map((contract) => {
-      const abiEvents = contract.abi.filter(
-        (item): item is AbiEvent => item.type === "event"
-      );
+  const allHandlers = contracts.map((contract) => {
+    const abiEvents = contract.abi.filter(
+      (item): item is AbiEvent => item.type === "event"
+    );
 
-      return abiEvents
-        .map(({ name, inputs }) => {
-          const paramsType = `{${inputs
-            .map(
-              (input) => `${input.name}:
+    return abiEvents
+      .map(({ name, inputs }) => {
+        const paramsType = `{${inputs
+          .map(
+            (input) => `${input.name}:
                 AbiParameterToPrimitiveType<${JSON.stringify(input)}>`
-            )
-            .join(";")}}`;
+          )
+          .join(";")}}`;
 
-          return `["${contract.name}:${name}"]: ({
+        return `["${contract.name}:${name}"]: ({
             event, context
             }: {
               event: {
@@ -30,14 +29,17 @@ export const buildEventTypes = (contracts: Contract[]) => {
               };
               context: Context;
             }) => Promise<any> | any;`;
-        })
-        .join("");
-    })
-    .join("");
+      })
+      .join("");
+  });
+
+  allHandlers.unshift(
+    `["setup"]: ({ context }: { context: Context; }) => Promise<any> | any;`
+  );
 
   const final = `
     export type AppType = {
-      ${allHandlers}
+      ${allHandlers.join("")}
     }
   `;
 

--- a/packages/core/src/errors/eventHandler.ts
+++ b/packages/core/src/errors/eventHandler.ts
@@ -13,20 +13,21 @@ export class EventHandlerError extends BaseError {
     cause,
   }: {
     eventName: string;
-    blockNumber: bigint;
-    params: any;
+    blockNumber?: bigint;
+    params?: any;
     stackTrace?: string;
     codeFrame?: string;
     cause?: Error;
   }) {
-    const shortMessage = `Error while handling \`${eventName}\` event at block ${blockNumber}`;
+    const shortMessage =
+      `Error while handling \`${eventName}\` event` +
+      (blockNumber ? ` at block ${blockNumber}` : "");
 
     const metaMessages = [];
 
     if (stackTrace) metaMessages.push(`Trace:\n${stackTrace}`);
     if (codeFrame) metaMessages.push(codeFrame);
-
-    metaMessages.push(`Event params:\n${prettyPrint(params)}`);
+    if (params) metaMessages.push(`Event params:\n${prettyPrint(params)}`);
 
     super(shortMessage, {
       metaMessages,

--- a/packages/core/src/handlers/getStackTrace.ts
+++ b/packages/core/src/handlers/getStackTrace.ts
@@ -14,14 +14,14 @@ import { parse as parseStackTrace, StackFrame } from "stacktrace-parser";
 import { PonderOptions } from "@/config/options";
 
 export const getStackTraceAndCodeFrame = (
-  stack: string | undefined,
+  error: Error,
   options: PonderOptions
 ) => {
-  if (!stack) return null;
+  if (!error.stack) return { stackTrace: undefined, codeFrame: undefined };
 
   const buildDir = path.join(options.ponderDir, "out");
 
-  const stackTrace = parseStackTrace(stack);
+  const stackTrace = parseStackTrace(error.stack);
 
   let codeFrame: string | undefined;
 
@@ -75,7 +75,7 @@ export const getStackTraceAndCodeFrame = (
     .filter((f): f is StackFrame => !!f);
 
   if (sourceMappedStackTrace.length === 0 || !codeFrame) {
-    return null;
+    return { stackTrace: undefined, codeFrame: undefined };
   }
 
   const formattedStackTrace = sourceMappedStackTrace

--- a/packages/core/test/Ponder/art-gobblers.test.ts
+++ b/packages/core/test/Ponder/art-gobblers.test.ts
@@ -75,6 +75,13 @@ describe("art-gobblers", () => {
   });
 
   describe("event processing", () => {
+    test("inserts data into the entity store from setup event", async () => {
+      const setupEntities = await ponder.resources.entityStore.getEntities({
+        entityName: "SetupEntity",
+      });
+      expect(setupEntities.length).toBe(1);
+    });
+
     test("inserts data into the entity store", async () => {
       const accounts = await ponder.resources.entityStore.getEntities({
         entityName: "Account",

--- a/packages/core/test/Ponder/art-gobblers/schema.graphql
+++ b/packages/core/test/Ponder/art-gobblers/schema.graphql
@@ -8,3 +8,7 @@ type Token @entity {
   claimedBy: Account
   owner: Account!
 }
+
+type SetupEntity @entity {
+  id: String!
+}

--- a/packages/core/test/Ponder/art-gobblers/src/index.ts
+++ b/packages/core/test/Ponder/art-gobblers/src/index.ts
@@ -1,5 +1,15 @@
 import { ponder } from "@/generated";
 
+ponder.on("setup", async ({ context }) => {
+  const { SetupEntity } = context.entities;
+
+  await SetupEntity.upsert({
+    id: "setup_id",
+    create: {},
+    update: {},
+  });
+});
+
 ponder.on("ArtGobblers:Transfer", async ({ event, context }) => {
   const { Account, Token } = context.entities;
 


### PR DESCRIPTION
This PR adds support for a `"setup"` event which gets processed before all log events. This event handler can be used to setup data in the entity store. It can read from contracts, fetch data from a remote source, or insert static data.

```ts
import { ponder } from "@/generated";

ponder.on("setup", async ({ context }) => {
  const { MyEntity } = context.entities;
  const { MyContract } = context.contracts

  const remoteData = await fetch("https://...");
  const contractData = await MyContract.method() 

  await MyEntity.create({
    id: setupData.id,
    data: { ...setupData, ...contractData }
  });
});
```

Fixes #150, fixes #87 