### PR TITLE
Versioned user store

### DIFF
--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -183,7 +183,7 @@ export class PostgresUserStore implements UserStore {
 
   findUnique = async ({
     modelName,
-    timestamp,
+    timestamp = MAX_INTEGER,
     id,
   }: {
     modelName: string;
@@ -192,14 +192,13 @@ export class PostgresUserStore implements UserStore {
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
-    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
 
     const instances = await this.db
       .selectFrom(tableName)
       .selectAll()
       .where("id", "=", formattedId)
-      .where("effectiveFrom", "<=", effectiveTimestamp)
-      .where("effectiveTo", ">=", effectiveTimestamp)
+      .where("effectiveFrom", "<=", timestamp)
+      .where("effectiveTo", ">=", timestamp)
       .execute();
 
     if (instances.length > 1) {
@@ -423,7 +422,7 @@ export class PostgresUserStore implements UserStore {
 
   findMany = async ({
     modelName,
-    timestamp,
+    timestamp = MAX_INTEGER,
     filter = {},
   }: {
     modelName: string;
@@ -431,13 +430,12 @@ export class PostgresUserStore implements UserStore {
     filter?: ModelFilter;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
-    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
 
     let query = this.db
       .selectFrom(tableName)
       .selectAll()
-      .where("effectiveFrom", "<=", effectiveTimestamp)
-      .where("effectiveTo", ">=", effectiveTimestamp);
+      .where("effectiveFrom", "<=", timestamp)
+      .where("effectiveTo", ">=", timestamp);
 
     const { where, first, skip, orderBy, orderDirection } = filter;
 

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -22,6 +22,8 @@ const gqlScalarToSqlType = {
   Float: "text",
 } as const;
 
+const MAX_INTEGER = 2_147_483_647 as const;
+
 export class SqliteUserStore implements UserStore {
   db: Kysely<any>;
 
@@ -72,7 +74,6 @@ export class SqliteUserStore implements UserStore {
                   gqlScalarToSqlType[field.scalarTypeName],
                   (col) => {
                     if (field.notNull) col = col.notNull();
-                    if (field.name === "id") col = col.primaryKey();
                     return col;
                   }
                 );
@@ -119,6 +120,24 @@ export class SqliteUserStore implements UserStore {
             }
           });
 
+          // Add the effective timestamp columns.
+          tableBuilder = tableBuilder.addColumn(
+            "effectiveFrom",
+            "integer",
+            (col) => col.notNull()
+          );
+          tableBuilder = tableBuilder.addColumn(
+            "effectiveTo",
+            "integer",
+            (col) => col.notNull()
+          );
+          tableBuilder = tableBuilder.addPrimaryKeyConstraint(
+            `${tableName}_id_effectiveTo_unique`,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            ["id", "effectiveTo"]
+          );
+
           await tableBuilder.execute();
         })
       );
@@ -144,36 +163,55 @@ export class SqliteUserStore implements UserStore {
 
   findUnique = async ({
     modelName,
+    timestamp,
     id,
   }: {
     modelName: string;
+    timestamp?: number;
     id: string | number | bigint;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
-    const instance = await this.db
+    const formattedId = formatModelFieldValue({ value: id });
+    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
+
+    const instances = await this.db
       .selectFrom(tableName)
       .selectAll()
-      .where("id", "=", formatModelFieldValue({ value: id }))
-      .executeTakeFirst();
+      .where("id", "=", formattedId)
+      .where("effectiveFrom", "<=", effectiveTimestamp)
+      .where("effectiveTo", ">=", effectiveTimestamp)
+      .execute();
 
-    return instance ? this.deserializeInstance({ modelName, instance }) : null;
+    if (instances.length > 1) {
+      throw new Error(`Expected 1 instance, found ${instances.length}`);
+    }
+
+    return instances[0]
+      ? this.deserializeInstance({ modelName, instance: instances[0] })
+      : null;
   };
 
   create = async ({
     modelName,
+    timestamp,
     id,
     data = {},
   }: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     data?: Omit<ModelInstance, "id">;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
-    const formattedInstance = formatModelInstance({ id, data });
+    const createInstance = formatModelInstance({ id, data });
 
     const instance = await this.db
       .insertInto(tableName)
-      .values(formattedInstance)
+      .values({
+        ...createInstance,
+        effectiveFrom: timestamp,
+        effectiveTo: MAX_INTEGER,
+      })
       .returningAll()
       .executeTakeFirstOrThrow();
 
@@ -182,80 +220,204 @@ export class SqliteUserStore implements UserStore {
 
   update = async ({
     modelName,
+    timestamp,
     id,
     data = {},
   }: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     data?: Partial<Omit<ModelInstance, "id">>;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
-    const formattedInstance = formatModelInstance({ id, data });
+    const formattedId = formatModelFieldValue({ value: id });
+    const updateInstance = formatModelInstance({ id, data });
 
-    const instance = await this.db
-      .updateTable(tableName)
-      .set(formattedInstance)
-      .where("id", "=", formattedInstance.id)
-      .returningAll()
-      .executeTakeFirstOrThrow();
+    const instance = await this.db.transaction().execute(async (tx) => {
+      // Find the latest version of this instance.
+      const latestInstance = await tx
+        .selectFrom(tableName)
+        .selectAll()
+        .where("id", "=", formattedId)
+        .orderBy("effectiveTo", "desc")
+        .executeTakeFirstOrThrow();
+
+      // If the latest version has the same effectiveFrom timestamp as the update,
+      // this update is occurring within the same block/second. Update in place.
+      if (latestInstance.effectiveFrom === timestamp) {
+        return await tx
+          .updateTable(tableName)
+          .set(updateInstance)
+          .where("id", "=", formattedId)
+          .where("effectiveFrom", "=", timestamp)
+          .returningAll()
+          .executeTakeFirstOrThrow();
+      }
+
+      if (latestInstance.effectiveFrom > timestamp) {
+        throw new Error(`Cannot update an instance in the past`);
+      }
+
+      // If the latest version has an earlier effectiveFrom timestamp than the update,
+      // we need to update the latest version AND insert a new version.
+      await tx
+        .updateTable(tableName)
+        .set({ effectiveTo: timestamp - 1 })
+        .where("id", "=", formattedId)
+        .where("effectiveTo", "=", MAX_INTEGER)
+        .execute();
+
+      return await tx
+        .insertInto(tableName)
+        .values({
+          ...latestInstance,
+          ...updateInstance,
+          effectiveFrom: timestamp,
+          effectiveTo: MAX_INTEGER,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    });
 
     return this.deserializeInstance({ modelName, instance });
   };
 
   upsert = async ({
     modelName,
+    timestamp,
     id,
     create = {},
     update = {},
   }: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
     update?: Partial<Omit<ModelInstance, "id">>;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
+    const formattedId = formatModelFieldValue({ value: id });
     const createInstance = formatModelInstance({ id, data: create });
     const updateInstance = formatModelInstance({ id, data: update });
 
-    const instance = await this.db
-      .insertInto(tableName)
-      .values(createInstance)
-      .onConflict((oc) => oc.column("id").doUpdateSet(updateInstance))
-      .returningAll()
-      .executeTakeFirstOrThrow();
+    const instance = await this.db.transaction().execute(async (tx) => {
+      // Attempt to find the latest version of this instance.
+      const latestInstance = await tx
+        .selectFrom(tableName)
+        .selectAll()
+        .where("id", "=", formattedId)
+        .orderBy("effectiveTo", "desc")
+        .executeTakeFirst();
+
+      // If there is no latest version, insert a new version using the create data.
+      if (!latestInstance) {
+        return await tx
+          .insertInto(tableName)
+          .values({
+            ...createInstance,
+            effectiveFrom: timestamp,
+            effectiveTo: MAX_INTEGER,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+      }
+
+      // If the latest version has the same effectiveFrom timestamp as the update,
+      // this update is occurring within the same block/second. Update in place.
+      if (latestInstance.effectiveFrom === timestamp) {
+        return await tx
+          .updateTable(tableName)
+          .set(updateInstance)
+          .where("id", "=", formattedId)
+          .where("effectiveFrom", "=", timestamp)
+          .returningAll()
+          .executeTakeFirstOrThrow();
+      }
+
+      if (latestInstance.effectiveFrom > timestamp) {
+        throw new Error(`Cannot update an instance in the past`);
+      }
+
+      // If the latest version has an earlier effectiveFrom timestamp than the update,
+      // we need to update the latest version AND insert a new version.
+      await tx
+        .updateTable(tableName)
+        .set({ effectiveTo: timestamp - 1 })
+        .where("id", "=", formattedId)
+        .where("effectiveTo", "=", MAX_INTEGER)
+        .execute();
+
+      return await tx
+        .insertInto(tableName)
+        .values({
+          ...latestInstance,
+          ...updateInstance,
+          effectiveFrom: timestamp,
+          effectiveTo: MAX_INTEGER,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    });
 
     return this.deserializeInstance({ modelName, instance });
   };
 
   delete = async ({
     modelName,
+    timestamp,
     id,
   }: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
 
-    const instance = await this.db
-      .deleteFrom(tableName)
-      .where("id", "=", formattedId)
-      .returningAll()
-      .executeTakeFirst();
+    const instance = await this.db.transaction().execute(async (tx) => {
+      // Update the latest version to be effective until the delete timestamp.
+      const deletedInstance = await tx
+        .updateTable(tableName)
+        .set({ effectiveTo: timestamp })
+        .where("id", "=", formattedId)
+        .where("effectiveTo", "=", MAX_INTEGER)
+        .returning(["id", "effectiveFrom"])
+        .executeTakeFirst();
 
-    return !!instance;
+      // If, after the update, the latest version is only effective from
+      // the delete timestamp, delete the instance in place. It "never existed".
+      if (deletedInstance?.effectiveFrom === timestamp) {
+        await tx
+          .deleteFrom(tableName)
+          .where("id", "=", formattedId)
+          .where("effectiveFrom", "=", timestamp)
+          .returning(["id"])
+          .executeTakeFirst();
+      }
+
+      return !!deletedInstance;
+    });
+
+    return instance;
   };
 
   findMany = async ({
     modelName,
+    timestamp,
     filter = {},
   }: {
     modelName: string;
+    timestamp: number;
     filter?: ModelFilter;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
+    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
 
-    let query = this.db.selectFrom(tableName).selectAll();
+    let query = this.db
+      .selectFrom(tableName)
+      .selectAll()
+      .where("effectiveFrom", "<=", effectiveTimestamp)
+      .where("effectiveTo", ">=", effectiveTimestamp);
 
     const { where, first, skip, orderBy, orderDirection } = filter;
 

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -163,7 +163,7 @@ export class SqliteUserStore implements UserStore {
 
   findUnique = async ({
     modelName,
-    timestamp,
+    timestamp = MAX_INTEGER,
     id,
   }: {
     modelName: string;
@@ -172,14 +172,13 @@ export class SqliteUserStore implements UserStore {
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
-    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
 
     const instances = await this.db
       .selectFrom(tableName)
       .selectAll()
       .where("id", "=", formattedId)
-      .where("effectiveFrom", "<=", effectiveTimestamp)
-      .where("effectiveTo", ">=", effectiveTimestamp)
+      .where("effectiveFrom", "<=", timestamp)
+      .where("effectiveTo", ">=", timestamp)
       .execute();
 
     if (instances.length > 1) {
@@ -403,7 +402,7 @@ export class SqliteUserStore implements UserStore {
 
   findMany = async ({
     modelName,
-    timestamp,
+    timestamp = MAX_INTEGER,
     filter = {},
   }: {
     modelName: string;
@@ -411,13 +410,12 @@ export class SqliteUserStore implements UserStore {
     filter?: ModelFilter;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
-    const effectiveTimestamp = timestamp ?? MAX_INTEGER;
 
     let query = this.db
       .selectFrom(tableName)
       .selectAll()
-      .where("effectiveFrom", "<=", effectiveTimestamp)
-      .where("effectiveTo", ">=", effectiveTimestamp);
+      .where("effectiveFrom", "<=", timestamp)
+      .where("effectiveTo", ">=", timestamp);
 
     const { where, first, skip, orderBy, orderDirection } = filter;
 

--- a/packages/core/src/user-store/store.ts
+++ b/packages/core/src/user-store/store.ts
@@ -39,28 +39,33 @@ export interface UserStore {
 
   findUnique(options: {
     modelName: string;
+    timestamp?: number;
     id: string | number | bigint;
   }): Promise<ModelInstance | null>;
 
   findMany(options: {
     modelName: string;
+    timestamp?: number;
     filter?: ModelFilter;
   }): Promise<ModelInstance[]>;
 
   create(options: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     data?: Omit<ModelInstance, "id">;
   }): Promise<ModelInstance>;
 
   update(options: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     data: Partial<Omit<ModelInstance, "id">>;
   }): Promise<ModelInstance>;
 
   upsert(options: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
     update?: Partial<Omit<ModelInstance, "id">>;
@@ -68,6 +73,7 @@ export interface UserStore {
 
   delete(options: {
     modelName: string;
+    timestamp: number;
     id: string | number | bigint;
   }): Promise<boolean>;
 }


### PR DESCRIPTION
This PR updates the user store to persist every version of every entity that the user inserts/updates/deletes. The versions are marked by timestamp using an `effectiveFrom`/`effectiveTo` range. When querying for entities using `findUnique`/`findMany` (as is done by the GraphQL server), the latest version of each entity will be returned by default.

This unblocks two features:
1. **Time-travel queries** - Using the timestamp argument to `findUnique`/`findMany`, we can add optional arguments to the GraphQL schema that enable users to query the database at a specific timestamp (Note: this is different that Graph Protocol time-travel queries, which only support querying by block height.)
2. **Reorg handling** - In a follow-up PR, I'll add a new method to the user store that reverts the state of the database back to a specified timestamp. When handling a reorg, the event handler service will call this method, then reprocess events from the reorg timestamp to latest.

Note that this will increase the size of the database, especially for Ponder apps that update entities a lot. It will also slow down event processing slightly because the user store methods make a few additional SQL queries to maintain entity versions.