### PR TITLE
Improve getEventLogs performance

### DIFF
--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -4,6 +4,7 @@ import {
   Migrator,
   NO_MIGRATIONS,
   PostgresDialect,
+  sql,
 } from "kysely";
 import type { Pool } from "pg";
 import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
@@ -196,224 +197,6 @@ export class PostgresEventStore implements EventStore {
         .where("chainId", "=", chainId)
         .execute();
     });
-  };
-
-  getLogEvents = async ({
-    fromTimestamp,
-    toTimestamp,
-    filters,
-  }: {
-    fromTimestamp: number;
-    toTimestamp: number;
-    filters: {
-      chainId: number;
-      address?: Address | Address[];
-      topics?: (Hex | Hex[] | null)[];
-      fromBlock?: number;
-      toBlock?: number;
-    }[];
-  }) => {
-    let query = this.db
-      .selectFrom("logs")
-      .leftJoin("blocks", "blocks.hash", "logs.blockHash")
-      .leftJoin("transactions", "transactions.hash", "logs.transactionHash")
-      .select([
-        "logs.chainId as chainId",
-
-        "logs.address as log_address",
-        "logs.blockHash as log_blockHash",
-        "logs.blockNumber as log_blockNumber",
-        // "logs.chainId as log_chainId",
-        "logs.data as log_data",
-        // "logs.finalized as log_finalized",
-        "logs.id as log_id",
-        "logs.logIndex as log_logIndex",
-        "logs.topic0 as log_topic0",
-        "logs.topic1 as log_topic1",
-        "logs.topic2 as log_topic2",
-        "logs.topic3 as log_topic3",
-        "logs.transactionHash as log_transactionHash",
-        "logs.transactionIndex as log_transactionIndex",
-
-        "blocks.baseFeePerGas as block_baseFeePerGas",
-        // "blocks.chainId as block_chainId",
-        "blocks.difficulty as block_difficulty",
-        "blocks.extraData as block_extraData",
-        // "blocks.finalized as block_finalized",
-        "blocks.gasLimit as block_gasLimit",
-        "blocks.gasUsed as block_gasUsed",
-        "blocks.hash as block_hash",
-        "blocks.logsBloom as block_logsBloom",
-        "blocks.miner as block_miner",
-        "blocks.mixHash as block_mixHash",
-        "blocks.nonce as block_nonce",
-        "blocks.number as block_number",
-        "blocks.parentHash as block_parentHash",
-        "blocks.receiptsRoot as block_receiptsRoot",
-        "blocks.sha3Uncles as block_sha3Uncles",
-        "blocks.size as block_size",
-        "blocks.stateRoot as block_stateRoot",
-        "blocks.timestamp as block_timestamp",
-        "blocks.totalDifficulty as block_totalDifficulty",
-        "blocks.transactionsRoot as block_transactionsRoot",
-
-        "transactions.accessList as tx_accessList",
-        "transactions.blockHash as tx_blockHash",
-        "transactions.blockNumber as tx_blockNumber",
-        // "transactions.chainId as tx_chainId",
-        // "transactions.finalized as tx_finalized",
-        "transactions.from as tx_from",
-        "transactions.gas as tx_gas",
-        "transactions.gasPrice as tx_gasPrice",
-        "transactions.hash as tx_hash",
-        "transactions.input as tx_input",
-        "transactions.maxFeePerGas as tx_maxFeePerGas",
-        "transactions.maxPriorityFeePerGas as tx_maxPriorityFeePerGas",
-        "transactions.nonce as tx_nonce",
-        "transactions.r as tx_r",
-        "transactions.s as tx_s",
-        "transactions.to as tx_to",
-        "transactions.transactionIndex as tx_transactionIndex",
-        "transactions.type as tx_type",
-        "transactions.value as tx_value",
-        "transactions.v as tx_v",
-      ])
-      .where("blocks.timestamp", ">=", intToBlob(fromTimestamp))
-      .where("blocks.timestamp", "<=", intToBlob(toTimestamp))
-      .orderBy("blocks.timestamp", "asc")
-      .orderBy("logs.chainId", "asc")
-      .orderBy("logs.logIndex", "asc");
-
-    query = query.where(({ and, or, cmpr }) =>
-      or(
-        filters.map((filter) => {
-          const { chainId, address, topics, fromBlock, toBlock } = filter;
-
-          const conditions = [cmpr("logs.chainId", "=", chainId)];
-
-          if (address) {
-            const addressArray =
-              typeof address === "string" ? [address] : address;
-            conditions.push(cmpr("logs.address", "in", addressArray));
-          }
-
-          if (topics) {
-            topics.forEach((topic, topicIndex) => {
-              if (topic === null) return;
-              const columnName = `logs.topic${
-                topicIndex as 0 | 1 | 2 | 3
-              }` as const;
-              const topicArray = typeof topic === "string" ? [topic] : topic;
-              conditions.push(cmpr(columnName, "in", topicArray));
-            });
-          }
-
-          if (fromBlock) {
-            conditions.push(cmpr("blocks.number", ">=", intToBlob(fromBlock)));
-          }
-          if (toBlock) {
-            conditions.push(cmpr("blocks.number", "<=", intToBlob(toBlock)));
-          }
-
-          return and(conditions);
-        })
-      )
-    );
-    const results = await query.execute();
-
-    const logEvents = results.map((result_) => {
-      // Without this cast, the block_ and tx_ fields are all nullable
-      // which makes this very annoying. Should probably add a runtime check
-      // that those fields are indeed present before continuing here.
-      const result = result_ as NonNull<(typeof results)[number]>;
-
-      // Note that because we set the `number` type parser to use BigInt in the
-      // constructor, _all_ numbers returned from the database are bigints.
-      // So, we must convert the index fields back to numbers here to match the viem types.
-      const event: {
-        chainId: number;
-        log: Log;
-        block: Block;
-        transaction: Transaction;
-      } = {
-        chainId: result.chainId,
-        log: {
-          address: result.log_address,
-          blockHash: result.log_blockHash,
-          blockNumber: blobToBigInt(result.log_blockNumber),
-          data: result.log_data,
-          id: result.log_id,
-          logIndex: Number(result.log_logIndex),
-          removed: false,
-          topics: [
-            result.log_topic0,
-            result.log_topic1,
-            result.log_topic2,
-            result.log_topic3,
-          ].filter((t): t is Hex => t !== null) as [Hex, ...Hex[]] | [],
-          transactionHash: result.log_transactionHash,
-          transactionIndex: Number(result.log_transactionIndex),
-        },
-        block: {
-          baseFeePerGas: blobToBigInt(result.block_baseFeePerGas),
-          difficulty: blobToBigInt(result.block_difficulty),
-          extraData: result.block_extraData,
-          gasLimit: blobToBigInt(result.block_gasLimit),
-          gasUsed: blobToBigInt(result.block_gasUsed),
-          hash: result.block_hash,
-          logsBloom: result.block_logsBloom,
-          miner: result.block_miner,
-          mixHash: result.block_mixHash,
-          nonce: result.block_nonce,
-          number: blobToBigInt(result.block_number),
-          parentHash: result.block_parentHash,
-          receiptsRoot: result.block_receiptsRoot,
-          sha3Uncles: result.block_sha3Uncles,
-          size: blobToBigInt(result.block_size),
-          stateRoot: result.block_stateRoot,
-          timestamp: blobToBigInt(result.block_timestamp),
-          totalDifficulty: blobToBigInt(result.block_totalDifficulty),
-          transactionsRoot: result.block_transactionsRoot,
-        },
-        transaction: {
-          blockHash: result.tx_blockHash,
-          blockNumber: blobToBigInt(result.tx_blockNumber),
-          from: result.tx_from,
-          gas: blobToBigInt(result.tx_gas),
-          hash: result.tx_hash,
-          input: result.tx_input,
-          nonce: Number(result.tx_nonce),
-          r: result.tx_r,
-          s: result.tx_s,
-          to: result.tx_to,
-          transactionIndex: Number(result.tx_transactionIndex),
-          value: blobToBigInt(result.tx_value),
-          v: blobToBigInt(result.tx_v),
-          ...(result.tx_type === "legacy"
-            ? {
-                type: result.tx_type,
-                gasPrice: blobToBigInt(result.tx_gasPrice),
-              }
-            : result.tx_type === "eip1559"
-            ? {
-                type: result.tx_type,
-                maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
-                maxPriorityFeePerGas: blobToBigInt(
-                  result.tx_maxPriorityFeePerGas
-                ),
-              }
-            : {
-                type: result.tx_type,
-                gasPrice: blobToBigInt(result.tx_gasPrice),
-                accessList: JSON.parse(result.tx_accessList),
-              }),
-        },
-      };
-
-      return event;
-    });
-
-    return logEvents;
   };
 
   getLogFilterCachedRanges = async ({ filterKey }: { filterKey: string }) => {
@@ -642,4 +425,335 @@ export class PostgresEventStore implements EventStore {
         }
       : null;
   };
+
+  getLogEvents = async ({
+    fromTimestamp,
+    toTimestamp,
+    filters = [],
+  }: {
+    fromTimestamp: number;
+    toTimestamp: number;
+    filters?: {
+      name: string;
+      chainId: number;
+      address?: Address | Address[];
+      topics?: (Hex | Hex[] | null)[];
+      fromBlock?: number;
+      toBlock?: number;
+      handledTopic0?: Hex[];
+    }[];
+  }) => {
+    const handledLogQuery = this.db
+      .with(
+        "logFilters(logFilter_name, logFilter_chainId, logFilter_address, logFilter_topic0, logFilter_topic1, logFilter_topic2, logFilter_topic3, logFilter_fromBlock, logFilter_toBlock, logFilter_handledTopic0)",
+        () => sql`( values ${sql.join(filters.map(buildLogFilterValues))} )`
+      )
+      .selectFrom("logs")
+      .leftJoin("blocks", "blocks.hash", "logs.blockHash")
+      .leftJoin("transactions", "transactions.hash", "logs.transactionHash")
+      .innerJoin("logFilters", (join) => join.onTrue())
+      .select([
+        "logFilter_name",
+
+        "logs.address as log_address",
+        "logs.blockHash as log_blockHash",
+        "logs.blockNumber as log_blockNumber",
+        // "logs.chainId as log_chainId",
+        "logs.data as log_data",
+        // "logs.finalized as log_finalized",
+        "logs.id as log_id",
+        "logs.logIndex as log_logIndex",
+        "logs.topic0 as log_topic0",
+        "logs.topic1 as log_topic1",
+        "logs.topic2 as log_topic2",
+        "logs.topic3 as log_topic3",
+        "logs.transactionHash as log_transactionHash",
+        "logs.transactionIndex as log_transactionIndex",
+
+        "blocks.baseFeePerGas as block_baseFeePerGas",
+        // "blocks.chainId as block_chainId",
+        "blocks.difficulty as block_difficulty",
+        "blocks.extraData as block_extraData",
+        // "blocks.finalized as block_finalized",
+        "blocks.gasLimit as block_gasLimit",
+        "blocks.gasUsed as block_gasUsed",
+        "blocks.hash as block_hash",
+        "blocks.logsBloom as block_logsBloom",
+        "blocks.miner as block_miner",
+        "blocks.mixHash as block_mixHash",
+        "blocks.nonce as block_nonce",
+        "blocks.number as block_number",
+        "blocks.parentHash as block_parentHash",
+        "blocks.receiptsRoot as block_receiptsRoot",
+        "blocks.sha3Uncles as block_sha3Uncles",
+        "blocks.size as block_size",
+        "blocks.stateRoot as block_stateRoot",
+        "blocks.timestamp as block_timestamp",
+        "blocks.totalDifficulty as block_totalDifficulty",
+        "blocks.transactionsRoot as block_transactionsRoot",
+
+        "transactions.accessList as tx_accessList",
+        "transactions.blockHash as tx_blockHash",
+        "transactions.blockNumber as tx_blockNumber",
+        // "transactions.chainId as tx_chainId",
+        // "transactions.finalized as tx_finalized",
+        "transactions.from as tx_from",
+        "transactions.gas as tx_gas",
+        "transactions.gasPrice as tx_gasPrice",
+        "transactions.hash as tx_hash",
+        "transactions.input as tx_input",
+        "transactions.maxFeePerGas as tx_maxFeePerGas",
+        "transactions.maxPriorityFeePerGas as tx_maxPriorityFeePerGas",
+        "transactions.nonce as tx_nonce",
+        "transactions.r as tx_r",
+        "transactions.s as tx_s",
+        "transactions.to as tx_to",
+        "transactions.transactionIndex as tx_transactionIndex",
+        "transactions.type as tx_type",
+        "transactions.value as tx_value",
+        "transactions.v as tx_v",
+      ])
+      .where(({ and, or, cmpr, ref }) =>
+        and([
+          cmpr("logs.chainId", "=", ref("logFilter_chainId")),
+          or([
+            cmpr("logFilter_address", "is", null),
+            cmpr("logFilter_address", "like", sql`'%' || logs.address || '%'`),
+          ]),
+          and([
+            or([
+              cmpr("logFilter_topic0", "is", null),
+              cmpr("logFilter_topic0", "like", sql`'%' || logs.topic0 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic1", "is", null),
+              cmpr("logFilter_topic1", "like", sql`'%' || logs.topic1 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic2", "is", null),
+              cmpr("logFilter_topic2", "like", sql`'%' || logs.topic2 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic3", "is", null),
+              cmpr("logFilter_topic3", "like", sql`'%' || logs.topic3 || '%'`),
+            ]),
+          ]),
+          or([
+            cmpr("logFilter_fromBlock", "is", null),
+            cmpr("blocks.number", ">=", ref("logFilter_fromBlock")),
+          ]),
+          or([
+            cmpr("logFilter_toBlock", "is", null),
+            cmpr("blocks.number", "<=", ref("logFilter_toBlock")),
+          ]),
+          or([
+            cmpr("logFilter_handledTopic0", "is", null),
+            cmpr(
+              "logFilter_handledTopic0",
+              "like",
+              sql`'%' || logs.topic0 || '%'`
+            ),
+          ]),
+        ])
+      )
+      .where("blocks.timestamp", ">=", intToBlob(fromTimestamp))
+      .where("blocks.timestamp", "<=", intToBlob(toTimestamp))
+      .orderBy("blocks.timestamp", "asc")
+      .orderBy("logs.chainId", "asc")
+      .orderBy("logs.logIndex", "asc")
+      .orderBy("logFilter_name", "asc");
+
+    // Get total count of matching logs.
+    const totalLogCountQuery = this.db
+      .with(
+        "logFilters(logFilter_name, logFilter_chainId, logFilter_address, logFilter_topic0, logFilter_topic1, logFilter_topic2, logFilter_topic3, logFilter_fromBlock, logFilter_toBlock, logFilter_handledTopic0)",
+        () => sql`( values ${sql.join(filters.map(buildLogFilterValues))} )`
+      )
+      .selectFrom("logs")
+      .leftJoin("blocks", "blocks.hash", "logs.blockHash")
+      .innerJoin("logFilters", (join) => join.onTrue())
+      .select(this.db.fn.count("logs.id").as("log_count"))
+      .where(({ and, or, cmpr, ref }) =>
+        and([
+          cmpr("logs.chainId", "=", ref("logFilter_chainId")),
+          or([
+            cmpr("logFilter_address", "is", null),
+            cmpr("logFilter_address", "like", sql`'%' || logs.address || '%'`),
+          ]),
+          and([
+            or([
+              cmpr("logFilter_topic0", "is", null),
+              cmpr("logFilter_topic0", "like", sql`'%' || logs.topic0 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic1", "is", null),
+              cmpr("logFilter_topic1", "like", sql`'%' || logs.topic1 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic2", "is", null),
+              cmpr("logFilter_topic2", "like", sql`'%' || logs.topic2 || '%'`),
+            ]),
+            or([
+              cmpr("logFilter_topic3", "is", null),
+              cmpr("logFilter_topic3", "like", sql`'%' || logs.topic3 || '%'`),
+            ]),
+          ]),
+          or([
+            cmpr("logFilter_fromBlock", "is", null),
+            cmpr("blocks.number", ">=", ref("logFilter_fromBlock")),
+          ]),
+          or([
+            cmpr("logFilter_toBlock", "is", null),
+            cmpr("blocks.number", "<=", ref("logFilter_toBlock")),
+          ]),
+        ])
+      )
+      .where("blocks.timestamp", ">=", intToBlob(fromTimestamp))
+      .where("blocks.timestamp", "<=", intToBlob(toTimestamp));
+
+    // Get handled logs.
+    const handledLogs = await handledLogQuery.execute();
+
+    const totalLogCount = await totalLogCountQuery.execute();
+    const totalEventCount = totalLogCount[0].log_count as number;
+
+    const events = handledLogs.map((result_) => {
+      // Without this cast, the block_ and tx_ fields are all nullable
+      // which makes this very annoying. Should probably add a runtime check
+      // that those fields are indeed present before continuing here.
+      const result = result_ as NonNull<(typeof handledLogs)[number]>;
+
+      const event: {
+        filterName: string;
+        log: Log;
+        block: Block;
+        transaction: Transaction;
+      } = {
+        filterName: result.logFilter_name,
+        log: {
+          address: result.log_address,
+          blockHash: result.log_blockHash,
+          blockNumber: blobToBigInt(result.log_blockNumber),
+          data: result.log_data,
+          id: result.log_id,
+          logIndex: Number(result.log_logIndex),
+          removed: false,
+          topics: [
+            result.log_topic0,
+            result.log_topic1,
+            result.log_topic2,
+            result.log_topic3,
+          ].filter((t): t is Hex => t !== null) as [Hex, ...Hex[]] | [],
+          transactionHash: result.log_transactionHash,
+          transactionIndex: Number(result.log_transactionIndex),
+        },
+        block: {
+          baseFeePerGas: blobToBigInt(result.block_baseFeePerGas),
+          difficulty: blobToBigInt(result.block_difficulty),
+          extraData: result.block_extraData,
+          gasLimit: blobToBigInt(result.block_gasLimit),
+          gasUsed: blobToBigInt(result.block_gasUsed),
+          hash: result.block_hash,
+          logsBloom: result.block_logsBloom,
+          miner: result.block_miner,
+          mixHash: result.block_mixHash,
+          nonce: result.block_nonce,
+          number: blobToBigInt(result.block_number),
+          parentHash: result.block_parentHash,
+          receiptsRoot: result.block_receiptsRoot,
+          sha3Uncles: result.block_sha3Uncles,
+          size: blobToBigInt(result.block_size),
+          stateRoot: result.block_stateRoot,
+          timestamp: blobToBigInt(result.block_timestamp),
+          totalDifficulty: blobToBigInt(result.block_totalDifficulty),
+          transactionsRoot: result.block_transactionsRoot,
+        },
+        transaction: {
+          blockHash: result.tx_blockHash,
+          blockNumber: blobToBigInt(result.tx_blockNumber),
+          from: result.tx_from,
+          gas: blobToBigInt(result.tx_gas),
+          hash: result.tx_hash,
+          input: result.tx_input,
+          nonce: Number(result.tx_nonce),
+          r: result.tx_r,
+          s: result.tx_s,
+          to: result.tx_to,
+          transactionIndex: Number(result.tx_transactionIndex),
+          value: blobToBigInt(result.tx_value),
+          v: blobToBigInt(result.tx_v),
+          ...(result.tx_type === "legacy"
+            ? {
+                type: result.tx_type,
+                gasPrice: blobToBigInt(result.tx_gasPrice),
+              }
+            : result.tx_type === "eip1559"
+            ? {
+                type: result.tx_type,
+                maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
+                maxPriorityFeePerGas: blobToBigInt(
+                  result.tx_maxPriorityFeePerGas
+                ),
+              }
+            : {
+                type: result.tx_type,
+                gasPrice: blobToBigInt(result.tx_gasPrice),
+                accessList: JSON.parse(result.tx_accessList),
+              }),
+        },
+      };
+
+      return event;
+    });
+
+    return {
+      events,
+      totalEventCount,
+    };
+  };
+}
+
+function getLogFilterAddressOrTopic(value: Hex | Hex[] | undefined | null) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value;
+  return value.join(",");
+}
+
+function getLogFilterTopics(topics: (Hex | Hex[] | null)[] | undefined) {
+  if (!topics) return [null, null, null, null];
+  const topic0 = getLogFilterAddressOrTopic(topics[0]);
+  const topic1 = getLogFilterAddressOrTopic(topics[1]);
+  const topic2 = getLogFilterAddressOrTopic(topics[2]);
+  const topic3 = getLogFilterAddressOrTopic(topics[3]);
+  return [topic0, topic1, topic2, topic3];
+}
+
+export function buildLogFilterValues(filter: {
+  name: string;
+  chainId: number;
+  address?: Address | Address[];
+  topics?: (Hex | Hex[] | null)[];
+  fromBlock?: number;
+  toBlock?: number;
+  handledTopic0?: Hex[];
+}) {
+  const { name, chainId, address, topics, fromBlock, toBlock, handledTopic0 } =
+    filter;
+
+  const address_ = getLogFilterAddressOrTopic(address);
+  const [topic0, topic1, topic2, topic3] = getLogFilterTopics(topics);
+  const handledTopic0_ = getLogFilterAddressOrTopic(handledTopic0);
+
+  return sql`(${sql.join([
+    sql.val(name),
+    sql`${sql.val(chainId)}::integer`,
+    sql.val(address_),
+    sql.val(topic0),
+    sql.val(topic1),
+    sql.val(topic2),
+    sql.val(topic3),
+    sql`${sql.val(fromBlock ? intToBlob(fromBlock) : null)}::bytea`,
+    sql`${sql.val(toBlock ? intToBlob(toBlock) : null)}::bytea`,
+    sql.val(handledTopic0_),
+  ])})`;
 }

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -615,7 +615,7 @@ export class PostgresEventStore implements EventStore {
     const handledLogs = await handledLogQuery.execute();
 
     const totalLogCount = await totalLogCountQuery.execute();
-    const totalEventCount = totalLogCount[0].log_count as number;
+    const totalEventCount = Number(totalLogCount[0].log_count);
 
     const events = handledLogs.map((result_) => {
       // Without this cast, the block_ and tx_ fields are all nullable

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -583,7 +583,7 @@ export class SqliteEventStore implements EventStore {
     const handledLogs = await handledLogQuery.execute();
 
     const totalLogCount = await totalLogCountQuery.execute();
-    const totalEventCount = totalLogCount[0].log_count as number;
+    const totalEventCount = Number(totalLogCount[0].log_count);
 
     const events = handledLogs.map((result_) => {
       // Without this cast, the block_ and tx_ fields are all nullable

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -235,373 +235,6 @@ test("insertUnfinalizedBlock inserts logs", async (context) => {
   expect(logs).toHaveLength(2);
 });
 
-test("getLogEvents returns log events", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ chainId: 1 }],
-  });
-  expect(logEvents[0].chainId).toEqual(1);
-
-  expect(logEvents[0].log).toMatchInlineSnapshot(`
-    {
-      "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "blockNumber": 15131999n,
-      "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
-      "id": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd-0x6c",
-      "logIndex": 108,
-      "removed": false,
-      "topics": [
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-        "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
-        "0x000000000000000000000000f16e9b0d03470827a95cdfd0cb8a8a3b46969b91",
-      ],
-      "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "transactionIndex": 69,
-    }
-  `);
-
-  expect(logEvents[0].block).toMatchInlineSnapshot(`
-    {
-      "baseFeePerGas": 0n,
-      "difficulty": 12730590371363483n,
-      "extraData": "0x",
-      "gasLimit": 29999943n,
-      "gasUsed": 0n,
-      "hash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-      "miner": "0x0000000000000000000000000000000000000000",
-      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "nonce": "0x0000000000000000",
-      "number": 15495110n,
-      "parentHash": "0xe55516ad8029e53cd32087f14653d851401b05245abb1b2d6ed4ddcc597ac5a6",
-      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-      "size": 520n,
-      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "timestamp": 1662619503n,
-      "totalDifficulty": 58750003716598352816469n,
-      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-    }
-  `);
-
-  expect(logEvents[0].transaction).toMatchInlineSnapshot(`
-    {
-      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "blockNumber": 69420n,
-      "from": "0x1",
-      "gas": 69420420n,
-      "gasPrice": 69n,
-      "hash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "input": "0x1",
-      "nonce": 1,
-      "r": "0x1",
-      "s": "0x1",
-      "to": "0x1",
-      "transactionIndex": 1,
-      "type": "legacy",
-      "v": 1n,
-      "value": 1n,
-    }
-  `);
-
-  expect(logEvents[1].log).toMatchInlineSnapshot(`
-    {
-      "address": "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
-      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "blockNumber": 15131999n,
-      "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
-      "id": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd-0x6d",
-      "logIndex": 109,
-      "removed": false,
-      "topics": [],
-      "transactionHash": "0xc3f1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "transactionIndex": 70,
-    }
-  `);
-
-  expect(logEvents[1].block).toMatchInlineSnapshot(`
-    {
-      "baseFeePerGas": 0n,
-      "difficulty": 12730590371363483n,
-      "extraData": "0x",
-      "gasLimit": 29999943n,
-      "gasUsed": 0n,
-      "hash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-      "miner": "0x0000000000000000000000000000000000000000",
-      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "nonce": "0x0000000000000000",
-      "number": 15495110n,
-      "parentHash": "0xe55516ad8029e53cd32087f14653d851401b05245abb1b2d6ed4ddcc597ac5a6",
-      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-      "size": 520n,
-      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "timestamp": 1662619503n,
-      "totalDifficulty": 58750003716598352816469n,
-      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-    }
-  `);
-
-  expect(logEvents[1].transaction).toMatchInlineSnapshot(`
-    {
-      "accessList": [
-        {
-          "address": "0x1",
-          "storageKeys": [
-            "0x1",
-          ],
-        },
-      ],
-      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
-      "blockNumber": 69420n,
-      "from": "0x1",
-      "gas": 69420420n,
-      "gasPrice": 69n,
-      "hash": "0xc3f1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "input": "0x1",
-      "nonce": 1,
-      "r": "0x1",
-      "s": "0x1",
-      "to": "0x1",
-      "transactionIndex": 1,
-      "type": "eip2930",
-      "v": 1n,
-      "value": 1n,
-    }
-  `);
-});
-
-test("getLogEvents filters on log address", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ chainId: 1, address: blockOneLogs[0].address }],
-  });
-
-  expect(logEvents[0].log.address).toBe(blockOneLogs[0].address);
-  expect(logEvents).toHaveLength(1);
-});
-
-test("getLogEvents filters on multiple log addresses", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [
-      {
-        chainId: 1,
-        address: [blockOneLogs[0].address, blockOneLogs[1].address],
-      },
-    ],
-  });
-
-  expect(logEvents.map((e) => e.log.address)).toMatchObject([
-    blockOneLogs[0].address,
-    blockOneLogs[1].address,
-  ]);
-  expect(logEvents).toHaveLength(2);
-});
-
-test("getLogEvents filters on single topic", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [
-      {
-        chainId: 1,
-        topics: [blockOneLogs[0].topics[0] as `0x${string}`],
-      },
-    ],
-  });
-
-  expect(logEvents.map((e) => e.log.topics)).toMatchObject([
-    blockOneLogs[0].topics,
-    blockTwoLogs[0].topics,
-  ]);
-  expect(logEvents).toHaveLength(2);
-});
-
-test("getLogEvents filters on multiple topics", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [
-      {
-        chainId: 1,
-        topics: [
-          blockOneLogs[0].topics[0] as `0x${string}`,
-          blockOneLogs[0].topics[1] as `0x${string}`,
-        ],
-      },
-    ],
-  });
-
-  expect(logEvents[0].log.topics).toMatchObject(blockOneLogs[0].topics);
-  expect(logEvents).toHaveLength(1);
-});
-
-test("getLogEvents filters on multiple filters", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [
-      {
-        chainId: 1,
-        address: blockOneLogs[0].address,
-      },
-      {
-        chainId: 1,
-        topics: [blockTwoLogs[0].topics[0] as `0x${string}`],
-      },
-    ],
-  });
-
-  expect(logEvents[0].log.topics).toMatchObject(blockOneLogs[0].topics);
-  expect(logEvents[1].log.topics).toMatchObject(blockTwoLogs[0].topics);
-  expect(logEvents).toHaveLength(2);
-});
-
-test("getLogEvents filters on fromTimestamp (inclusive)", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: hexToNumber(blockTwo.timestamp!),
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ chainId: 1 }],
-  });
-
-  expect(logEvents[0].block.hash).toBe(blockTwo.hash);
-  expect(logEvents).toHaveLength(1);
-});
-
-test("getLogEvents filters on toTimestamp (inclusive)", async (context) => {
-  const { eventStore } = context;
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockOne,
-    transactions: blockOneTransactions,
-    logs: blockOneLogs,
-  });
-
-  await eventStore.insertUnfinalizedBlock({
-    chainId: 1,
-    block: blockTwo,
-    transactions: blockTwoTransactions,
-    logs: blockTwoLogs,
-  });
-
-  const logEvents = await eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: hexToNumber(blockOne.timestamp!),
-    filters: [{ chainId: 1 }],
-  });
-
-  expect(logEvents.map((e) => e.block.hash)).toMatchObject([
-    blockOne.hash,
-    blockOne.hash,
-  ]);
-  expect(logEvents).toHaveLength(2);
-});
-
 test("insertFinalizedLogs inserts logs as finalized", async (context) => {
   const { eventStore } = context;
 
@@ -976,4 +609,478 @@ test("getContractReadResult returns null if not found", async (context) => {
   });
 
   expect(contractReadResult).toBe(null);
+});
+
+test("getLogEvents returns log events", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter", chainId: 1 }],
+  });
+  expect(events[0].filterName).toEqual("noFilter");
+
+  expect(events[0].log).toMatchInlineSnapshot(`
+    {
+      "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "blockNumber": 15131999n,
+      "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
+      "id": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd-0x6c",
+      "logIndex": 108,
+      "removed": false,
+      "topics": [
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
+        "0x000000000000000000000000f16e9b0d03470827a95cdfd0cb8a8a3b46969b91",
+      ],
+      "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
+      "transactionIndex": 69,
+    }
+  `);
+
+  expect(events[0].block).toMatchInlineSnapshot(`
+    {
+      "baseFeePerGas": 0n,
+      "difficulty": 12730590371363483n,
+      "extraData": "0x",
+      "gasLimit": 29999943n,
+      "gasUsed": 0n,
+      "hash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "miner": "0x0000000000000000000000000000000000000000",
+      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "nonce": "0x0000000000000000",
+      "number": 15495110n,
+      "parentHash": "0xe55516ad8029e53cd32087f14653d851401b05245abb1b2d6ed4ddcc597ac5a6",
+      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+      "size": 520n,
+      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "timestamp": 1662619503n,
+      "totalDifficulty": 58750003716598352816469n,
+      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    }
+  `);
+
+  expect(events[0].transaction).toMatchInlineSnapshot(`
+    {
+      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "blockNumber": 69420n,
+      "from": "0x1",
+      "gas": 69420420n,
+      "gasPrice": 69n,
+      "hash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
+      "input": "0x1",
+      "nonce": 1,
+      "r": "0x1",
+      "s": "0x1",
+      "to": "0x1",
+      "transactionIndex": 1,
+      "type": "legacy",
+      "v": 1n,
+      "value": 1n,
+    }
+  `);
+
+  expect(events[1].log).toMatchInlineSnapshot(`
+    {
+      "address": "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "blockNumber": 15131999n,
+      "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
+      "id": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd-0x6d",
+      "logIndex": 109,
+      "removed": false,
+      "topics": [],
+      "transactionHash": "0xc3f1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
+      "transactionIndex": 70,
+    }
+  `);
+
+  expect(events[1].block).toMatchInlineSnapshot(`
+    {
+      "baseFeePerGas": 0n,
+      "difficulty": 12730590371363483n,
+      "extraData": "0x",
+      "gasLimit": 29999943n,
+      "gasUsed": 0n,
+      "hash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "miner": "0x0000000000000000000000000000000000000000",
+      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "nonce": "0x0000000000000000",
+      "number": 15495110n,
+      "parentHash": "0xe55516ad8029e53cd32087f14653d851401b05245abb1b2d6ed4ddcc597ac5a6",
+      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+      "size": 520n,
+      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "timestamp": 1662619503n,
+      "totalDifficulty": 58750003716598352816469n,
+      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    }
+  `);
+
+  expect(events[1].transaction).toMatchInlineSnapshot(`
+    {
+      "accessList": [
+        {
+          "address": "0x1",
+          "storageKeys": [
+            "0x1",
+          ],
+        },
+      ],
+      "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
+      "blockNumber": 69420n,
+      "from": "0x1",
+      "gas": 69420420n,
+      "gasPrice": 69n,
+      "hash": "0xc3f1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
+      "input": "0x1",
+      "nonce": 1,
+      "r": "0x1",
+      "s": "0x1",
+      "to": "0x1",
+      "transactionIndex": 1,
+      "type": "eip2930",
+      "v": 1n,
+      "value": 1n,
+    }
+  `);
+});
+
+test("getLogEvents filters on log address", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      { name: "singleAddress", chainId: 1, address: blockOneLogs[0].address },
+    ],
+  });
+
+  expect(events[0].log.address).toBe(blockOneLogs[0].address);
+  expect(events).toHaveLength(1);
+});
+
+test("getLogEvents filters on multiple addresses", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      {
+        name: "multipleAddress",
+        chainId: 1,
+        address: [blockOneLogs[0].address, blockOneLogs[1].address],
+      },
+    ],
+  });
+
+  expect(events[0]).toMatchObject({
+    filterName: "multipleAddress",
+    log: {
+      address: blockOneLogs[0].address,
+    },
+  });
+  expect(events[1]).toMatchObject({
+    filterName: "multipleAddress",
+    log: {
+      address: blockOneLogs[1].address,
+    },
+  });
+  expect(events).toHaveLength(2);
+});
+
+test("getLogEvents filters on single topic", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      {
+        name: "singleTopic",
+        chainId: 1,
+        topics: [blockOneLogs[0].topics[0] as `0x${string}`],
+      },
+    ],
+  });
+
+  expect(events[0]).toMatchObject({
+    filterName: "singleTopic",
+    log: {
+      topics: blockOneLogs[0].topics,
+    },
+  });
+  expect(events[1]).toMatchObject({
+    filterName: "singleTopic",
+    log: {
+      topics: blockTwoLogs[0].topics,
+    },
+  });
+  expect(events).toHaveLength(2);
+});
+
+test("getLogEvents filters on multiple topics", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      {
+        name: "multipleTopics",
+        chainId: 1,
+        topics: [
+          blockOneLogs[0].topics[0] as `0x${string}`,
+          blockOneLogs[0].topics[1] as `0x${string}`,
+        ],
+      },
+    ],
+  });
+
+  expect(events[0]).toMatchObject({
+    filterName: "multipleTopics",
+    log: {
+      topics: blockOneLogs[0].topics,
+    },
+  });
+  expect(events).toHaveLength(1);
+});
+
+test("getLogEvents filters on fromBlock", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      {
+        name: "fromBlock",
+        chainId: 1,
+        fromBlock: 15495111,
+      },
+    ],
+  });
+
+  expect(events[0]).toMatchObject({
+    filterName: "fromBlock",
+    block: {
+      number: 15495111n,
+    },
+  });
+  expect(events).toHaveLength(1);
+});
+
+test("getLogEvents filters on multiple filters", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [
+      {
+        name: "singleAddress", // This should match blockOneLogs[0]
+        chainId: 1,
+        address: blockOneLogs[0].address,
+      },
+      {
+        name: "singleTopic", // This should match blockOneLogs[0] AND blockTwoLogs[0]
+        chainId: 1,
+        topics: [blockOneLogs[0].topics[0] as `0x${string}`],
+      },
+    ],
+  });
+
+  expect(events[0]).toMatchObject({
+    filterName: "singleAddress",
+    log: {
+      address: blockOneLogs[0].address,
+    },
+  });
+  expect(events[1]).toMatchObject({
+    filterName: "singleTopic",
+    log: {
+      address: blockOneLogs[0].address,
+    },
+  });
+  expect(events[2]).toMatchObject({
+    filterName: "singleTopic",
+    log: {
+      topics: blockTwoLogs[0].topics,
+    },
+  });
+});
+
+test("getLogEvents filters on fromTimestamp (inclusive)", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: hexToNumber(blockTwo.timestamp!),
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter", chainId: 1 }],
+  });
+
+  expect(events[0].block.hash).toBe(blockTwo.hash);
+  expect(events).toHaveLength(1);
+});
+
+test("getLogEvents filters on toTimestamp (inclusive)", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: hexToNumber(blockOne.timestamp!),
+    filters: [{ name: "noFilter", chainId: 1 }],
+  });
+
+  expect(events.map((e) => e.block.hash)).toMatchObject([
+    blockOne.hash,
+    blockOne.hash,
+  ]);
+  expect(events).toHaveLength(2);
+});
+
+test("getLogEvents returns no events if handledTopic0 is an empty array", async (context) => {
+  const { eventStore } = context;
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockOne,
+    transactions: blockOneTransactions,
+    logs: blockOneLogs,
+  });
+
+  await eventStore.insertUnfinalizedBlock({
+    chainId: 1,
+    block: blockTwo,
+    transactions: blockTwoTransactions,
+    logs: blockTwoLogs,
+  });
+
+  const { events } = await eventStore.getLogEvents({
+    fromTimestamp: 0,
+    toTimestamp: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter", chainId: 1, handledTopic0: [] }],
+  });
+
+  expect(events).toHaveLength(0);
 });

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -34,19 +34,21 @@ export interface EventStore {
   migrateUp(): Promise<void>;
   migrateDown(): Promise<void>;
 
-  getLogEvents(arg: {
-    fromTimestamp: number;
-    toTimestamp: number;
-    filters: {
-      chainId: number;
-      address?: Address | Address[];
-      topics?: (Hex | Hex[] | null)[];
-      fromBlock?: number;
-      toBlock?: number;
-    }[];
-  }): Promise<
-    { chainId: number; log: Log; block: Block; transaction: Transaction }[]
-  >;
+  insertFinalizedLogs(options: {
+    chainId: number;
+    logs: RpcLog[];
+  }): Promise<void>;
+
+  insertFinalizedBlock(options: {
+    chainId: number;
+    block: RpcBlock;
+    transactions: RpcTransaction[];
+    logFilterRange: {
+      logFilterKey: string;
+      blockNumberToCacheFrom: number;
+      logFilterStartBlockNumber: number;
+    };
+  }): Promise<{ startingRangeEndTimestamp: number }>;
 
   insertUnfinalizedBlock(options: {
     chainId: number;
@@ -69,22 +71,6 @@ export interface EventStore {
     filterKey: string;
   }): Promise<LogFilterCachedRange[]>;
 
-  insertFinalizedLogs(options: {
-    chainId: number;
-    logs: RpcLog[];
-  }): Promise<void>;
-
-  insertFinalizedBlock(options: {
-    chainId: number;
-    block: RpcBlock;
-    transactions: RpcTransaction[];
-    logFilterRange: {
-      logFilterKey: string;
-      blockNumberToCacheFrom: number;
-      logFilterStartBlockNumber: number;
-    };
-  }): Promise<{ startingRangeEndTimestamp: number }>;
-
   insertContractReadResult(options: {
     address: string;
     blockNumber: bigint;
@@ -100,4 +86,26 @@ export interface EventStore {
     chainId: number;
     data: Hex;
   }): Promise<ContractReadResult | null>;
+
+  getLogEvents(arg: {
+    fromTimestamp: number;
+    toTimestamp: number;
+    filters?: {
+      name: string;
+      chainId: number;
+      address?: Address | Address[];
+      topics?: (Hex | Hex[] | null)[];
+      fromBlock?: number;
+      toBlock?: number;
+      handledTopic0?: Hex[];
+    }[];
+  }): Promise<{
+    totalEventCount: number;
+    events: {
+      filterName: string;
+      log: Log;
+      block: Block;
+      transaction: Transaction;
+    }[];
+  }>;
 }

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -85,31 +85,32 @@ test("start() adds events to event store", async (context) => {
   service.start();
   await service.onIdle();
 
-  const logEvents = await eventStore.getLogEvents({
+  const { events } = await eventStore.getLogEvents({
     fromTimestamp: 0,
     toTimestamp: Number.MAX_SAFE_INTEGER,
     filters: [
       {
+        name: "usdc",
         chainId: network.chainId,
         address: usdcContractConfig.address,
       },
     ],
   });
 
-  expect(logEvents[0].block).toMatchObject({
+  expect(events[0].block).toMatchObject({
     hash: "0x0d8710de44b1b42ef86da0e9bebeaacb6d1cb5603f8014dec82e429f0cbf2fe0",
     number: 16369950n,
     timestamp: 1673275799n,
   });
 
-  expect(logEvents[0].transaction).toMatchObject({
+  expect(events[0].transaction).toMatchObject({
     blockHash:
       "0x0d8710de44b1b42ef86da0e9bebeaacb6d1cb5603f8014dec82e429f0cbf2fe0",
     blockNumber: 16369950n,
     hash: "0xc921941ceddbd1341e3899d0b51e4cacbc9675ee07549d12d99ce7caecc6904b",
   });
 
-  expect(logEvents[0].log).toMatchObject({
+  expect(events[0].log).toMatchObject({
     address: usdcContractConfig.address,
     blockHash:
       "0x0d8710de44b1b42ef86da0e9bebeaacb6d1cb5603f8014dec82e429f0cbf2fe0",
@@ -118,7 +119,7 @@ test("start() adds events to event store", async (context) => {
       "0xc921941ceddbd1341e3899d0b51e4cacbc9675ee07549d12d99ce7caecc6904b",
   });
 
-  expect(logEvents).toHaveLength(61);
+  expect(events).toHaveLength(61);
 });
 
 test("start() inserts cached ranges", async (context) => {


### PR DESCRIPTION
This PR moves the log filter matching code into SQL such that only the logs that the user has registered a handler for will be fetched from the event store. This will reduce memory usage and improve event processing performance.