### PR TITLE
fix: event handling issue with timestamp

### DIFF
--- a/.changeset/poor-radios-own.md
+++ b/.changeset/poor-radios-own.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixes a bug where event handler was always using the minimum value for toTimestamp from all block timestamps, resulting in new events not being added for event handling.

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -207,7 +207,6 @@ export class Ponder {
       await this.eventHandlerService.processEvents();
     });
     this.backfillService.on("backfillStarted", async () => {
-      this.frontfillService.backfillCutoffTimestamp;
       this.eventHandlerService.isBackfillStarted = true;
       await this.eventHandlerService.processEvents();
     });

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -202,14 +202,18 @@ export class Ponder {
     });
 
     this.frontfillService.on("frontfillStarted", async () => {
+      this.eventHandlerService.backfillCutoffTimestamp =
+        this.frontfillService.backfillCutoffTimestamp;
       await this.eventHandlerService.processEvents();
     });
     this.backfillService.on("backfillStarted", async () => {
+      this.frontfillService.backfillCutoffTimestamp;
       this.eventHandlerService.isBackfillStarted = true;
       await this.eventHandlerService.processEvents();
     });
 
     this.frontfillService.on("eventsAdded", async () => {
+      console.log("Events added so processing them now");
       await this.eventHandlerService.processEvents();
     });
     this.backfillService.on("eventsAdded", async () => {

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -212,7 +212,6 @@ export class Ponder {
     });
 
     this.frontfillService.on("eventsAdded", async () => {
-      console.log("Events added so processing them now");
       await this.eventHandlerService.processEvents();
     });
     this.backfillService.on("eventsAdded", async () => {


### PR DESCRIPTION
This PR Fixes event handling timestamp ranges. Before we were always grabbing the lowest block timestamp for event handling even when there were other blocks with higher timestamp available to process events from. (mostly in case of multiple chains running on the same app).

With this fix: If the minimum cached to timestamp >= backfillCutoffTimestamp, then we set the new toTimestamp to the max value that exists in the DB and continue with fetching events.