### PR TITLE
fix: anonymous event parameter codegen

### DIFF
--- a/.changeset/light-penguins-thank.md
+++ b/.changeset/light-penguins-thank.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where codegen broke if an ABI included an event with an anonymous input.

--- a/packages/core/src/codegen/buildEventTypes.ts
+++ b/packages/core/src/codegen/buildEventTypes.ts
@@ -11,10 +11,11 @@ export const buildEventTypes = (logFilters: LogFilter[]) => {
     return abiEvents
       .map(({ name, inputs }) => {
         const paramsType = `{${inputs
-          .map(
-            (input) => `${input.name}:
-                AbiParameterToPrimitiveType<${JSON.stringify(input)}>`
-          )
+          .map((input, index) => {
+            const inputName = input.name ? input.name : `param_${index}`;
+            return `${inputName}:
+              AbiParameterToPrimitiveType<${JSON.stringify(input)}>`;
+          })
           .join(";")}}`;
 
         return `["${logFilter.name}:${name}"]: ({


### PR DESCRIPTION
Fixes #178 by setting the name of anonymous event params to `param_${index}`.