### PR TITLE
Add ERC721 example app

### DIFF
--- a/.changeset/short-dingos-sip.md
+++ b/.changeset/short-dingos-sip.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed transaction and block formatting to handle Arbitrum RPC data formats.

--- a/examples/token-erc721/.env.example
+++ b/examples/token-erc721/.env.example
@@ -1,0 +1,2 @@
+# Arbitrum RPC URL used for fetching blockchain data. Alchemy is recommended.
+PONDER_RPC_URL_42161=

--- a/examples/token-erc721/.gitignore
+++ b/examples/token-erc721/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.DS_Store
+
+.env.local
+.ponder/
+generated/

--- a/examples/token-erc721/README.md
+++ b/examples/token-erc721/README.md
@@ -1,0 +1,35 @@
+# Example ERC721 token API
+
+This example shows how to create a GraphQL API for an ERC721 token using Ponder. It uses the Smol Brains NFT contract on Arbitrum, which emits `Transfer`, `Approval`, and `OwnershipTransferred` events.
+
+## Sample queries
+
+### Get all tokens currently owned by an account
+
+```graphql
+{
+  account(id: "0x2B8E4729672613D69e5006a97dD56A455389FB2b") {
+    id
+    tokens {
+      id
+    }
+  }
+}
+```
+
+### Get the current owner and all transfer events for a token
+
+```graphql
+{
+  token(id: "7777") {
+    owner {
+      id
+    }
+    transferEvents {
+      from
+      to
+      timestamp
+    }
+  }
+}
+```

--- a/examples/token-erc721/abis/SmolBrain.json
+++ b/examples/token-erc721/abis/SmolBrain.json
@@ -1,0 +1,633 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_luckyWinner", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "brainMaxLevel",
+        "type": "uint256"
+      }
+    ],
+    "name": "LandMaxLevel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "land",
+        "type": "address"
+      }
+    ],
+    "name": "LandSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "levelIQCost",
+        "type": "uint256"
+      }
+    ],
+    "name": "LevelIQCost",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "school",
+        "type": "address"
+      }
+    ],
+    "name": "SchoolSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum SmolBrain.Gender",
+        "name": "gender",
+        "type": "uint8"
+      }
+    ],
+    "name": "SmolBrainMint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SMOLBRAIN_MINTER_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SMOLBRAIN_OWNER_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "averageIQ",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "baseURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "brainMaxLevel",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "brainz",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "getApproved",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+    ],
+    "name": "getGender",
+    "outputs": [
+      { "internalType": "enum SmolBrain.Gender", "name": "", "type": "uint8" }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_minter", "type": "address" }
+    ],
+    "name": "grantMinter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "grantOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "operator", "type": "address" }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_minter", "type": "address" }
+    ],
+    "name": "isMinter",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "isOwner",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "land",
+    "outputs": [
+      { "internalType": "contract Land", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "levelIQCost",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_to", "type": "address" }],
+    "name": "mintFemale",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_to", "type": "address" }],
+    "name": "mintMale",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "ownerOf",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+    ],
+    "name": "scanBrain",
+    "outputs": [{ "internalType": "uint256", "name": "IQ", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "school",
+    "outputs": [
+      { "internalType": "contract School", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+      { "internalType": "uint256", "name": "_iqEarned", "type": "uint256" }
+    ],
+    "name": "schoolDrop",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "operator", "type": "address" },
+      { "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "_baseURItoSet", "type": "string" }
+    ],
+    "name": "setBaseURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_land", "type": "address" }
+    ],
+    "name": "setLand",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_levelIQCost", "type": "uint256" }
+    ],
+    "name": "setLevelIQCost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_brainMaxLevel", "type": "uint256" }
+    ],
+    "name": "setMaxLevel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_school", "type": "address" }
+    ],
+    "name": "setSchool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
+    ],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+    ],
+    "name": "tokenURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/examples/token-erc721/package.json
+++ b/examples/token-erc721/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "ponder dev",
+    "start": "ponder start",
+    "codegen": "ponder codegen"
+  },
+  "dependencies": {
+    "@ponder/core": "workspace:latest"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.18",
+    "abitype": "^0.6.7",
+    "typescript": "^4.9.5",
+    "viem": "0.1.6"
+  }
+}

--- a/examples/token-erc721/ponder.config.ts
+++ b/examples/token-erc721/ponder.config.ts
@@ -1,0 +1,20 @@
+import type { PonderConfig } from "@ponder/core";
+
+export const config: PonderConfig = {
+  networks: [
+    {
+      name: "arbitrum",
+      chainId: 42161,
+      rpcUrl: process.env.PONDER_RPC_URL_42161,
+    },
+  ],
+  contracts: [
+    {
+      name: "SmolBrain",
+      network: "arbitrum",
+      abi: "./abis/SmolBrain.json",
+      address: "0x6325439389E0797Ab35752B4F43a14C004f22A9c",
+      startBlock: 3163146,
+    },
+  ],
+};

--- a/examples/token-erc721/schema.graphql
+++ b/examples/token-erc721/schema.graphql
@@ -1,0 +1,20 @@
+type Account @entity {
+  id: String!
+  tokens: [Token!]! @derivedFrom(field: "owner")
+  transferFromEvents: [TransferEvent!]! @derivedFrom(field: "from")
+  transferToEvents: [TransferEvent!]! @derivedFrom(field: "to")
+}
+
+type Token @entity {
+  id: BigInt!
+  owner: Account!
+  transferEvents: [TransferEvent!]! @derivedFrom(field: "tokenId")
+}
+
+type TransferEvent @entity {
+  id: String!
+  from: Account!
+  to: Account!
+  tokenId: BigInt!
+  timestamp: Int!
+}

--- a/examples/token-erc721/src/index.ts
+++ b/examples/token-erc721/src/index.ts
@@ -1,0 +1,41 @@
+import { ponder } from "@/generated";
+
+ponder.on("SmolBrain:Transfer", async ({ event, context }) => {
+  const { Account, Token, TransferEvent } = context.entities;
+
+  // Create an Account for the sender, or update the balance if it already exists.
+  await Account.upsert({
+    id: event.params.from,
+    create: {},
+    update: {},
+  });
+
+  // Create an Account for the recipient, or update the balance if it already exists.
+  await Account.upsert({
+    id: event.params.to,
+    create: {},
+    update: {},
+  });
+
+  // Create or update a Token.
+  await Token.upsert({
+    id: event.params.tokenId,
+    create: {
+      owner: event.params.to,
+    },
+    update: {
+      owner: event.params.to,
+    },
+  });
+
+  // Create a TransferEvent.
+  await TransferEvent.create({
+    id: event.log.id,
+    data: {
+      from: event.params.from,
+      to: event.params.to,
+      tokenId: event.params.tokenId,
+      timestamp: Number(event.block.timestamp),
+    },
+  });
+});

--- a/examples/token-erc721/tsconfig.json
+++ b/examples/token-erc721/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "rootDir": ".",
+    "paths": {
+      "@/generated": ["./generated/index.ts"]
+    }
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/src/event-store/postgres/format.ts
+++ b/packages/core/src/event-store/postgres/format.ts
@@ -4,7 +4,6 @@ import {
   type RpcLog,
   type RpcTransaction,
   hexToNumber,
-  transactionType,
 } from "viem";
 import { Address, Hash, Hex } from "viem";
 
@@ -78,7 +77,7 @@ type TransactionsTable = {
   v: Buffer; // BigInt
   value: Buffer; // BigInt
 
-  type: "legacy" | "eip2930" | "eip1559";
+  type: Hex;
   gasPrice: Buffer | null; // BigInt
   maxFeePerGas: Buffer | null; // BigInt
   maxPriorityFeePerGas: Buffer | null; // BigInt
@@ -115,7 +114,7 @@ export function rpcToPostgresTransaction(
     s: transaction.s,
     to: transaction.to ? transaction.to : null,
     transactionIndex: Number(transaction.transactionIndex),
-    type: transactionType[transaction.type],
+    type: transaction.type ?? "0x0",
     value: intToBlob(transaction.value),
     v: intToBlob(transaction.v),
   };

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -648,7 +648,9 @@ export class PostgresEventStore implements EventStore {
           transactionIndex: Number(result.log_transactionIndex),
         },
         block: {
-          baseFeePerGas: blobToBigInt(result.block_baseFeePerGas),
+          baseFeePerGas: result.block_baseFeePerGas
+            ? blobToBigInt(result.block_baseFeePerGas)
+            : null,
           difficulty: blobToBigInt(result.block_difficulty),
           extraData: result.block_extraData,
           gasLimit: blobToBigInt(result.block_gasLimit),

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -682,14 +682,28 @@ export class PostgresEventStore implements EventStore {
           transactionIndex: Number(result.tx_transactionIndex),
           value: blobToBigInt(result.tx_value),
           v: blobToBigInt(result.tx_v),
-          ...(result.tx_type === "legacy"
+          ...(result.tx_type === "0x0"
             ? {
-                type: result.tx_type,
+                type: "legacy",
                 gasPrice: blobToBigInt(result.tx_gasPrice),
               }
-            : result.tx_type === "eip1559"
+            : result.tx_type === "0x1"
             ? {
-                type: result.tx_type,
+                type: "eip2930",
+                gasPrice: blobToBigInt(result.tx_gasPrice),
+                accessList: JSON.parse(result.tx_accessList),
+              }
+            : result.tx_type === "0x2"
+            ? {
+                type: "eip1559",
+                maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
+                maxPriorityFeePerGas: blobToBigInt(
+                  result.tx_maxPriorityFeePerGas
+                ),
+              }
+            : result.tx_type === "0x7e"
+            ? {
+                type: "deposit",
                 maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
                 maxPriorityFeePerGas: blobToBigInt(
                   result.tx_maxPriorityFeePerGas
@@ -697,8 +711,6 @@ export class PostgresEventStore implements EventStore {
               }
             : {
                 type: result.tx_type,
-                gasPrice: blobToBigInt(result.tx_gasPrice),
-                accessList: JSON.parse(result.tx_accessList),
               }),
         },
       };

--- a/packages/core/src/event-store/sqlite/format.ts
+++ b/packages/core/src/event-store/sqlite/format.ts
@@ -4,7 +4,6 @@ import {
   type RpcLog,
   type RpcTransaction,
   hexToNumber,
-  transactionType,
 } from "viem";
 import { Address, Hash, Hex } from "viem";
 
@@ -78,7 +77,7 @@ type TransactionsTable = {
   v: Buffer; // BigInt
   value: Buffer; // BigInt
 
-  type: "legacy" | "eip2930" | "eip1559";
+  type: Hex;
   gasPrice: Buffer | null; // BigInt
   maxFeePerGas: Buffer | null; // BigInt
   maxPriorityFeePerGas: Buffer | null; // BigInt
@@ -115,7 +114,7 @@ export function rpcToSqliteTransaction(
     s: transaction.s,
     to: transaction.to ? transaction.to : null,
     transactionIndex: Number(transaction.transactionIndex),
-    type: transactionType[transaction.type],
+    type: transaction.type ?? "0x0",
     value: intToBlob(transaction.value),
     v: intToBlob(transaction.v),
   };

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -616,7 +616,9 @@ export class SqliteEventStore implements EventStore {
           transactionIndex: Number(result.log_transactionIndex),
         },
         block: {
-          baseFeePerGas: blobToBigInt(result.block_baseFeePerGas),
+          baseFeePerGas: result.block_baseFeePerGas
+            ? blobToBigInt(result.block_baseFeePerGas)
+            : null,
           difficulty: blobToBigInt(result.block_difficulty),
           extraData: result.block_extraData,
           gasLimit: blobToBigInt(result.block_gasLimit),

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -650,14 +650,28 @@ export class SqliteEventStore implements EventStore {
           transactionIndex: Number(result.tx_transactionIndex),
           value: blobToBigInt(result.tx_value),
           v: blobToBigInt(result.tx_v),
-          ...(result.tx_type === "legacy"
+          ...(result.tx_type === "0x0"
             ? {
-                type: result.tx_type,
+                type: "legacy",
                 gasPrice: blobToBigInt(result.tx_gasPrice),
               }
-            : result.tx_type === "eip1559"
+            : result.tx_type === "0x1"
             ? {
-                type: result.tx_type,
+                type: "eip2930",
+                gasPrice: blobToBigInt(result.tx_gasPrice),
+                accessList: JSON.parse(result.tx_accessList),
+              }
+            : result.tx_type === "0x2"
+            ? {
+                type: "eip1559",
+                maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
+                maxPriorityFeePerGas: blobToBigInt(
+                  result.tx_maxPriorityFeePerGas
+                ),
+              }
+            : result.tx_type === "0x7e"
+            ? {
+                type: "deposit",
                 maxFeePerGas: blobToBigInt(result.tx_maxFeePerGas),
                 maxPriorityFeePerGas: blobToBigInt(
                   result.tx_maxPriorityFeePerGas
@@ -665,8 +679,6 @@ export class SqliteEventStore implements EventStore {
               }
             : {
                 type: result.tx_type,
-                gasPrice: blobToBigInt(result.tx_gasPrice),
-                accessList: JSON.parse(result.tx_accessList),
               }),
         },
       };

--- a/packages/core/src/types/transaction.ts
+++ b/packages/core/src/types/transaction.ts
@@ -47,6 +47,16 @@ export type Transaction = Prettify<
       }
     | {
         /** Transaction type. */
+        type: "eip2930";
+        /** List of addresses and storage keys the transaction will access. */
+        accessList: AccessList;
+        /** Base fee per gas. Only present in legacy and EIP-2930 transactions. */
+        gasPrice: bigint;
+        maxFeePerGas?: never;
+        maxPriorityFeePerGas?: never;
+      }
+    | {
+        /** Transaction type. */
         type: "eip1559";
         accessList?: never;
         gasPrice?: never;
@@ -57,11 +67,19 @@ export type Transaction = Prettify<
       }
     | {
         /** Transaction type. */
-        type: "eip2930";
-        /** Base fee per gas. Only present in legacy and EIP-2930 transactions. */
-        gasPrice: bigint;
-        /** List of addresses and storage keys the transaction will access. */
-        accessList: AccessList;
+        type: "deposit";
+        accessList?: never;
+        gasPrice?: never;
+        /** Total fee per gas in wei (gasPrice/baseFeePerGas + maxPriorityFeePerGas). Only present in EIP-1559 transactions. */
+        maxFeePerGas: bigint;
+        /** Max priority fee per gas (in wei). Only present in EIP-1559 transactions. */
+        maxPriorityFeePerGas: bigint;
+      }
+    | {
+        /** Transaction type. */
+        type: Hex;
+        gasPrice?: never;
+        accessList?: never;
         maxFeePerGas?: never;
         maxPriorityFeePerGas?: never;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,21 @@ importers:
       typescript: 4.9.5
       viem: 0.1.6_typescript@4.9.5
 
+  examples/token-erc721:
+    specifiers:
+      '@ponder/core': workspace:latest
+      '@types/node': ^18.11.18
+      abitype: ^0.6.7
+      typescript: ^4.9.5
+      viem: 0.1.6
+    dependencies:
+      '@ponder/core': link:../../packages/core
+    devDependencies:
+      '@types/node': 18.16.18
+      abitype: 0.6.7_typescript@4.9.5
+      typescript: 4.9.5
+      viem: 0.1.6_typescript@4.9.5
+
   packages/core:
     specifiers:
       '@babel/code-frame': ^7.18.6


### PR DESCRIPTION
This PR adds an ERC271 example app for the Smol Brains NFT collection on Arbitrum. I also noticed some RPC provider inconsistencies while testing this out. Specifically, Alchemy seems to rename `transaction.type` to `transaction.arbType` for some bizarre reason. Quicknode works as expected.

I've ran into enough issues related to this specific field that it may be worth making it nullable in the database, but for now I added a default of `"0x0"` so that Alchemy still works.

Also fixed a bug where `block.baseFeePerGas` was assumed to be non-null when formatting event objects coming out of the event store.