### PR TITLE
fix: added missing Float scalar in the codegen

### DIFF
--- a/.changeset/modern-nails-travel.md
+++ b/.changeset/modern-nails-travel.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fixed a bug where codegen would fail for schemas that include a field typed as `Float`.

--- a/packages/core/src/codegen/buildEntityTypes.ts
+++ b/packages/core/src/codegen/buildEntityTypes.ts
@@ -7,6 +7,7 @@ const gqlScalarToTsType: Record<string, string | undefined> = {
   String: "string",
   Boolean: "boolean",
   Int: "number",
+  Float: "number",
   BigInt: "bigint",
   Bytes: "string",
 };

--- a/packages/core/test/codegen/main.test.ts
+++ b/packages/core/test/codegen/main.test.ts
@@ -1,0 +1,32 @@
+import { buildSchema as buildGraphqlSchema } from "graphql";
+import { describe, expect, test } from "vitest";
+
+import { buildEntityTypes } from "@/codegen/buildEntityTypes";
+import { schemaHeader } from "@/reload/readGraphqlSchema";
+import { buildSchema } from "@/schema/buildSchema";
+
+describe("entity types builder", () => {
+  test("entity generated successfully", () => {
+    const graphqlSchema = buildGraphqlSchema(`
+      ${schemaHeader}
+
+      type Entity @entity {
+        id: String!
+        int: Int
+        float: Float
+        bool: Boolean
+        bytes: Bytes
+        bigInt: BigInt
+        nonNullInt: Int!
+        nonNullFloat: Float!
+        nonNullBool: Boolean!
+        nonNullBytes: Bytes!
+        nonNullBigInt: BigInt!
+      }
+    `);
+
+    const schema = buildSchema(graphqlSchema);
+    const output = buildEntityTypes(schema.entities);
+    expect(output).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Currently, when we define schema field with `Float` of `Float!` it will raise an error like the following:

```
 FAIL  test/codegen/main.test.ts > entity types builder > normal entity
Error: TypeScript type not found for scalar: Float
 ❯ src/codegen/buildEntityTypes.ts:27:25
     25|                 const scalarTsType = gqlScalarToTsType[field.scalarTypeName];
     26|                 if (!scalarTsType) {
     27|                   throw new Error(
       |                         ^
     28|                     `TypeScript type not found for scalar: ${field.scalarTypeName}`
     29|                   );
 ❯ src/codegen/buildEntityTypes.ts:22:12
 ❯ Module.buildEntityTypes src/codegen/buildEntityTypes.ts:19:6
 ❯ test/codegen/main.test.ts:26:20
```

this pull request added the missing `Float` field in the `buildEntityTypes` and added some new test case. Let me know if the test is unnecessary, I will remove it. 

Thanks 🙏 