### PR TITLE
Add support for Zora explorer URLs in `create-ponder`

### DIFF
--- a/.changeset/short-pumpkins-wash.md
+++ b/.changeset/short-pumpkins-wash.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Added support for explorer.zora.energy links in `create-ponder` etherscan template.

--- a/packages/create-ponder/src/helpers/getEtherscanChainId.ts
+++ b/packages/create-ponder/src/helpers/getEtherscanChainId.ts
@@ -62,6 +62,11 @@ const networkByEtherscanHostname: Record<
     chainId: 421613,
     apiUrl: "https://api-goerli.arbiscan.io/api",
   },
+  "explorer.zora.energy": {
+    name: "zora",
+    chainId: 7777777,
+    apiUrl: "https://explorer.zora.energy/api",
+  },
 };
 
 export const getNetworkByEtherscanHostname = (hostname: string) => {

--- a/packages/create-ponder/test/main.test.ts
+++ b/packages/create-ponder/test/main.test.ts
@@ -217,6 +217,65 @@ describe("create-ponder", () => {
         expect(JSON.parse(implementationAbiString).length).toBeGreaterThan(0);
       });
     });
+
+    describe("zora EIP-1967 proxy (ZoraNFTCreatorProxy)", () => {
+      const rootDir = path.join(tmpDir, randomUUID());
+
+      beforeAll(async () => {
+        await run(
+          {
+            projectName: "ZoraNFTCreatorProxy",
+            rootDir,
+            template: {
+              kind: TemplateKind.ETHERSCAN,
+              link: "https://explorer.zora.energy/address/0xA2c2A96A232113Dd4993E8b048EEbc3371AE8d85",
+            },
+          },
+          {
+            installCommand:
+              'export npm_config_LOCKFILE=false ; pnpm --silent --filter "." install',
+          }
+        );
+      });
+
+      test("creates project files and directories", async () => {
+        const root = fs.readdirSync(rootDir);
+        expect(root).toContain(".env.local");
+        expect(root).toContain(".gitignore");
+        expect(root).toContain("abis");
+        expect(root).toContain("generated");
+        expect(root).toContain("src");
+        expect(root).toContain("node_modules");
+        expect(root).toContain("package.json");
+        expect(root).toContain("ponder.config.ts");
+        expect(root).toContain("schema.graphql");
+        expect(root).toContain("tsconfig.json");
+      });
+
+      test("downloads abis", async () => {
+        const proxyAbiString = fs.readFileSync(
+          path.join(rootDir, `abis/ZoraNFTCreatorProxy.json`),
+          { encoding: "utf8" }
+        );
+        expect(JSON.parse(proxyAbiString).length).toBeGreaterThan(0);
+
+        const implementationAbiString = fs.readFileSync(
+          path.join(rootDir, `abis/ZoraNFTCreatorV1_0xe776.json`),
+          { encoding: "utf8" }
+        );
+        expect(JSON.parse(implementationAbiString).length).toBeGreaterThan(0);
+      });
+
+      test("creates codegen files", async () => {
+        const generated = fs.readdirSync(path.join(rootDir, "generated"));
+        expect(generated.sort()).toEqual(["index.ts", "schema.graphql"].sort());
+      });
+
+      test("creates src files", async () => {
+        const src = fs.readdirSync(path.join(rootDir, "src"));
+        expect(src.sort()).toEqual(["ZoraNFTCreatorProxy.ts"].sort());
+      });
+    });
   });
 
   describe("from subgraph id", () => {


### PR DESCRIPTION
This PR adds support for `explorer.zora.energy` contract page URLs in `create-ponder`.

**NOTE:** Conduit (the provider Zora is using) uses Blockscout for their explorer, which as of writing does not support the `?module=contract&action=getcontractcreation` endpoint. Without this endpoint, we can't find the contract's `startBlock` to write it into `ponder.config.ts`. This PR refactors the `etherscan` template code slightly to allow for this case.