### PR TITLE
Add reorg support to user store

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -375,6 +375,20 @@ export class Ponder {
           );
         });
       });
+
+      realtimeSyncService.on("finalityCheckpoint", ({ timestamp }) => {
+        this.resources.logger.logMessage(
+          "realtime",
+          `finality checkpoint, timestamp: ${timestamp}`
+        );
+      });
+
+      realtimeSyncService.on("shallowReorg", ({ commonAncestorTimestamp }) => {
+        this.resources.logger.logMessage(
+          "realtime",
+          `reorg detected, common ancestor timestamp: ${commonAncestorTimestamp}`
+        );
+      });
     });
 
     setInterval(() => {

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -246,7 +246,7 @@ export class Ponder {
 
     await this.reloadService.kill?.();
     this.uiService.kill();
-    this.eventHandlerService.killQueue();
+    this.eventHandlerService.kill();
     await this.serverService.teardown();
     await this.userStore.teardown();
   }
@@ -262,12 +262,10 @@ export class Ponder {
 
       this.serverService.reload({ graphqlSchema });
 
-      await this.userStore.reload({ schema });
       this.eventHandlerService.reset({ schema });
     });
 
     this.reloadService.on("newHandlers", async ({ handlers }) => {
-      await this.userStore.reload();
       this.eventHandlerService.reset({ handlers });
     });
 
@@ -322,6 +320,10 @@ export class Ponder {
 
     this.eventAggregatorService.on("newCheckpoint", ({ timestamp }) => {
       this.eventHandlerService.processEvents({ toTimestamp: timestamp });
+    });
+
+    this.eventAggregatorService.on("reorg", ({ commonAncestorTimestamp }) => {
+      this.eventHandlerService.handleReorg({ commonAncestorTimestamp });
     });
 
     this.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -42,9 +42,7 @@ export function buildNetwork({
     rpcUrl: network.rpcUrl,
     pollingInterval: network.pollingInterval ?? 1_000,
     defaultMaxBlockRange: getDefaultMaxBlockRange(network),
-    // TODO: Get this from a list of known finality block counts, then
-    // fallback to a default.
-    finalityBlockCount: 10,
+    finalityBlockCount: getFinalityBlockCount(network),
   };
 
   return resolvedNetwork;
@@ -64,7 +62,7 @@ function getDefaultMaxBlockRange(network: {
 
   let maxBlockRange: number;
   switch (network.chainId) {
-    // Mainnet.
+    // Mainnet and mainnet testnets.
     case 1:
     case 3:
     case 4:
@@ -93,4 +91,45 @@ function getDefaultMaxBlockRange(network: {
   }
 
   return maxBlockRange;
+}
+
+/**
+ * Returns the number of blocks that must pass before a block is considered final.
+ * Note that a value of `0` indicates that blocks are considered final immediately.
+ *
+ * @param network The network to get the finality block count for.
+ * @returns The finality block count.
+ */
+function getFinalityBlockCount(network: { chainId: number }) {
+  let finalityBlockCount: number;
+  switch (network.chainId) {
+    // Mainnet and mainnet testnets.
+    case 1:
+    case 3:
+    case 4:
+    case 5:
+    case 42:
+    case 11155111:
+      finalityBlockCount = 32;
+      break;
+    // Optimism.
+    case 10:
+    case 420:
+      finalityBlockCount = 0;
+      break;
+    // Polygon.
+    case 137:
+    case 80001:
+      finalityBlockCount = 100;
+      break;
+    // Arbitrum.
+    case 42161:
+    case 421613:
+      finalityBlockCount = 0;
+      break;
+    default:
+      finalityBlockCount = 0;
+  }
+
+  return finalityBlockCount;
 }

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -378,7 +378,7 @@ export class SqliteUserStore implements UserStore {
       // Update the latest version to be effective until the delete timestamp.
       const deletedInstance = await tx
         .updateTable(tableName)
-        .set({ effectiveTo: timestamp })
+        .set({ effectiveTo: timestamp - 1 })
         .where("id", "=", formattedId)
         .where("effectiveTo", "=", MAX_INTEGER)
         .returning(["id", "effectiveFrom"])
@@ -453,6 +453,31 @@ export class SqliteUserStore implements UserStore {
     return instances.map((instance) =>
       this.deserializeInstance({ modelName, instance })
     );
+  };
+
+  revert = async ({ safeTimestamp }: { safeTimestamp: number }) => {
+    this.db.transaction().execute(async (tx) => {
+      await Promise.all(
+        (this.schema?.entities ?? []).map(async (entity) => {
+          const modelName = entity.name;
+          const tableName = `${modelName}_${this.versionId}`;
+
+          // Delete any versions that are newer than the safe timestamp.
+          await tx
+            .deleteFrom(tableName)
+            .where("effectiveFrom", ">", safeTimestamp)
+            .execute();
+
+          // Now, any versions that have effectiveTo greater than or equal
+          // to the safe timestamp are the new latest version.
+          await tx
+            .updateTable(tableName)
+            .where("effectiveTo", ">=", safeTimestamp)
+            .set({ effectiveTo: MAX_INTEGER })
+            .execute();
+        })
+      );
+    });
   };
 
   private deserializeInstance = ({

--- a/packages/core/src/user-store/store.ts
+++ b/packages/core/src/user-store/store.ts
@@ -37,6 +37,8 @@ export interface UserStore {
   reload(options?: { schema?: Schema }): Promise<void>;
   teardown(): Promise<void>;
 
+  revert(options: { safeTimestamp: number }): Promise<void>;
+
   findUnique(options: {
     modelName: string;
     timestamp?: number;

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -11,14 +11,6 @@ export enum LogLevel {
   Trace, // 5
 }
 
-type MessageKind =
-  | "event"
-  | "error"
-  | "warning"
-  | "historical"
-  | "realtime"
-  | "indexer";
-
 export class LoggerService {
   logLevel: number;
 
@@ -44,7 +36,10 @@ export class LoggerService {
 
   private maxWidth = 0;
   // This function is specifically for message logs.
-  logMessage(kind: MessageKind, message: string) {
+  logMessage(
+    kind: "event" | "error" | "warning" | "historical" | "realtime" | "indexer",
+    message: string
+  ) {
     this.maxWidth = Math.max(this.maxWidth, kind.length);
     const padded = kind.padEnd(this.maxWidth, " ");
 


### PR DESCRIPTION
This PR adds a `revert(timestamp: number)` method to the user store which rolls the database back to the state at the specified timestamp.

It also adds a `handleReorg` method to the user handler service which calls `revert` whenever a reorg is detected.