### PR TITLE
Support EIP-1967 proxies in `create-ponder`

### DIFF
--- a/.changeset/neat-shirts-pay.md
+++ b/.changeset/neat-shirts-pay.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Added support for EIP-1967 proxies (Transparent and UUPS) when using the Etherscan template

--- a/.changeset/smart-masks-argue.md
+++ b/.changeset/smart-masks-argue.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added support for multiple ABIs in `ponder.config.ts` contracts/log filters. This can be used to combine the proxy and implementation ABIs for proxy contracts. Ponder will internally merge the provided ABIs and de-duplicate any ABI items.

--- a/examples/art-gobblers/ponder.config.ts
+++ b/examples/art-gobblers/ponder.config.ts
@@ -1,5 +1,7 @@
 import type { PonderConfig } from "@ponder/core";
 
+import ArtGobblersAbi from "./abis/ArtGobblers.json";
+
 export const config: PonderConfig = {
   networks: [
     {
@@ -12,7 +14,7 @@ export const config: PonderConfig = {
     {
       name: "ArtGobblers",
       network: "mainnet",
-      abi: "./abis/ArtGobblers.json",
+      abi: ArtGobblersAbi,
       address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
       startBlock: 15863321,
     },

--- a/examples/art-gobblers/tsconfig.json
+++ b/examples/art-gobblers/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "strict": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "rootDir": ".",
     "paths": {
       "@/generated": ["./generated/index.ts"]

--- a/examples/ethfs/ponder.config.ts
+++ b/examples/ethfs/ponder.config.ts
@@ -1,5 +1,8 @@
 import type { PonderConfig } from "@ponder/core";
 
+import FileStoreAbi from "./abis/FileStore.json";
+import FileStoreFrontendAbi from "./abis/FileStoreFrontend.json";
+
 export const config: PonderConfig = {
   networks: [
     {
@@ -12,7 +15,7 @@ export const config: PonderConfig = {
     {
       name: "FileStore",
       network: "mainnet",
-      abi: "./abis/FileStore.json",
+      abi: FileStoreAbi,
       address: "0x9746fD0A77829E12F8A9DBe70D7a322412325B91",
       startBlock: 15963553,
       endBlock: 16000000,
@@ -21,7 +24,7 @@ export const config: PonderConfig = {
       name: "FileStoreFrontend",
       network: "mainnet",
       address: "0xBc66C61BCF49Cc3fe4E321aeCEa307F61EC57C0b",
-      abi: "./abis/FileStoreFrontend.json",
+      abi: FileStoreFrontendAbi,
       isLogEventSource: false,
     },
   ],

--- a/examples/ethfs/tsconfig.json
+++ b/examples/ethfs/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "strict": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "rootDir": ".",
     "paths": {
       "@/generated": ["./generated/index.ts"]

--- a/packages/core/src/config/abi.test.ts
+++ b/packages/core/src/config/abi.test.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { buildAbi } from "./abi";
+
+const abiSimple = [
+  {
+    inputs: [],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: false,
+        type: "uint256",
+      },
+    ],
+    name: "Transfer",
+    type: "event",
+  },
+  {
+    inputs: [
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: false,
+        type: "uint256",
+      },
+    ],
+    name: "Approve",
+    type: "event",
+  },
+];
+
+const abiDuplicateEvent = [
+  {
+    inputs: [],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: true,
+        type: "address",
+      },
+      {
+        indexed: false,
+        type: "uint256",
+      },
+    ],
+    name: "Approve",
+    type: "event",
+  },
+];
+
+describe("buildAbi", () => {
+  const tmpDir = path.join(tmpdir(), randomUUID());
+  const configFilePath = path.join(tmpDir, "ponder.config.ts");
+
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("singular abi", () => {
+    test("file path", () => {
+      const abiSimplePath = path.join(tmpDir, "abiSimple.json");
+      writeFileSync(abiSimplePath, JSON.stringify(abiSimple));
+
+      const { abi, filePaths } = buildAbi({
+        abiConfig: "./abiSimple.json",
+        configFilePath,
+      });
+
+      expect(abi).toMatchObject(abiSimple);
+      expect(filePaths).toMatchObject([abiSimplePath]);
+    });
+
+    test("object", () => {
+      const { abi, filePaths } = buildAbi({
+        abiConfig: abiSimple,
+        configFilePath,
+      });
+
+      expect(abi).toMatchObject(abiSimple);
+      expect(filePaths).toMatchObject([]);
+    });
+  });
+
+  describe("array of abis", () => {
+    test("single file path", () => {
+      const abiSimplePath = path.join(tmpDir, "abiSimple.json");
+      writeFileSync(abiSimplePath, JSON.stringify(abiSimple));
+
+      const { abi, filePaths } = buildAbi({
+        abiConfig: ["./abiSimple.json"],
+        configFilePath,
+      });
+
+      expect(abi).toMatchObject(
+        abiSimple.filter((x) => x.type !== "constructor")
+      );
+      expect(filePaths).toMatchObject([abiSimplePath]);
+    });
+
+    test("multiple file paths", () => {
+      const abiSimplePath = path.join(tmpDir, "abiSimple.json");
+      writeFileSync(abiSimplePath, JSON.stringify(abiSimple));
+      const abiDuplicateEventPath = path.join(tmpDir, "abiDuplicateEvent.json");
+      writeFileSync(abiDuplicateEventPath, JSON.stringify(abiDuplicateEvent));
+
+      const { abi, filePaths } = buildAbi({
+        abiConfig: ["./abiSimple.json", "./abiDuplicateEvent.json"],
+        configFilePath,
+      });
+
+      expect(abi.filter((x) => x.type === "event")).toMatchObject(
+        abiSimple.filter((x) => x.type === "event")
+      );
+      expect(filePaths).toMatchObject([abiSimplePath, abiDuplicateEventPath]);
+    });
+
+    test("one file path and one object, removes duplicate abi items", () => {
+      const abiSimplePath = path.join(tmpDir, "abiSimple.json");
+      writeFileSync(abiSimplePath, JSON.stringify(abiSimple));
+
+      const { abi, filePaths } = buildAbi({
+        abiConfig: ["./abiSimple.json", abiDuplicateEvent],
+        configFilePath,
+      });
+
+      expect(abi.filter((x) => x.type === "event")).toMatchObject(
+        abiSimple.filter((x) => x.type === "event")
+      );
+      expect(filePaths).toMatchObject([abiSimplePath]);
+    });
+  });
+});

--- a/packages/core/src/config/contracts.ts
+++ b/packages/core/src/config/contracts.ts
@@ -23,7 +23,10 @@ export function buildContracts({
   return (config.contracts ?? []).map((contract) => {
     const address = contract.address.toLowerCase() as Address;
 
-    const { abi } = buildAbi({ abiConfig: contract.abi, options });
+    const { abi } = buildAbi({
+      abiConfig: contract.abi,
+      configFilePath: options.configFile,
+    });
 
     // Get the contract network/provider.
     const rawNetwork = config.networks.find((n) => n.name === contract.network);

--- a/packages/core/src/config/logFilters.ts
+++ b/packages/core/src/config/logFilters.ts
@@ -34,7 +34,10 @@ export function buildLogFilters({
   const contractLogFilters = (config.contracts ?? [])
     .filter((contract) => contract.isLogEventSource ?? true)
     .map((contract) => {
-      const { abi } = buildAbi({ abiConfig: contract.abi, options });
+      const { abi } = buildAbi({
+        abiConfig: contract.abi,
+        configFilePath: options.configFile,
+      });
 
       // Get the contract network/provider.
       const rawNetwork = config.networks.find(
@@ -81,7 +84,10 @@ export function buildLogFilters({
     });
 
   const filterLogFilters = (config.filters ?? []).map((filter) => {
-    const { abi } = buildAbi({ abiConfig: filter.abi, options });
+    const { abi } = buildAbi({
+      abiConfig: filter.abi,
+      configFilePath: options.configFile,
+    });
 
     // Get the contract network/provider.
     const rawNetwork = config.networks.find((n) => n.name === filter.network);

--- a/packages/core/src/config/ponderConfig.ts
+++ b/packages/core/src/config/ponderConfig.ts
@@ -36,7 +36,7 @@ export type ResolvedPonderConfig = {
     /** Network that this contract is deployed to. Must match a network name in `networks`. */
     network: string; // TODO: narrow this type to TNetworks[number]['name']
     /** Contract ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
-    abi: string | any[] | (string | any[])[];
+    abi: string | any[] | readonly any[] | (string | any[] | readonly any[])[];
     /** Contract address. */
     address: `0x${string}`;
     /** Block number at which to start processing events (inclusive). Default: `0`. */
@@ -55,7 +55,7 @@ export type ResolvedPonderConfig = {
     /** Network that this filter is deployed to. Must match a network name in `networks`. */
     network: string; // TODO: narrow this type to TNetworks[number]['name']
     /** Log filter ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
-    abi: string | any[] | (string | any[])[];
+    abi: string | any[] | readonly any[] | (string | any[] | readonly any[])[];
     /** Log filter options. */
     filter: {
       /** Contract addresses to include. If `undefined`, no filter will be applied. Default: `undefined`. */

--- a/packages/core/src/config/ponderConfig.ts
+++ b/packages/core/src/config/ponderConfig.ts
@@ -35,8 +35,8 @@ export type ResolvedPonderConfig = {
     name: string;
     /** Network that this contract is deployed to. Must match a network name in `networks`. */
     network: string; // TODO: narrow this type to TNetworks[number]['name']
-    /** Contract ABI. Can be a path to file (relative or absolute), or the ABI itself as an object. */
-    abi: string | any[] | object;
+    /** Contract ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
+    abi: string | any[] | (string | any[])[];
     /** Contract address. */
     address: `0x${string}`;
     /** Block number at which to start processing events (inclusive). Default: `0`. */
@@ -54,8 +54,8 @@ export type ResolvedPonderConfig = {
     name: string;
     /** Network that this filter is deployed to. Must match a network name in `networks`. */
     network: string; // TODO: narrow this type to TNetworks[number]['name']
-    /** Log filter ABI. Can be a path to file (relative or absolute), or the ABI itself as an object. */
-    abi: string | any[] | object;
+    /** Log filter ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
+    abi: string | any[] | (string | any[])[];
     /** Log filter options. */
     filter: {
       /** Contract addresses to include. If `undefined`, no filter will be applied. Default: `undefined`. */

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -175,6 +175,7 @@ export const run = async (
         "target": "ESNext",
         "module": "ESNext",
         "moduleResolution": "node",
+        "resolveJsonModule": true,
         "esModuleInterop": true,
         "strict": true,
         "rootDir": ".",

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -86,10 +86,19 @@ export const run = async (
 
   // Write the handler ts files.
   ponderConfig.contracts.forEach((contract) => {
-    const abiString = readFileSync(path.join(rootDir, contract.abi), {
-      encoding: "utf-8",
-    });
-    const abi: Abi = JSON.parse(abiString);
+    let abi: Abi;
+    if (Array.isArray(contract.abi)) {
+      // If it's an array of ABIs, use the 2nd one (the implementation ABI).
+      const abiString = readFileSync(path.join(rootDir, contract.abi[1]), {
+        encoding: "utf-8",
+      });
+      abi = JSON.parse(abiString);
+    } else {
+      const abiString = readFileSync(path.join(rootDir, contract.abi), {
+        encoding: "utf-8",
+      });
+      abi = JSON.parse(abiString);
+    }
 
     const abiEvents = abi.filter(
       (item): item is AbiEvent => item.type === "event"

--- a/packages/create-ponder/test/main.test.ts
+++ b/packages/create-ponder/test/main.test.ts
@@ -124,7 +124,7 @@ describe("create-ponder", () => {
       });
     });
 
-    describe.only("mainnet EIP-1967 proxy", () => {
+    describe("mainnet EIP-1967 proxy", () => {
       const rootDir = path.join(tmpDir, randomUUID());
 
       beforeAll(async () => {


### PR DESCRIPTION
This PR adds support for EIP-1967 proxies in `create-ponder` when using the Etherscan template option. It checks if the specified contract address is a proxy, and if it is, fetches all historical implementation contract ABIs.