### PR TITLE
Monitoring

### DIFF
--- a/.changeset/small-emus-hide.md
+++ b/.changeset/small-emus-hide.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where `Keep-Alive` HTTP connections were not being terminated properly on process exit

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,25 @@
+## Miscellaneous
+
+This directory contains miscellaneous files, such as example Grafana dashboards and Prometheus configuration.
+
+_Note: The files in this directory are adapted from `reth`._
+
+### Overview
+
+- [**Prometheus**](./prometheus/prometheus.yml): An example Prometheus configuration.
+- [**Grafana**](./grafana/): Example Grafana dashboards & data sources.
+
+### Run monitoring services (Docker Compose)
+
+To start Ponder's monitoring services locally, run:
+
+```sh
+docker compose -p ponder -f ./etc/docker-monitoring.yml up
+```
+
+This will start a Prometheus instance that collects metrics from `localhost:42069/metrics` and a Grafana server that uses Prometheus as a data source. The Grafana dashboard will be exposed on `localhost:3000` and accessible via default credentials:
+
+```
+username: admin
+password: admin
+```

--- a/etc/docker-monitoring.yml
+++ b/etc/docker-monitoring.yml
@@ -36,5 +36,6 @@ services:
       - grafana_data:/var/lib/grafana
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboards:/etc/grafana/provisioning_temp/dashboards
+      - ./grafana/grafana.ini:/etc/grafana/grafana.ini
     depends_on:
       - prometheus

--- a/etc/docker-monitoring.yml
+++ b/etc/docker-monitoring.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+services:
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+    extra_hosts:
+      # https://stackoverflow.com/a/43541732/5204678
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - 3000:3000
+    environment:
+      PROMETHEUS_URL: http://prometheus:9090
+    # 1. Copy dashboards from temp directory to prevent modifying original host files
+    # 2. Replace Prometheus datasource placeholder with the actual name
+    # 3. Run Grafana
+    entrypoint: >
+      sh -c "cp -r /etc/grafana/provisioning_temp/dashboards/. /etc/grafana/provisioning/dashboards &&
+             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${DS_PROMETHEUS}/Prometheus/g' {} \+ &&
+             /run.sh"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/dashboards:/etc/grafana/provisioning_temp/dashboards
+    depends_on:
+      - prometheus

--- a/etc/grafana/dashboards/dashboard.yml
+++ b/etc/grafana/dashboards/dashboard.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+providers:
+  - name: "Folder"
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -1,4 +1,47 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -18,7 +61,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -30,6 +73,290 @@
         "x": 0,
         "y": 0
       },
+      "id": 123130,
+      "panels": [],
+      "title": "Real-time sync",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 123128,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "ponder_realtime_latest_block_number{network=\"$networks\"}",
+          "instant": false,
+          "legendFormat": "Block number",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latest block number",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 125
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 123132,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, ponder_realtime_rpc_request_duration_bucket)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC request duration (mean)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 123129,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "time() - ponder_realtime_latest_block_timestamp{network=\"$networks\"}",
+          "instant": false,
+          "legendFormat": "Block number",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Since latest block timestamp",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "orange",
+                "value": 2000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 5
+      },
+      "id": 123135,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.95, ponder_realtime_rpc_request_duration_bucket)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC request duration (p95)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
       "id": 123126,
       "panels": [],
       "title": "Historical sync",
@@ -38,7 +365,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -60,10 +387,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 10
       },
       "id": 123124,
       "interval": "1s",
@@ -82,7 +409,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -102,7 +429,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -160,10 +487,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 9,
+        "h": 8,
+        "w": 11,
         "x": 6,
-        "y": 1
+        "y": 10
       },
       "id": 123127,
       "interval": "1s",
@@ -183,7 +510,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(ponder_historical_task_completed{network=\"$networks\"}[$__rate_interval])",
@@ -196,7 +523,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(ponder_historical_task_failed{network=\"$networks\"}[$__rate_interval])",
@@ -212,12 +539,446 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 125
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 10
+      },
+      "id": 123133,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, ponder_historical_rpc_request_duration_bucket)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC request duration (mean)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 125
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 14
+      },
+      "id": 123134,
+      "interval": "1s",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.95, ponder_historical_rpc_request_duration_bucket)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC request duration (p95)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 123136,
+      "panels": [],
+      "title": "Process",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 123137,
+      "interval": "1s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "ponder_default_process_resident_memory_bytes",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total (RSS)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "ponder_default_nodejs_heap_size_total_bytes",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Heap total (V8)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "ponder_default_nodejs_heap_size_used_bytes",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Heap used (V8)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 123138,
+      "interval": "1s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "rate(ponder_default_process_cpu_seconds_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(ponder_default_process_cpu_user_seconds_total[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "User",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "rate(ponder_default_process_cpu_system_seconds_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "System",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -229,55 +990,143 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 9,
-        "x": 15,
-        "y": 1
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
       },
-      "id": 123125,
+      "id": 123139,
+      "interval": "3s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "ponder_default_nodejs_eventloop_lag_seconds",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Event loop lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 123140,
       "interval": "1s",
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": ["last"],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
-        "showUnfilled": true,
-        "text": {
-          "titleSize": 12,
-          "valueSize": 12
-        },
-        "valueMode": "text"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum without(method) (ponder_historical_rpc_request_duration_bucket) / scalar(sum without(method) (ponder_historical_rpc_request_duration_count))",
-          "format": "heatmap",
+          "expr": "histogram_quantile(0.5, sum(rate(ponder_default_nodejs_gc_duration_seconds_bucket[$__rate_interval])) by (le))",
+          "hide": false,
           "instant": false,
-          "interval": "",
-          "legendFormat": "__auto",
+          "legendFormat": "Total",
           "range": true,
-          "refId": "A"
+          "refId": "C"
         }
       ],
-      "title": "Historical sync RPC request duration",
-      "type": "bargauge"
+      "title": "Garbage collection duration",
+      "type": "timeseries"
     }
   ],
   "refresh": "1s",
@@ -287,14 +1136,10 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": ["mainnet"],
-          "value": ["mainnet"]
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(network)",
         "hide": 0,
@@ -339,6 +1184,6 @@
   "timezone": "browser",
   "title": "Ponder",
   "uid": "c9256f5e-776b-48bd-ae68-b0ed508c8ceb",
-  "version": 24,
+  "version": 36,
   "weekStart": ""
 }

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -1,0 +1,344 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 123126,
+      "panels": [],
+      "title": "Historical sync",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 123124,
+      "interval": "1s",
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ponder_historical_task_completed{network=\"$networks\"}) / sum(ponder_historical_task_total{network=\"$networks\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Historical sync progress",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Tasks / second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 6,
+        "y": 1
+      },
+      "id": 123127,
+      "interval": "1s",
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "rate(ponder_historical_task_completed{network=\"$networks\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Completed {{kind}} tasks",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(ponder_historical_task_failed{network=\"$networks\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Failed {{kind}} tasks",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Historical sync tasks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 15,
+        "y": 1
+      },
+      "id": 123125,
+      "interval": "1s",
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["last"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {
+          "titleSize": 12,
+          "valueSize": 12
+        },
+        "valueMode": "text"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum without(method) (ponder_historical_rpc_request_duration_bucket) / scalar(sum without(method) (ponder_historical_rpc_request_duration_count))",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Historical sync RPC request duration",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "1s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": ["mainnet"],
+          "value": ["mainnet"]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(network)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "networks",
+        "options": [],
+        "query": {
+          "query": "label_values(network)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"],
+    "type": "timepicker"
+  },
+  "timezone": "browser",
+  "title": "Ponder",
+  "uid": "c9256f5e-776b-48bd-ae68-b0ed508c8ceb",
+  "version": 24,
+  "weekStart": ""
+}

--- a/etc/grafana/datasources/prometheus.yml
+++ b/etc/grafana/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: $PROMETHEUS_URL
+    editable: true

--- a/etc/grafana/grafana.ini
+++ b/etc/grafana/grafana.ini
@@ -1,0 +1,8 @@
+[server]
+# The http port to use
+http_port = 3000
+
+[dashboards]
+# Minimum dashboard refresh interval. When set, this will restrict users to set the refresh interval of a dashboard lower than given interval. Per default this is 5 seconds.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+min_refresh_interval = 500ms

--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: ponder
+    metrics_path: "/metrics"
+    scrape_interval: 1s
+    static_configs:
+      - targets: ["localhost:42069", "host.docker.internal:42069"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "pg": "^8.9.0",
     "picocolors": "^1.0.0",
     "prettier": "^2.6.2",
+    "prom-client": "^14.2.0",
     "react": "17",
     "retry": "^0.13.1",
     "stacktrace-parser": "^0.1.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "express-graphql": "^0.12.0",
     "glob": "^8.1.0",
     "graphql": "^15.3.0",
+    "http-terminator": "^3.2.0",
     "ink": "^3.2.0",
     "kysely": "^0.24.2",
     "node-fetch": "^2.6.7",

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -13,6 +13,7 @@ import { PostgresEventStore } from "@/event-store/postgres/store";
 import { SqliteEventStore } from "@/event-store/sqlite/store";
 import { type EventStore } from "@/event-store/store";
 import { HistoricalSyncService } from "@/historical-sync/service";
+import { MetricsService } from "@/metrics/service";
 import { RealtimeSyncService } from "@/realtime-sync/service";
 import { ReloadService } from "@/reload/service";
 import { ServerService } from "@/server/service";
@@ -28,6 +29,7 @@ export type Resources = {
   options: PonderOptions;
   logger: LoggerService;
   errors: ErrorService;
+  metrics: MetricsService;
 };
 
 export class Ponder {
@@ -67,8 +69,9 @@ export class Ponder {
   }) {
     const logger = new LoggerService({ options });
     const errors = new ErrorService();
+    const metrics = new MetricsService();
 
-    const resources = { options, logger, errors };
+    const resources = { options, logger, errors, metrics };
     this.resources = resources;
 
     const logFilters = buildLogFilters({ options, config });

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -102,6 +102,7 @@ export class Ponder {
         network,
         logFilters: logFiltersForNetwork,
         historicalSyncService: new HistoricalSyncService({
+          resources,
           eventStore: this.eventStore,
           network,
           logFilters: logFiltersForNetwork,

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -102,12 +102,13 @@ export class Ponder {
         network,
         logFilters: logFiltersForNetwork,
         historicalSyncService: new HistoricalSyncService({
-          resources,
+          metrics,
           eventStore: this.eventStore,
           network,
           logFilters: logFiltersForNetwork,
         }),
         realtimeSyncService: new RealtimeSyncService({
+          metrics,
           eventStore: this.eventStore,
           network,
           logFilters: logFiltersForNetwork,
@@ -401,7 +402,7 @@ export class Ponder {
           networkSyncService;
 
         if (
-          realtimeSyncService.metrics.isConnected &&
+          realtimeSyncService.stats.isConnected &&
           !this.uiService.ui.networks.includes(network.name)
         ) {
           this.uiService.ui.networks.push(network.name);

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -375,7 +375,7 @@ export class Ponder {
           this.resources.logger.logMessage(
             "historical",
             `started historical sync for ${pico.bold(name)} (${formatPercentage(
-              historicalSyncService.metrics.logFilters[name].cacheRate
+              historicalSyncService.stats.logFilters[name].cacheRate
             )} cached)`
           );
         });
@@ -410,7 +410,7 @@ export class Ponder {
 
         this.logFilters.forEach(({ name }) => {
           const historicalMetrics =
-            historicalSyncService.metrics.logFilters[name];
+            historicalSyncService.stats.logFilters[name];
 
           this.uiService.ui.stats[name].cacheRate = historicalMetrics.cacheRate;
 
@@ -427,7 +427,7 @@ export class Ponder {
       });
 
       const isHistoricalSyncComplete = this.networkSyncServices.every(
-        (n) => n.historicalSyncService.metrics.isComplete
+        (n) => n.historicalSyncService.stats.isComplete
       );
       this.uiService.ui.isHistoricalSyncComplete = isHistoricalSyncComplete;
 
@@ -435,7 +435,7 @@ export class Ponder {
         this.uiService.ui.historicalSyncDuration = formatEta(
           Math.max(
             ...this.networkSyncServices.map(
-              (n) => n.historicalSyncService.metrics.duration
+              (n) => n.historicalSyncService.stats.duration
             )
           )
         );

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -9,6 +9,7 @@ import { mainnet } from "viem/chains";
 
 import { buildOptions } from "@/config/options";
 import { ErrorService } from "@/errors/ErrorService";
+import { MetricsService } from "@/metrics/service";
 import { Resources } from "@/Ponder";
 import { LoggerService } from "@/utils/logger";
 
@@ -62,4 +63,5 @@ export const testResources: Resources = {
     cliOptions: { configFile: "", rootDir: "" },
   }),
   errors: new ErrorService(),
+  metrics: new MetricsService(),
 };

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -48,7 +48,7 @@ test("setup() calculates cached and total block counts", async (context) => {
   });
   await service.setup({ finalizedBlockNumber: 16369955 });
 
-  expect(service.metrics.logFilters["USDC"]).toMatchObject({
+  expect(service.stats.logFilters["USDC"]).toMatchObject({
     totalBlockCount: 6,
     cacheRate: 0,
   });
@@ -68,7 +68,7 @@ test("start() runs log tasks and block tasks", async (context) => {
 
   await service.onIdle();
 
-  expect(service.metrics.logFilters["USDC"]).toMatchObject({
+  expect(service.stats.logFilters["USDC"]).toMatchObject({
     blockTaskTotalCount: 6,
     blockTaskCompletedCount: 6,
     logTaskTotalCount: 2,
@@ -168,7 +168,7 @@ test("start() retries errors", async (context) => {
   service.start();
   await service.onIdle();
 
-  expect(service.metrics.logFilters["USDC"]).toMatchObject({
+  expect(service.stats.logFilters["USDC"]).toMatchObject({
     logTaskTotalCount: 2,
     logTaskErrorCount: 1,
     logTaskCompletedCount: 1,
@@ -207,7 +207,7 @@ test("start() handles Alchemy 'Log response size exceeded' error", async (contex
   service.start();
   await service.onIdle();
 
-  expect(service.metrics.logFilters["USDC"]).toMatchObject({
+  expect(service.stats.logFilters["USDC"]).toMatchObject({
     logTaskTotalCount: 4,
     logTaskErrorCount: 1,
     logTaskCompletedCount: 3,
@@ -245,7 +245,7 @@ test("start() handles Quicknode 'eth_getLogs and eth_newFilter are limited to a 
   service.start();
   await service.onIdle();
 
-  expect(service.metrics.logFilters["USDC"]).toMatchObject({
+  expect(service.stats.logFilters["USDC"]).toMatchObject({
     logTaskTotalCount: 4,
     logTaskErrorCount: 1,
     logTaskCompletedCount: 3,

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -2,13 +2,14 @@ import { HttpRequestError, InvalidParamsRpcError } from "viem";
 import { expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
-import { publicClient } from "@/_test/utils";
+import { publicClient, testResources } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { Network } from "@/config/networks";
 
 import { HistoricalSyncService } from "./service";
 
+const { metrics } = testResources;
 const network: Network = {
   name: "mainnet",
   chainId: 1,
@@ -40,6 +41,7 @@ test("setup() calculates cached and total block counts", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -56,6 +58,7 @@ test("start() runs log tasks and block tasks", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -77,6 +80,7 @@ test("start() adds events to event store", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -126,6 +130,7 @@ test("start() inserts cached ranges", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -154,6 +159,7 @@ test("start() retries errors", async (context) => {
   spy.mockRejectedValueOnce(new Error("Unexpected error!"));
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -192,6 +198,7 @@ test("start() handles Alchemy 'Log response size exceeded' error", async (contex
   );
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -229,6 +236,7 @@ test("start() handles Quicknode 'eth_getLogs and eth_newFilter are limited to a 
   );
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -257,6 +265,7 @@ test("start() emits sync started and completed events", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,
@@ -276,6 +285,7 @@ test("start() emits historicalCheckpoint event", async (context) => {
   const { eventStore } = context;
 
   const service = new HistoricalSyncService({
+    metrics,
     eventStore,
     logFilters,
     network,

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -329,11 +329,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
   private logTaskWorker = async ({ task }: { task: LogSyncTask }) => {
     const { logFilter, fromBlock, toBlock } = task;
 
-    const endTimer =
-      this.metricsNew.ponder_historical_rpc_request_duration.startTimer({
-        network: this.network.name,
-        method: "eth_getLogs",
-      });
+    const stopClock = startClock();
     const logs = await this.network.client.request({
       method: "eth_getLogs",
       params: [
@@ -345,8 +341,15 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         },
       ],
     });
-    endTimer();
+    this.metricsNew.ponder_historical_rpc_request_duration.observe(
+      {
+        method: "eth_getLogs",
+        network: this.network.name,
+      },
+      stopClock()
+    );
     this.metricsNew.ponder_historical_rpc_request_total.inc({
+      method: "eth_getLogs",
       network: this.network.name,
     });
 
@@ -409,17 +412,21 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     const { logFilter, blockNumber, blockNumberToCacheFrom, requiredTxHashes } =
       task;
 
-    const endTimer =
-      this.metricsNew.ponder_historical_rpc_request_duration.startTimer({
-        network: this.network.name,
-        method: "eth_getBlockByNumber",
-      });
+    const stopClock = startClock();
     const block = await this.network.client.request({
       method: "eth_getBlockByNumber",
       params: [toHex(blockNumber), true],
     });
-    endTimer();
+
+    this.metricsNew.ponder_historical_rpc_request_duration.observe(
+      {
+        method: "eth_getBlockByNumber",
+        network: this.network.name,
+      },
+      stopClock()
+    );
     this.metricsNew.ponder_historical_rpc_request_total.inc({
+      method: "eth_getBlockByNumber",
       network: this.network.name,
     });
 

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -24,7 +24,7 @@ type HistoricalSyncEvents = {
   error: { error: Error };
 };
 
-type HistoricalSyncMetrics = {
+type HistoricalSyncStats = {
   endDuration: () => number;
   isComplete: boolean;
   duration: number;
@@ -63,13 +63,13 @@ type BlockSyncTask = {
 type HistoricalSyncQueue = Queue<LogSyncTask | BlockSyncTask>;
 
 export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
-  private metricsNew: MetricsService;
+  private metrics: MetricsService;
   private eventStore: EventStore;
   private logFilters: LogFilter[];
   network: Network;
 
   private queue: HistoricalSyncQueue;
-  metrics: HistoricalSyncMetrics = {
+  stats: HistoricalSyncStats = {
     endDuration: startClock(),
     duration: 0,
     isComplete: false,
@@ -92,7 +92,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
   }) {
     super();
 
-    this.metricsNew = metrics;
+    this.metrics = metrics;
     this.eventStore = eventStore;
     this.logFilters = logFilters;
     this.network = network;
@@ -101,7 +101,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     this.logFilterCheckpoints = {};
 
     logFilters.forEach((logFilter) => {
-      this.metrics.logFilters[logFilter.name] = {
+      this.stats.logFilters[logFilter.name] = {
         totalBlockCount: 0,
         cacheRate: 0,
         logTaskTotalCount: 0,
@@ -147,9 +147,8 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           0
         );
 
-        this.metrics.logFilters[logFilter.name].totalBlockCount =
-          totalBlockCount;
-        this.metrics.logFilters[logFilter.name].cacheRate = Math.min(
+        this.stats.logFilters[logFilter.name].totalBlockCount = totalBlockCount;
+        this.stats.logFilters[logFilter.name].cacheRate = Math.min(
           1,
           cachedBlockCount / (totalBlockCount || 1)
         );
@@ -167,7 +166,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
               fromBlock,
               toBlock,
             });
-            this.metricsNew.ponder_historical_task_total.inc({
+            this.metrics.ponder_historical_task_total.inc({
               kind: "log",
               network: this.network.name,
             });
@@ -184,8 +183,8 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     // need to emit the historicalCheckpoint event with some timestamp. It should
     // be safe to use the current timestamp.
     if (this.queue.size === 0) {
-      this.metrics.duration = this.metrics.endDuration();
-      this.metrics.isComplete = true;
+      this.stats.duration = this.stats.endDuration();
+      this.stats.isComplete = true;
       this.emit("historicalCheckpoint", { timestamp: Date.now() });
       this.emit("syncComplete");
     }
@@ -225,20 +224,20 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       onAdd: ({ task }) => {
         const { logFilter } = task;
         if (task.kind === "LOG_SYNC") {
-          this.metrics.logFilters[logFilter.name].logTaskTotalCount += 1;
+          this.stats.logFilters[logFilter.name].logTaskTotalCount += 1;
         } else {
-          this.metrics.logFilters[logFilter.name].blockTaskTotalCount += 1;
+          this.stats.logFilters[logFilter.name].blockTaskTotalCount += 1;
         }
       },
       onComplete: ({ task }) => {
         const { logFilter } = task;
         if (task.kind === "LOG_SYNC") {
-          this.metrics.logFilters[logFilter.name].logTaskCompletedCount += 1;
+          this.stats.logFilters[logFilter.name].logTaskCompletedCount += 1;
         } else {
-          this.metrics.logFilters[logFilter.name].blockTaskCompletedCount += 1;
+          this.stats.logFilters[logFilter.name].blockTaskCompletedCount += 1;
         }
 
-        this.metricsNew.ponder_historical_task_completed.inc({
+        this.metrics.ponder_historical_task_completed.inc({
           kind: task.kind === "LOG_SYNC" ? "log" : "block",
           network: this.network.name,
         });
@@ -246,12 +245,12 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       onError: ({ error, task, queue }) => {
         const { logFilter } = task;
         if (task.kind === "LOG_SYNC") {
-          this.metrics.logFilters[logFilter.name].logTaskErrorCount += 1;
+          this.stats.logFilters[logFilter.name].logTaskErrorCount += 1;
         } else {
-          this.metrics.logFilters[logFilter.name].blockTaskErrorCount += 1;
+          this.stats.logFilters[logFilter.name].blockTaskErrorCount += 1;
         }
 
-        this.metricsNew.ponder_historical_task_failed.inc({
+        this.metrics.ponder_historical_task_failed.inc({
           kind: task.kind === "LOG_SYNC" ? "log" : "block",
           network: this.network.name,
         });
@@ -272,7 +271,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           );
           queue.addTask({ ...task, fromBlock: safeEnd + 1 }, { front: true });
           // Splitting the task into two parts increases the total count by 1.
-          this.metricsNew.ponder_historical_task_total.inc({
+          this.metrics.ponder_historical_task_total.inc({
             kind: "log",
             network: this.network.name,
           });
@@ -293,7 +292,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           queue.addTask({ ...task, toBlock: midpoint }, { front: true });
           queue.addTask({ ...task, fromBlock: midpoint + 1 }, { front: true });
           // Splitting the task into two parts increases the total count by 1.
-          this.metricsNew.ponder_historical_task_total.inc({
+          this.metrics.ponder_historical_task_total.inc({
             kind: "log",
             network: this.network.name,
           });
@@ -315,9 +314,9 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         queue.addTask(task, { retry: true });
       },
       onIdle: () => {
-        if (this.metrics.isComplete) return;
-        this.metrics.duration = this.metrics.endDuration();
-        this.metrics.isComplete = true;
+        if (this.stats.isComplete) return;
+        this.stats.duration = this.stats.endDuration();
+        this.stats.isComplete = true;
         this.emit("syncComplete");
       },
     });
@@ -340,17 +339,13 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         },
       ],
     });
-    this.metricsNew.ponder_historical_rpc_request_duration.observe(
+    this.metrics.ponder_historical_rpc_request_duration.observe(
       {
         method: "eth_getLogs",
         network: this.network.name,
       },
       stopClock()
     );
-    this.metricsNew.ponder_historical_rpc_request_total.inc({
-      method: "eth_getLogs",
-      network: this.network.name,
-    });
 
     await this.eventStore.insertFinalizedLogs({
       chainId: this.network.chainId,
@@ -398,7 +393,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     }
 
     this.queue.addTasks(blockTasks, { front: true });
-    this.metricsNew.ponder_historical_task_total.inc(
+    this.metrics.ponder_historical_task_total.inc(
       {
         kind: "block",
         network: this.network.name,
@@ -417,17 +412,13 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       params: [toHex(blockNumber), true],
     });
 
-    this.metricsNew.ponder_historical_rpc_request_duration.observe(
+    this.metrics.ponder_historical_rpc_request_duration.observe(
       {
         method: "eth_getBlockByNumber",
         network: this.network.name,
       },
       stopClock()
     );
-    this.metricsNew.ponder_historical_rpc_request_total.inc({
-      method: "eth_getBlockByNumber",
-      network: this.network.name,
-    });
 
     if (!block) throw new Error(`Block not found: ${blockNumber}`);
 

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -236,12 +236,12 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       onComplete: ({ task }) => {
         const { logFilter } = task;
         if (task.kind === "LOG_SYNC") {
-          this.metricsNew.ponder_historical_log_task_processed.inc({
+          this.metricsNew.ponder_historical_log_task_completed.inc({
             network: this.network.name,
           });
           this.metrics.logFilters[logFilter.name].logTaskCompletedCount += 1;
         } else {
-          this.metricsNew.ponder_historical_block_task_processed.inc({
+          this.metricsNew.ponder_historical_block_task_completed.inc({
             network: this.network.name,
           });
           this.metrics.logFilters[logFilter.name].blockTaskCompletedCount += 1;
@@ -250,8 +250,14 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       onError: ({ error, task, queue }) => {
         const { logFilter } = task;
         if (task.kind === "LOG_SYNC") {
+          this.metricsNew.ponder_historical_log_task_failed.inc({
+            network: this.network.name,
+          });
           this.metrics.logFilters[logFilter.name].logTaskErrorCount += 1;
         } else {
+          this.metricsNew.ponder_historical_block_task_failed.inc({
+            network: this.network.name,
+          });
           this.metrics.logFilters[logFilter.name].blockTaskErrorCount += 1;
         }
 

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -12,7 +12,6 @@ import type { Network } from "@/config/networks";
 import { QueueError } from "@/errors/queue";
 import type { EventStore } from "@/event-store/store";
 import { MetricsService } from "@/metrics/service";
-import { Resources } from "@/Ponder";
 import { type Queue, createQueue } from "@/utils/queue";
 import { startClock } from "@/utils/timer";
 
@@ -81,19 +80,19 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
   private logFilterCheckpoints: Record<string, number>;
 
   constructor({
-    resources,
+    metrics,
     eventStore,
     logFilters,
     network,
   }: {
-    resources: Resources;
+    metrics: MetricsService;
     eventStore: EventStore;
     logFilters: LogFilter[];
     network: Network;
   }) {
     super();
 
-    this.metricsNew = resources.metrics;
+    this.metricsNew = metrics;
     this.eventStore = eventStore;
     this.logFilters = logFilters;
     this.network = network;

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -1,12 +1,18 @@
 import prometheus from "prom-client";
 
+const httpRequestBucketsInMs = [
+  10, 25, 50, 75, 100, 200, 300, 400, 500, 750, 1_000, 1_500, 2_000, 4_000,
+];
+
 export class MetricsService {
   private registry: prometheus.Registry;
 
   ponder_historical_log_task_total: prometheus.Counter<"network">;
-  ponder_historical_log_task_processed: prometheus.Counter<"network">;
+  ponder_historical_log_task_failed: prometheus.Counter<"network">;
+  ponder_historical_log_task_completed: prometheus.Counter<"network">;
   ponder_historical_block_task_total: prometheus.Counter<"network">;
-  ponder_historical_block_task_processed: prometheus.Counter<"network">;
+  ponder_historical_block_task_failed: prometheus.Counter<"network">;
+  ponder_historical_block_task_completed: prometheus.Counter<"network">;
   ponder_historical_rpc_request_total: prometheus.Counter<"network" | "method">;
   ponder_historical_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
@@ -21,8 +27,14 @@ export class MetricsService {
       labelNames: ["network"] as const,
       registers: [this.registry],
     });
-    this.ponder_historical_log_task_processed = new prometheus.Counter({
-      name: "ponder_historical_log_task_processed",
+    this.ponder_historical_log_task_failed = new prometheus.Counter({
+      name: "ponder_historical_log_task_failed",
+      help: "Number of historical sync log tasks that failed due to an error",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_log_task_completed = new prometheus.Counter({
+      name: "ponder_historical_log_task_completed",
       help: "Number of historical sync log tasks that have been processed",
       labelNames: ["network"] as const,
       registers: [this.registry],
@@ -33,8 +45,14 @@ export class MetricsService {
       labelNames: ["network"] as const,
       registers: [this.registry],
     });
-    this.ponder_historical_block_task_processed = new prometheus.Counter({
-      name: "ponder_historical_block_task_processed",
+    this.ponder_historical_block_task_failed = new prometheus.Counter({
+      name: "ponder_historical_block_task_failed",
+      help: "Number of historical sync block tasks that failed due to an error",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_block_task_completed = new prometheus.Counter({
+      name: "ponder_historical_block_task_completed",
       help: "Number of historical sync block tasks that have been processed",
       labelNames: ["network"] as const,
       registers: [this.registry],
@@ -49,6 +67,7 @@ export class MetricsService {
       name: "ponder_historical_rpc_request_duration",
       help: "Duration of RPC requests completed during the historical sync",
       labelNames: ["network", "method"] as const,
+      buckets: httpRequestBucketsInMs,
       registers: [this.registry],
     });
   }

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -23,6 +23,12 @@ export class MetricsService {
   constructor() {
     this.registry = new prometheus.Registry();
 
+    // Register default metric collection.
+    prometheus.collectDefaultMetrics({
+      register: this.registry,
+      prefix: "ponder_default_",
+    });
+
     // Historical sync metrics
     this.ponder_historical_task_total = new prometheus.Counter({
       name: "ponder_historical_task_total",

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -1,34 +1,63 @@
 import prometheus from "prom-client";
 
-/**
- * MetricsService is a wrapper around the `prom-client` NPM package.
- *
- */
 export class MetricsService {
-  registry: prometheus.Registry;
+  private registry: prometheus.Registry;
+
+  ponder_historical_log_task_total: prometheus.Counter<"network">;
+  ponder_historical_log_task_processed: prometheus.Counter<"network">;
+  ponder_historical_block_task_total: prometheus.Counter<"network">;
+  ponder_historical_block_task_processed: prometheus.Counter<"network">;
+  ponder_historical_rpc_request_total: prometheus.Counter<"network" | "method">;
+  ponder_historical_rpc_request_duration: prometheus.Histogram<
+    "network" | "method"
+  >;
 
   constructor() {
-    const registry = new prometheus.Registry();
+    this.registry = new prometheus.Registry();
 
-    const counter = new prometheus.Counter({
-      name: "test_metric",
-      help: "placeholder help message",
-      labelNames: ["label1", "label2"],
-      registers: [registry],
+    this.ponder_historical_log_task_total = new prometheus.Counter({
+      name: "ponder_historical_log_task_total",
+      help: "Number of historical sync log tasks that have been scheduled",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
     });
-
-    setInterval(() => {
-      counter.inc();
-    }, 500);
-
-    this.registry = registry;
+    this.ponder_historical_log_task_processed = new prometheus.Counter({
+      name: "ponder_historical_log_task_processed",
+      help: "Number of historical sync log tasks that have been processed",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_block_task_total = new prometheus.Counter({
+      name: "ponder_historical_block_task_total",
+      help: "Number of historical sync block tasks that have been scheduled",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_block_task_processed = new prometheus.Counter({
+      name: "ponder_historical_block_task_processed",
+      help: "Number of historical sync block tasks that have been processed",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_rpc_request_total = new prometheus.Counter({
+      name: "ponder_historical_rpc_request_total",
+      help: "Number of RPC requests executed during the historical sync",
+      labelNames: ["network", "method"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_historical_rpc_request_duration = new prometheus.Histogram({
+      name: "ponder_historical_rpc_request_duration",
+      help: "Duration of RPC requests completed during the historical sync",
+      labelNames: ["network", "method"] as const,
+      registers: [this.registry],
+    });
   }
 
   /**
-   * Get string representation for all metrics
+   * Get string representation for all metrics.
    * @returns Metrics encoded using Prometheus v0.0.4 format.
    */
-  async metrics() {
+  async getMetrics() {
     return await this.registry.metrics();
   }
 }

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -1,7 +1,8 @@
 import prometheus from "prom-client";
 
 const httpRequestBucketsInMs = [
-  10, 25, 50, 75, 100, 200, 300, 400, 500, 750, 1_000, 1_500, 2_000, 4_000,
+  5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 150, 200, 250, 300, 350, 400, 450,
+  500, 750, 1_000, 2_000, 10_000,
 ];
 
 export class MetricsService {
@@ -10,12 +11,14 @@ export class MetricsService {
   ponder_historical_task_total: prometheus.Counter<"network" | "kind">;
   ponder_historical_task_failed: prometheus.Counter<"network" | "kind">;
   ponder_historical_task_completed: prometheus.Counter<"network" | "kind">;
-  ponder_historical_rpc_request_total: prometheus.Counter<"network" | "method">;
   ponder_historical_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
   >;
   ponder_realtime_latest_block_number: prometheus.Gauge<"network">;
   ponder_realtime_latest_block_timestamp: prometheus.Gauge<"network">;
+  ponder_realtime_rpc_request_duration: prometheus.Histogram<
+    "network" | "method"
+  >;
 
   constructor() {
     this.registry = new prometheus.Registry();
@@ -39,12 +42,6 @@ export class MetricsService {
       labelNames: ["network", "kind"] as const,
       registers: [this.registry],
     });
-    this.ponder_historical_rpc_request_total = new prometheus.Counter({
-      name: "ponder_historical_rpc_request_total",
-      help: "Number of RPC requests executed during the historical sync",
-      labelNames: ["network", "method"] as const,
-      registers: [this.registry],
-    });
     this.ponder_historical_rpc_request_duration = new prometheus.Histogram({
       name: "ponder_historical_rpc_request_duration",
       help: "Duration of RPC requests completed during the historical sync",
@@ -64,6 +61,13 @@ export class MetricsService {
       name: "ponder_realtime_latest_block_timestamp",
       help: "Block timestamp of the latest synced block",
       labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_realtime_rpc_request_duration = new prometheus.Histogram({
+      name: "ponder_realtime_rpc_request_duration",
+      help: "Duration of RPC requests completed during the realtime sync",
+      labelNames: ["network", "method"] as const,
+      buckets: httpRequestBucketsInMs,
       registers: [this.registry],
     });
   }

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -7,12 +7,9 @@ const httpRequestBucketsInMs = [
 export class MetricsService {
   private registry: prometheus.Registry;
 
-  ponder_historical_log_task_total: prometheus.Counter<"network">;
-  ponder_historical_log_task_failed: prometheus.Counter<"network">;
-  ponder_historical_log_task_completed: prometheus.Counter<"network">;
-  ponder_historical_block_task_total: prometheus.Counter<"network">;
-  ponder_historical_block_task_failed: prometheus.Counter<"network">;
-  ponder_historical_block_task_completed: prometheus.Counter<"network">;
+  ponder_historical_task_total: prometheus.Counter<"network" | "kind">;
+  ponder_historical_task_failed: prometheus.Counter<"network" | "kind">;
+  ponder_historical_task_completed: prometheus.Counter<"network" | "kind">;
   ponder_historical_rpc_request_total: prometheus.Counter<"network" | "method">;
   ponder_historical_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
@@ -21,40 +18,22 @@ export class MetricsService {
   constructor() {
     this.registry = new prometheus.Registry();
 
-    this.ponder_historical_log_task_total = new prometheus.Counter({
-      name: "ponder_historical_log_task_total",
-      help: "Number of historical sync log tasks that have been scheduled",
-      labelNames: ["network"] as const,
+    this.ponder_historical_task_total = new prometheus.Counter({
+      name: "ponder_historical_task_total",
+      help: "Number of historical sync tasks that have been scheduled",
+      labelNames: ["network", "kind"] as const,
       registers: [this.registry],
     });
-    this.ponder_historical_log_task_failed = new prometheus.Counter({
-      name: "ponder_historical_log_task_failed",
-      help: "Number of historical sync log tasks that failed due to an error",
-      labelNames: ["network"] as const,
+    this.ponder_historical_task_failed = new prometheus.Counter({
+      name: "ponder_historical_task_failed",
+      help: "Number of historical sync tasks that failed due to an error",
+      labelNames: ["network", "kind"] as const,
       registers: [this.registry],
     });
-    this.ponder_historical_log_task_completed = new prometheus.Counter({
-      name: "ponder_historical_log_task_completed",
-      help: "Number of historical sync log tasks that have been processed",
-      labelNames: ["network"] as const,
-      registers: [this.registry],
-    });
-    this.ponder_historical_block_task_total = new prometheus.Counter({
-      name: "ponder_historical_block_task_total",
-      help: "Number of historical sync block tasks that have been scheduled",
-      labelNames: ["network"] as const,
-      registers: [this.registry],
-    });
-    this.ponder_historical_block_task_failed = new prometheus.Counter({
-      name: "ponder_historical_block_task_failed",
-      help: "Number of historical sync block tasks that failed due to an error",
-      labelNames: ["network"] as const,
-      registers: [this.registry],
-    });
-    this.ponder_historical_block_task_completed = new prometheus.Counter({
-      name: "ponder_historical_block_task_completed",
-      help: "Number of historical sync block tasks that have been processed",
-      labelNames: ["network"] as const,
+    this.ponder_historical_task_completed = new prometheus.Counter({
+      name: "ponder_historical_task_completed",
+      help: "Number of historical sync tasks that have been processed",
+      labelNames: ["network", "kind"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_rpc_request_total = new prometheus.Counter({

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -1,0 +1,34 @@
+import prometheus from "prom-client";
+
+/**
+ * MetricsService is a wrapper around the `prom-client` NPM package.
+ *
+ */
+export class MetricsService {
+  registry: prometheus.Registry;
+
+  constructor() {
+    const registry = new prometheus.Registry();
+
+    const counter = new prometheus.Counter({
+      name: "test_metric",
+      help: "placeholder help message",
+      labelNames: ["label1", "label2"],
+      registers: [registry],
+    });
+
+    setInterval(() => {
+      counter.inc();
+    }, 500);
+
+    this.registry = registry;
+  }
+
+  /**
+   * Get string representation for all metrics
+   * @returns Metrics encoded using Prometheus v0.0.4 format.
+   */
+  async metrics() {
+    return await this.registry.metrics();
+  }
+}

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -14,10 +14,13 @@ export class MetricsService {
   ponder_historical_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
   >;
+  ponder_realtime_latest_block_number: prometheus.Gauge<"network">;
+  ponder_realtime_latest_block_timestamp: prometheus.Gauge<"network">;
 
   constructor() {
     this.registry = new prometheus.Registry();
 
+    // Historical sync metrics
     this.ponder_historical_task_total = new prometheus.Counter({
       name: "ponder_historical_task_total",
       help: "Number of historical sync tasks that have been scheduled",
@@ -47,6 +50,20 @@ export class MetricsService {
       help: "Duration of RPC requests completed during the historical sync",
       labelNames: ["network", "method"] as const,
       buckets: httpRequestBucketsInMs,
+      registers: [this.registry],
+    });
+
+    // Realtime sync metrics
+    this.ponder_realtime_latest_block_number = new prometheus.Gauge({
+      name: "ponder_realtime_latest_block_number",
+      help: "Block number of the latest synced block",
+      labelNames: ["network"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_realtime_latest_block_timestamp = new prometheus.Gauge({
+      name: "ponder_realtime_latest_block_timestamp",
+      help: "Block timestamp of the latest synced block",
+      labelNames: ["network"] as const,
       registers: [this.registry],
     });
   }

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -10,6 +10,7 @@ import { MetricsService } from "@/metrics/service";
 import { poll } from "@/utils/poll";
 import { type Queue, createQueue } from "@/utils/queue";
 import { range } from "@/utils/range";
+import { startClock } from "@/utils/timer";
 
 import { isMatchedLogInBloomFilter } from "./bloom";
 import { filterLogs } from "./filter";
@@ -128,11 +129,19 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     }
 
     // Fetch the block at the finalized block number.
+    const stopClock = startClock();
     const finalizedBlock = await this.network.client.request({
       method: "eth_getBlockByNumber",
       params: [numberToHex(this.finalizedBlockNumber), false],
     });
     if (!finalizedBlock) throw new Error(`Unable to fetch finalized block`);
+    this.metrics.ponder_realtime_rpc_request_duration.observe(
+      {
+        method: "eth_getBlockByNumber",
+        network: this.network.name,
+      },
+      stopClock()
+    );
 
     // Add the finalized block as the first element of the list of unfinalized blocks.
     this.blocks.push(rpcBlockToLightBlock(finalizedBlock));
@@ -149,7 +158,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       },
       {
         emitOnBegin: false,
-        interval: 10_000,
+        interval: this.network.pollingInterval,
       }
     );
   };
@@ -168,11 +177,19 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
   private getLatestBlock = async () => {
     // Fetch the latest block for the network.
+    const stopClock = startClock();
     const latestBlock_ = await this.network.client.request({
       method: "eth_getBlockByNumber",
       params: ["latest", true],
     });
     if (!latestBlock_) throw new Error(`Unable to fetch latest block`);
+    this.metrics.ponder_realtime_rpc_request_duration.observe(
+      {
+        method: "eth_getBlockByNumber",
+        network: this.network.name,
+      },
+      stopClock()
+    );
     return latestBlock_ as BlockWithTransactions;
   };
 
@@ -236,6 +253,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
       if (isMatchedLogPresentInBlock) {
         // If there's a potential match, fetch the logs from the block.
+        const stopClock = startClock();
         const logs = await this.network.client.request({
           method: "eth_getLogs",
           params: [
@@ -244,6 +262,13 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
             },
           ],
         });
+        this.metrics.ponder_realtime_rpc_request_duration.observe(
+          {
+            method: "eth_getLogs",
+            network: this.network.name,
+          },
+          stopClock()
+        );
 
         // Filter logs down to those that actually match the registered filters.
         const filteredLogs = filterLogs({
@@ -347,12 +372,21 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
       const missingBlockRequests = missingBlockNumbers.map((number) => {
         return limit(async () => {
+          const stopClock = startClock();
           const block = await this.network.client.request({
             method: "eth_getBlockByNumber",
             params: [numberToHex(number), true],
           });
-          if (!block)
+          if (!block) {
             throw new Error(`Failed to fetch block number: ${number}`);
+          }
+          this.metrics.ponder_realtime_rpc_request_duration.observe(
+            {
+              method: "eth_getBlockByNumber",
+              network: this.network.name,
+            },
+            stopClock()
+          );
           return block as BlockWithTransactions;
         });
       });
@@ -422,10 +456,20 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         return;
       }
 
+      // If the parent block is not present in our local chain, keep traversing up the canonical chain.
+      const stopClock = startClock();
       const parentBlock_ = await this.network.client.request({
         method: "eth_getBlockByHash",
         params: [canonicalBlock.parentHash, true],
       });
+      this.metrics.ponder_realtime_rpc_request_duration.observe(
+        {
+          method: "eth_getBlockByHash",
+          network: this.network.name,
+        },
+        stopClock()
+      );
+
       if (!parentBlock_)
         throw new Error(
           `Failed to fetch parent block with hash: ${canonicalBlock.parentHash}`

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -51,8 +51,8 @@ export class ServerService extends Emittery<ServerServiceEvents> {
 
     this.app.post("/metrics", async (_, res) => {
       try {
-        res.set("Content-Type", this.resources.metrics.registry.contentType);
-        res.end(await this.resources.metrics.metrics());
+        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+        res.end(await this.resources.metrics.getMetrics());
       } catch (error) {
         res.status(500).end(error);
       }
@@ -60,8 +60,8 @@ export class ServerService extends Emittery<ServerServiceEvents> {
 
     this.app.get("/metrics", async (_, res) => {
       try {
-        res.set("Content-Type", this.resources.metrics.registry.contentType);
-        res.end(await this.resources.metrics.metrics());
+        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+        res.end(await this.resources.metrics.getMetrics());
       } catch (error) {
         res.status(500).end(error);
       }

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -49,6 +49,24 @@ export class ServerService extends Emittery<ServerServiceEvents> {
       port: resolvedPort,
     });
 
+    this.app.post("/metrics", async (_, res) => {
+      try {
+        res.set("Content-Type", this.resources.metrics.registry.contentType);
+        res.end(await this.resources.metrics.metrics());
+      } catch (error) {
+        res.status(500).end(error);
+      }
+    });
+
+    this.app.get("/metrics", async (_, res) => {
+      try {
+        res.set("Content-Type", this.resources.metrics.registry.contentType);
+        res.end(await this.resources.metrics.metrics());
+      } catch (error) {
+        res.status(500).end(error);
+      }
+    });
+
     // By default, the server will respond as unhealthy until historical events have
     // been processed OR 4.5 minutes have passed since the app was created. This
     // enables zero-downtime deployments on PaaS platforms like Railway and Render.

--- a/packages/core/src/utils/timer.ts
+++ b/packages/core/src/utils/timer.ts
@@ -1,5 +1,12 @@
-export const startBenchmark = () => process.hrtime();
-export const endBenchmark = (hrt: [number, number]) => {
-  const diffHrt = process.hrtime(hrt);
-  return Math.round(diffHrt[0] * 1000 + diffHrt[1] / 1000000);
+/**
+ * Measures the elapsed wall clock time in milliseconds (ms) between two points.
+ * @returns A function returning the elapsed time in milliseconds (ms).
+ */
+export const startClock = () => {
+  const start = process.hrtime();
+
+  return () => {
+    const diff = process.hrtime(start);
+    return Math.round(diff[0] * 1000 + diff[1] / 1000000);
+  };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
       pg: ^8.9.0
       picocolors: ^1.0.0
       prettier: ^2.6.2
+      prom-client: ^14.2.0
       react: '17'
       retry: ^0.13.1
       stacktrace-parser: ^0.1.10
@@ -170,6 +171,7 @@ importers:
       pg: 8.9.0
       picocolors: 1.0.0
       prettier: 2.8.2
+      prom-client: 14.2.0
       react: 17.0.2
       retry: 0.13.1
       stacktrace-parser: 0.1.10
@@ -3553,6 +3555,10 @@ packages:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
     dependencies:
       file-uri-to-path: 1.0.0
+    dev: false
+
+  /bintrees/1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
     dev: false
 
   /bl/4.1.0:
@@ -7752,6 +7758,13 @@ packages:
       react-is: 17.0.2
     dev: true
 
+  /prom-client/14.2.0:
+    resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
+    engines: {node: '>=10'}
+    dependencies:
+      tdigest: 0.1.2
+    dev: false
+
   /prompts/2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -8741,6 +8754,12 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.1
+    dev: false
+
+  /tdigest/0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+    dependencies:
+      bintrees: 1.0.2
     dev: false
 
   /term-size/2.2.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,7 @@ importers:
       express-graphql: ^0.12.0
       glob: ^8.1.0
       graphql: ^15.3.0
+      http-terminator: ^3.2.0
       ink: ^3.2.0
       kysely: ^0.24.2
       module-alias: ^2.2.2
@@ -163,6 +164,7 @@ importers:
       express-graphql: 0.12.0_graphql@15.8.0
       glob: 8.1.0
       graphql: 15.8.0_qb2u6q36ugvr6swjr2i3rg76ty
+      http-terminator: 3.2.0
       ink: 3.2.0_qnxonbsml5syl42mqdnwkqq4yu
       kysely: 0.24.2
       node-fetch: 2.6.7
@@ -3304,7 +3306,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
 
   /ansi-colors/4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3592,6 +3593,10 @@ packages:
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
+
+  /boolean/3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    dev: false
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -4140,7 +4145,6 @@ packages:
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /defaults/1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -4159,7 +4163,11 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
-    dev: true
+
+  /delay/5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -5257,7 +5265,6 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-diff/1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
@@ -5275,11 +5282,27 @@ packages:
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    dev: true
+
+  /fast-json-stringify/2.7.13:
+    resolution: {integrity: sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      ajv: 6.12.6
+      deepmerge: 4.2.2
+      rfdc: 1.3.0
+      string-similarity: 4.0.4
+    dev: false
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-printf/1.6.9:
+    resolution: {integrity: sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==}
+    engines: {node: '>=10.0'}
+    dependencies:
+      boolean: 3.2.0
+    dev: false
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -5609,6 +5632,13 @@ packages:
       type-fest: 0.20.2
     dev: true
 
+  /globalthis/1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.1.4
+    dev: false
+
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
     dev: true
@@ -5688,7 +5718,6 @@ packages:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.1.3
-    dev: true
 
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
@@ -5777,6 +5806,16 @@ packages:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+    dev: false
+
+  /http-terminator/3.2.0:
+    resolution: {integrity: sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==}
+    engines: {node: '>=14'}
+    dependencies:
+      delay: 5.0.0
+      p-wait-for: 3.2.0
+      roarr: 7.15.0
+      type-fest: 2.19.0
     dev: false
 
   /human-id/1.0.2:
@@ -6171,7 +6210,6 @@ packages:
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -7253,7 +7291,6 @@ packages:
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object.assign/4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
@@ -7443,6 +7480,13 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /p-wait-for/3.2.0:
+    resolution: {integrity: sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-timeout: 3.2.0
+    dev: false
 
   /packet-reader/1.0.0:
     resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
@@ -7810,7 +7854,6 @@ packages:
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
-    dev: true
 
   /qs/6.10.3:
     resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
@@ -8155,6 +8198,10 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  /rfdc/1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
+    dev: false
+
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -8167,6 +8214,18 @@ packages:
     engines: {node: '>=14'}
     deprecated: Please upgrade to 4.3.1 or higher to fix a potentially damaging issue regarding symbolic link following. See https://github.com/isaacs/rimraf/issues/259 for details.
     hasBin: true
+    dev: false
+
+  /roarr/7.15.0:
+    resolution: {integrity: sha512-CV9WefQfUXTX6wr8CrEMhfNef3sjIt9wNhE/5PNu4tNWsaoDNDXqq+OGn/RW9A1UPb0qc7FQlswXRaJJJsqn8A==}
+    engines: {node: '>=12.0'}
+    dependencies:
+      boolean: 3.2.0
+      fast-json-stringify: 2.7.13
+      fast-printf: 1.6.9
+      globalthis: 1.0.3
+      safe-stable-stringify: 2.4.3
+      semver-compare: 1.0.0
     dev: false
 
   /rollup/3.18.0:
@@ -8205,6 +8264,11 @@ packages:
       is-regex: 1.1.4
     dev: true
 
+  /safe-stable-stringify/2.4.3:
+    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
+    engines: {node: '>=10'}
+    dev: false
+
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -8233,6 +8297,10 @@ packages:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+    dev: false
+
+  /semver-compare/1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
     dev: false
 
   /semver/5.7.1:
@@ -8498,6 +8566,11 @@ packages:
     dependencies:
       mixme: 0.5.4
     dev: true
+
+  /string-similarity/4.0.4:
+    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dev: false
 
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -9070,6 +9143,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /type-fest/2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: false
+
   /type-is/1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -9250,7 +9328,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
-    dev: true
 
   /use-sync-external-store/1.2.0_react@18.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}


### PR DESCRIPTION
This PR adds support for monitoring ponder instances.
- New endpoint at `/metrics` serving a Prometheus client with the metrics listed below
- An `/etc` directory containing Prometheus and Grafana config and a docker compose config file that starts both services, pointing Prometheus at `http://localhost:42069`
- Fixes a bug where `Keep-Alive` HTTP connections were not being terminated properly on process exit

Prometheus client schema (will add more shortly):
```ts
type Metrics = {
  ponder_historical_task_total: prometheus.Counter<"network" | "kind">;
  ponder_historical_task_failed: prometheus.Counter<"network" | "kind">;
  ponder_historical_task_completed: prometheus.Counter<"network" | "kind">;
  ponder_historical_rpc_request_duration: prometheus.Histogram<"network" | "method">;
  ponder_realtime_latest_block_number: prometheus.Gauge<"network">;
  ponder_realtime_latest_block_timestamp: prometheus.Gauge<"network">;
  ponder_realtime_rpc_request_duration: prometheus.Histogram<"network" | "method">;
}
```