### PR TITLE
Bump viem/abitype versions

### DIFF
--- a/.changeset/late-birds-scream.md
+++ b/.changeset/late-birds-scream.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": patch
+---
+
+Bumped `viem` and `abitype` versions.

--- a/.changeset/nervous-vans-arrive.md
+++ b/.changeset/nervous-vans-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where the Ponder server would occasionally fail to start due to a port detection race condition.

--- a/.changeset/smart-roses-return.md
+++ b/.changeset/smart-roses-return.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Bumped `viem` and `abitype` versions.

--- a/examples/art-gobblers/package.json
+++ b/examples/art-gobblers/package.json
@@ -10,8 +10,8 @@
     "@ponder/core": "workspace:latest"
   },
   "devDependencies": {
-    "abitype": "^0.6.7",
+    "abitype": "^0.8.11",
     "typescript": "^5.1.3",
-    "viem": "0.3.50"
+    "viem": "^1.2.6"
   }
 }

--- a/examples/ethfs/package.json
+++ b/examples/ethfs/package.json
@@ -10,8 +10,8 @@
     "@ponder/core": "workspace:latest"
   },
   "devDependencies": {
-    "abitype": "^0.6.7",
+    "abitype": "^0.8.11",
     "typescript": "^5.1.3",
-    "viem": "0.3.50"
+    "viem": "^1.2.6"
   }
 }

--- a/examples/token-erc20/package.json
+++ b/examples/token-erc20/package.json
@@ -9,9 +9,8 @@
     "@ponder/core": "workspace:latest"
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
-    "abitype": "^0.6.7",
-    "typescript": "^4.9.5",
-    "viem": "0.1.6"
+    "abitype": "^0.8.11",
+    "typescript": "^5.1.3",
+    "viem": "^1.2.6"
   }
 }

--- a/examples/token-erc721/package.json
+++ b/examples/token-erc721/package.json
@@ -9,9 +9,8 @@
     "@ponder/core": "workspace:latest"
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
-    "abitype": "^0.6.7",
-    "typescript": "^4.9.5",
-    "viem": "0.1.6"
+    "abitype": "^0.8.11",
+    "typescript": "^5.1.3",
+    "viem": "^1.2.6"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "retry": "^0.13.1",
     "stacktrace-parser": "^0.1.10",
     "tsc-alias": "^1.8.2",
-    "viem": "0.3.50"
+    "viem": "1.2.2"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "retry": "^0.13.1",
     "stacktrace-parser": "^0.1.10",
     "tsc-alias": "^1.8.2",
-    "viem": "1.2.2"
+    "viem": "^1.2.2"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3",
@@ -69,7 +69,7 @@
     "@types/react": "^18.0.25",
     "@types/retry": "^0.12.2",
     "@types/supertest": "^2.0.12",
-    "abitype": "^0.6.7",
+    "abitype": "^0.8.11",
     "module-alias": "^2.2.2",
     "supertest": "^6.3.3",
     "tsup": "^6.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "retry": "^0.13.1",
     "stacktrace-parser": "^0.1.10",
     "tsc-alias": "^1.8.2",
-    "viem": "^1.2.2"
+    "viem": "^1.2.6"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
     "chokidar": "^3.5.3",
     "cors": "^2.8.5",
     "data-uri-to-buffer": "3.0.1",
-    "detect-port": "^1.5.1",
     "dotenv": "^16.0.1",
     "emittery": "^0.13.1",
     "esbuild": "^0.15.2",

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -407,6 +407,8 @@ export class Ponder {
         this.eventHandlerService.metrics.totalMatchedEvents;
       this.uiService.ui.handlersToTimestamp =
         this.eventHandlerService.metrics.latestHandledEventTimestamp;
+
+      this.uiService.ui.port = this.serverService.port;
     }, 17);
 
     this.killFunctions.push(() => {
@@ -431,10 +433,6 @@ export class Ponder {
       this.uiService.ui.handlersToTimestamp =
         this.eventHandlerService.metrics.latestHandledEventTimestamp;
       this.uiService.render();
-    });
-
-    this.serverService.on("serverStarted", ({ port }) => {
-      this.uiService.ui.port = port;
     });
   }
 }

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -1,12 +1,16 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
 import request from "supertest";
-import { afterEach, expect, test, TestContext } from "vitest";
+import { afterEach, beforeEach, expect, test, TestContext } from "vitest";
 
+import { setupEventStore, setupUserStore } from "@/_test/setup";
 import { testNetworkConfig } from "@/_test/utils";
 import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
+
+beforeEach(async (context) => await setupEventStore(context));
+beforeEach(async (context) => await setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -1,12 +1,16 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
 import request from "supertest";
-import { afterEach, expect, test, TestContext } from "vitest";
+import { afterEach, beforeEach, expect, test, TestContext } from "vitest";
 
+import { setupEventStore, setupUserStore } from "@/_test/setup";
 import { testNetworkConfig } from "@/_test/utils";
 import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
+
+beforeEach(async (context) => await setupEventStore(context));
+beforeEach(async (context) => await setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/_test/utils.ts
+++ b/packages/core/src/_test/utils.ts
@@ -1,5 +1,9 @@
 import {
   type Chain,
+  type HttpTransport,
+  type PublicClient,
+  type TestClient,
+  type WalletClient,
   createPublicClient,
   createTestClient,
   createWalletClient,
@@ -19,7 +23,7 @@ import { Resources } from "@/Ponder";
 // ID of the current test worker. Used by the `@viem/anvil` proxy server.
 export const poolId = Number(process.env.VITEST_POOL_ID ?? 1);
 
-export const anvil = {
+export const anvil: Chain = {
   ...mainnet, // We are using a mainnet fork for testing.
   id: 1, // We configured our anvil instance to use `1` as the chain id (see `globalSetup.ts`);
   rpcUrls: {
@@ -32,7 +36,7 @@ export const anvil = {
       webSocket: [`ws://127.0.0.1:8545/${poolId}`],
     },
   },
-} as Chain;
+};
 
 export const testNetworkConfig = {
   name: "mainnet",
@@ -41,27 +45,28 @@ export const testNetworkConfig = {
   pollingInterval: 500,
 };
 
-export const testClient = createTestClient({
-  chain: anvil,
-  mode: "anvil",
-  transport: http(),
-});
+export const testClient: TestClient<"anvil", HttpTransport, Chain> =
+  createTestClient({
+    chain: anvil,
+    mode: "anvil",
+    transport: http(),
+  });
 
-export const publicClient = createPublicClient({
-  chain: anvil,
-  transport: http(),
-});
+export const publicClient: PublicClient<HttpTransport, Chain> =
+  createPublicClient({
+    chain: anvil,
+    transport: http(),
+  });
 
-export const walletClient = createWalletClient({
-  chain: anvil,
-  transport: http(),
-});
+export const walletClient: WalletClient<HttpTransport, Chain> =
+  createWalletClient({
+    chain: anvil,
+    transport: http(),
+  });
 
 export const testResources: Resources = {
+  options: buildOptions({ cliOptions: { configFile: "", rootDir: "" } }),
   logger: new LoggerService({ level: "silent" }),
-  options: buildOptions({
-    cliOptions: { configFile: "", rootDir: "" },
-  }),
   errors: new UserErrorService(),
   metrics: new MetricsService(),
 };

--- a/packages/core/src/event-aggregator/service.test.ts
+++ b/packages/core/src/event-aggregator/service.test.ts
@@ -1,12 +1,15 @@
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
+import { setupEventStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { Network } from "@/config/networks";
 
 import { EventAggregatorService } from "./service";
+
+beforeEach(async (context) => await setupEventStore(context));
 
 const mainnet: Network = {
   name: "mainnet",

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -1,7 +1,8 @@
 import { hexToNumber, RpcBlock, RpcLog, RpcTransaction } from "viem";
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
+import { setupEventStore } from "@/_test/setup";
 import { blobToBigInt } from "@/utils/decode";
 
 /**
@@ -9,6 +10,7 @@ import { blobToBigInt } from "@/utils/decode";
  * At the moment, this could be either a PostgresEventStore or a
  * SqliteEventStore; the tests run as expected either way.
  */
+beforeEach(async (context) => await setupEventStore(context));
 
 test("setup creates tables", async (context) => {
   const { eventStore } = context;

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -11,6 +11,7 @@ import { publicClient, testResources } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { Network } from "@/config/networks";
+import { wait } from "@/utils/wait";
 
 import { HistoricalSyncService } from "./service";
 
@@ -315,6 +316,10 @@ test("start() emits historicalCheckpoint event", async (context) => {
   service.start();
 
   await service.onIdle();
+
+  // TODO: Remove this. It's just a test to see if there's indeed a
+  // a race condition happening here.
+  await wait(300);
 
   expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
     timestamp: 1673275859, // Block timestamp of block 16369955

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -3,15 +3,18 @@ import {
   HttpRequestError,
   InvalidParamsRpcError,
 } from "viem";
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
+import { setupEventStore } from "@/_test/setup";
 import { publicClient, testResources } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { Network } from "@/config/networks";
 
 import { HistoricalSyncService } from "./service";
+
+beforeEach(async (context) => await setupEventStore(context));
 
 const { metrics, logger } = testResources;
 const network: Network = {

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -1,4 +1,8 @@
-import { HttpRequestError, InvalidParamsRpcError } from "viem";
+import {
+  EIP1193RequestFn,
+  HttpRequestError,
+  InvalidParamsRpcError,
+} from "viem";
 import { expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
@@ -18,6 +22,11 @@ const network: Network = {
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,
 };
+
+const rpcRequestSpy = vi.spyOn(
+  network.client as { request: EIP1193RequestFn },
+  "request"
+);
 
 const logFilters: LogFilter[] = [
   {
@@ -192,8 +201,7 @@ test("start() retries errors", async (context) => {
 test("start() handles Alchemy 'Log response size exceeded' error", async (context) => {
   const { eventStore } = context;
 
-  const spy = vi.spyOn(network.client, "request");
-  spy.mockRejectedValueOnce(
+  rpcRequestSpy.mockRejectedValueOnce(
     new InvalidParamsRpcError(
       new Error(
         // The suggested block range is 16369950 to 16369951.
@@ -232,8 +240,7 @@ test("start() handles Alchemy 'Log response size exceeded' error", async (contex
 test("start() handles Quicknode 'eth_getLogs and eth_newFilter are limited to a 10,000 blocks range' error", async (context) => {
   const { eventStore } = context;
 
-  const spy = vi.spyOn(network.client, "request");
-  spy.mockRejectedValueOnce(
+  rpcRequestSpy.mockRejectedValueOnce(
     new HttpRequestError({
       url: "http://",
       details:

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -320,6 +320,10 @@ test("start() emits historicalCheckpoint event", async (context) => {
   // TODO: Remove this. It's just a test to see if there's indeed a
   // a race condition happening here.
   await wait(300);
+  const logFilterCachedRanges = await eventStore.getLogFilterCachedRanges({
+    filterKey: logFilters[0].filter.key,
+  });
+  console.log(logFilterCachedRanges);
 
   expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
     timestamp: 1673275859, // Block timestamp of block 16369955

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -559,9 +559,9 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     }
 
     for (const blockTask of blockTasks) {
-      this.queue.addTask(blockTask, {
-        priority: Number.MAX_SAFE_INTEGER - blockTask.blockNumberToCacheFrom,
-      });
+      const priority =
+        Number.MAX_SAFE_INTEGER - blockTask.blockNumberToCacheFrom;
+      this.queue.addTask(blockTask, { priority });
     }
 
     this.metrics.ponder_historical_scheduled_tasks.inc(

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
 
 import { accounts, usdcContractConfig, vitalik } from "@/_test/constants";
-import { resetTestClient } from "@/_test/setup";
+import { resetTestClient, setupEventStore } from "@/_test/setup";
 import {
   publicClient,
   testClient,
@@ -16,6 +16,9 @@ import { blobToBigInt } from "@/utils/decode";
 import { range } from "@/utils/range";
 
 import { RealtimeSyncService } from "./service";
+
+beforeEach(async (context) => await setupEventStore(context));
+beforeEach(async () => await resetTestClient());
 
 const network: Network = {
   name: "mainnet",
@@ -60,10 +63,6 @@ const sendUsdcTransferTransaction = async () => {
     account: vitalik.account,
   });
 };
-
-beforeEach(async () => {
-  return await resetTestClient();
-});
 
 test("setup() returns the finalized block number", async (context) => {
   const { eventStore } = context;

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -1,7 +1,8 @@
 import { buildSchema as buildGraphqlSchema } from "graphql";
 import request from "supertest";
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 
+import { setupUserStore } from "@/_test/setup";
 import { testResources } from "@/_test/utils";
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
@@ -10,6 +11,8 @@ import { range } from "@/utils/range";
 
 import { buildGqlSchema } from "./graphql/buildGqlSchema";
 import { ServerService } from "./service";
+
+beforeEach(async (context) => await setupUserStore(context));
 
 const userSchema = buildGraphqlSchema(`
   ${schemaHeader}

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -1,12 +1,15 @@
 import { getFunctionSelector, hexToBigInt } from "viem";
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants";
+import { setupEventStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
 import { Contract } from "@/config/contracts";
 import { Network } from "@/config/networks";
 
 import { getInjectedContract } from "./contract";
+
+beforeEach(async (context) => await setupEventStore(context));
 
 const network: Network = {
   name: "mainnet",

--- a/packages/core/src/user-handlers/contract.ts
+++ b/packages/core/src/user-handlers/contract.ts
@@ -1,12 +1,15 @@
 import {
+  type Abi,
+  type BaseError,
+  type CallParameters,
+  type GetContractReturnType,
+  type Hex,
+  type PublicClient,
   type ReadContractParameters,
-  BaseError,
-  CallParameters,
   decodeFunctionResult,
   encodeFunctionData,
   getContract,
   getContractError,
-  Hex,
 } from "viem";
 
 import type { Contract } from "@/config/contracts";
@@ -20,7 +23,7 @@ export function getInjectedContract({
   contract: Contract;
   getCurrentBlockNumber: () => bigint;
   eventStore: EventStore;
-}) {
+}): GetContractReturnType<Abi, PublicClient> {
   const { abi, address } = contract;
   const { chainId, client: publicClient } = contract.network;
 

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -1,6 +1,7 @@
 import { buildSchema as buildGraphqlSchema } from "graphql";
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 
+import { setupUserStore } from "@/_test/setup";
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 
@@ -9,6 +10,7 @@ import { buildSchema } from "@/schema/schema";
  * At the moment, this could be either a PostgresUserStore or a
  * SqliteUserStore; the tests run as expected either way.
  */
+beforeEach(async (context) => await setupUserStore(context));
 
 const graphqlSchema = buildGraphqlSchema(`
   ${schemaHeader}

--- a/packages/core/src/utils/wait.ts
+++ b/packages/core/src/utils/wait.ts
@@ -1,3 +1,7 @@
-export async function wait(time: number) {
-  return new Promise((res) => setTimeout(res, time));
+/** Waits a specified amount of time.
+ *
+ * @param milliseconds Number of milliseconds to wait.
+ */
+export async function wait(milliseconds: number) {
+  return new Promise<void>((res) => setTimeout(res, milliseconds));
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,8 +13,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "abitype": ["node_modules/abitype/dist"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src"],

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -24,7 +24,7 @@
     "picocolors": "^1.0.0",
     "prettier": "^2.6.2",
     "prompts": "^2.4.2",
-    "rimraf": "^4.1.2",
+    "rimraf": "^5.0.1",
     "yaml": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -166,9 +166,9 @@ export const run = async (
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
-        "abitype": "^0.6.7",
+        "abitype": "^0.8.11",
         "typescript": "^4.9.5",
-        "viem": "0.1.6"
+        "viem": "^1.2.2"
       }
     }
   `;

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -168,7 +168,7 @@ export const run = async (
         "@types/node": "^18.11.18",
         "abitype": "^0.8.11",
         "typescript": "^5.1.3",
-        "viem": "^1.2.2"
+        "viem": "^1.2.6"
       }
     }
   `;

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -167,7 +167,7 @@ export const run = async (
       "devDependencies": {
         "@types/node": "^18.11.18",
         "abitype": "^0.8.11",
-        "typescript": "^4.9.5",
+        "typescript": "^5.1.3",
         "viem": "^1.2.2"
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,7 @@ importers:
       '@types/retry': ^0.12.2
       '@types/supertest': ^2.0.12
       '@viem/anvil': ^0.0.5
-      abitype: ^0.6.7
+      abitype: ^0.8.11
       async-mutex: ^0.4.0
       better-sqlite3: '7'
       cac: ^6.7.14
@@ -195,7 +195,7 @@ importers:
       tsc-alias: ^1.8.2
       tsup: ^6.7.0
       typescript: ^5.1.3
-      viem: 1.2.2
+      viem: ^1.2.2
       vite: ^4.1.4
       vitest: ^0.29.2
     dependencies:
@@ -247,7 +247,7 @@ importers:
       '@types/react': 18.0.25
       '@types/retry': 0.12.2
       '@types/supertest': 2.0.12
-      abitype: 0.6.7_typescript@5.1.3
+      abitype: 0.8.11_typescript@5.1.3
       module-alias: 2.2.2
       supertest: 6.3.3
       tsup: 6.7.0_typescript@5.1.3
@@ -4152,6 +4152,18 @@ packages:
     peerDependencies:
       typescript: '>=4.9.4'
       zod: '>=3.19.1'
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+    dev: true
+
+  /abitype/0.8.11_typescript@5.1.3:
+    resolution: {integrity: sha512-bM4v2dKvX08sZ9IU38IN5BKmN+ZkOSd2oI4a9f0ejHYZQYV6cDr7j+d95ga0z2XHG36Y4jzoG5Z7qDqxp7fi/A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
     peerDependenciesMeta:
       zod:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,58 +89,54 @@ importers:
   examples/art-gobblers:
     specifiers:
       '@ponder/core': workspace:latest
-      abitype: ^0.6.7
+      abitype: ^0.8.11
       typescript: ^5.1.3
-      viem: 0.3.50
+      viem: ^1.2.6
     dependencies:
       '@ponder/core': link:../../packages/core
     devDependencies:
-      abitype: 0.6.7_typescript@5.1.3
+      abitype: 0.8.11_typescript@5.1.3
       typescript: 5.1.3
-      viem: 0.3.50_typescript@5.1.3
+      viem: 1.2.6_typescript@5.1.3
 
   examples/ethfs:
     specifiers:
       '@ponder/core': workspace:latest
-      abitype: ^0.6.7
+      abitype: ^0.8.11
       typescript: ^5.1.3
-      viem: 0.3.50
+      viem: ^1.2.6
     dependencies:
       '@ponder/core': link:../../packages/core
     devDependencies:
-      abitype: 0.6.7_typescript@5.1.3
+      abitype: 0.8.11_typescript@5.1.3
       typescript: 5.1.3
-      viem: 0.3.50_typescript@5.1.3
+      viem: 1.2.6_typescript@5.1.3
 
   examples/token-erc20:
     specifiers:
       '@ponder/core': workspace:latest
-      '@types/node': ^18.11.18
-      abitype: ^0.6.7
-      typescript: ^4.9.5
-      viem: 0.1.6
+      abitype: ^0.8.11
+      typescript: ^5.1.3
+      viem: ^1.2.6
     dependencies:
       '@ponder/core': link:../../packages/core
     devDependencies:
-      '@types/node': 18.16.18
-      abitype: 0.6.7_typescript@4.9.5
-      typescript: 4.9.5
-      viem: 0.1.6_typescript@4.9.5
+      abitype: 0.8.11_typescript@5.1.3
+      typescript: 5.1.3
+      viem: 1.2.6_typescript@5.1.3
 
   examples/token-erc721:
     specifiers:
       '@ponder/core': workspace:latest
-      '@types/node': ^18.11.18
-      abitype: ^0.6.7
-      typescript: ^4.9.5
-      viem: 0.1.6
+      abitype: ^0.8.11
+      typescript: ^5.1.3
+      viem: ^1.2.6
     dependencies:
       '@ponder/core': link:../../packages/core
     devDependencies:
-      '@types/node': 18.16.18
-      abitype: 0.6.7_typescript@4.9.5
-      typescript: 4.9.5
-      viem: 0.1.6_typescript@4.9.5
+      abitype: 0.8.11_typescript@5.1.3
+      typescript: 5.1.3
+      viem: 1.2.6_typescript@5.1.3
 
   packages/core:
     specifiers:
@@ -194,7 +190,7 @@ importers:
       tsc-alias: ^1.8.2
       tsup: ^6.7.0
       typescript: ^5.1.3
-      viem: ^1.2.2
+      viem: ^1.2.6
       vite: ^4.1.4
       vitest: ^0.29.2
     dependencies:
@@ -230,7 +226,7 @@ importers:
       retry: 0.13.1
       stacktrace-parser: 0.1.10
       tsc-alias: 1.8.2
-      viem: 1.2.2_typescript@5.1.3
+      viem: 1.2.6_typescript@5.1.3
     devDependencies:
       '@types/babel__code-frame': 7.0.3
       '@types/better-sqlite3': 7.6.0
@@ -4060,17 +4056,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@wagmi/chains/0.2.25_typescript@4.9.5:
-    resolution: {integrity: sha512-Gah0bgR+14navwxi7xTL2oFB8YgK4qoBPye1b8ucccIwF3Z8Zg1u2gVTDFAyPT4lyB+ZVqwYKs3Y/IkFNG5O4Q==}
-    peerDependencies:
-      typescript: '>=4.9.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 4.9.5
-    dev: true
-
   /@wagmi/chains/1.0.0_typescript@5.1.3:
     resolution: {integrity: sha512-eNbqRWyHbivcMNq5tbXJks4NaOzVLHnNQauHPeE/EDT9AlpqzcrMc+v2T1/2Iw8zN4zgqB86NCsxeJHJs7+xng==}
     peerDependencies:
@@ -4091,7 +4076,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.3
-    dev: false
 
   /@whatwg-node/events/0.0.3:
     resolution: {integrity: sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==}
@@ -4145,18 +4129,6 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /abitype/0.6.7_typescript@5.1.3:
-    resolution: {integrity: sha512-PFiyVoR09ZYqOG8/LJg9T1CTsYzfBRcyp5sNQYq7PRZ4oZ+c3yp22GFIeP99pTrMEQxuoA3pq4f0kEjWyVqOSQ==}
-    peerDependencies:
-      typescript: '>=4.9.4'
-      zod: '>=3.19.1'
-    peerDependenciesMeta:
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.1.3
-    dev: true
-
   /abitype/0.8.11_typescript@5.1.3:
     resolution: {integrity: sha512-bM4v2dKvX08sZ9IU38IN5BKmN+ZkOSd2oI4a9f0ejHYZQYV6cDr7j+d95ga0z2XHG36Y4jzoG5Z7qDqxp7fi/A==}
     peerDependencies:
@@ -4167,7 +4139,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.3
-    dev: true
 
   /abitype/0.8.7_typescript@5.1.3:
     resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
@@ -4179,6 +4150,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.3
+    dev: true
 
   /abort-controller/3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -7842,13 +7814,6 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /idna-uts46-hx/4.1.2:
-    resolution: {integrity: sha512-EAB3egrcalcTQHcjA7yzXXkE4E09TIFerR//4yUYGYCeCfXmkU0LgsGJgYSIQA1lQunfsn4ZCWJhbelgl3cdiQ==}
-    engines: {node: '>=16.15.1', npm: '>=8.11.1'}
-    dependencies:
-      punycode: 2.3.0
-    dev: true
-
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -8397,14 +8362,6 @@ packages:
       ws: '*'
     dependencies:
       ws: 8.12.0
-
-  /isomorphic-ws/5.0.0_ws@8.13.0:
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '*'
-    dependencies:
-      ws: 8.13.0
-    dev: true
 
   /isstream/0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -12819,22 +12776,6 @@ packages:
       vfile-message: 3.1.3
     dev: false
 
-  /viem/0.1.6_typescript@4.9.5:
-    resolution: {integrity: sha512-ffbavU8RBGYltzr0huE2NLJFKH5eeaEsWReoLD6r7rBxBWWWgdUoGx1UnAKtT4Q+GN3r0G7v673JXIKKRuT7Uw==}
-    dependencies:
-      '@noble/hashes': 1.3.0
-      '@wagmi/chains': 0.2.25_typescript@4.9.5
-      abitype: 0.6.7_typescript@4.9.5
-      idna-uts46-hx: 4.1.2
-      isomorphic-ws: 5.0.0_ws@8.13.0
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: true
-
   /viem/0.3.50_typescript@5.1.3:
     resolution: {integrity: sha512-s+LxCYZTR9F/qPk1/n1YDVAX9vSeVz7GraqBZWGrDuenCJxo9ArCoIceJ6ksI0WwSeNzcZ0VVbD/kWRzTxkipw==}
     dependencies:
@@ -12854,8 +12795,8 @@ packages:
       - zod
     dev: true
 
-  /viem/1.2.2_typescript@5.1.3:
-    resolution: {integrity: sha512-wpYGUSlY++XSMBoY4vKq8XKWNeKlv0EpEHiooElSZ6XNoh8txE+FJR+Hutlnak1uCS8X1DG3Xhmhppac53YLsA==}
+  /viem/1.2.6_typescript@5.1.3:
+    resolution: {integrity: sha512-3tWiUb0D8dbFj66rUGLg6TKJjH98ZziomkyCyI0evqJFYdNfiEG0K2Ns07MlOXZZF4sGe+a5Mj15DaDOwm7sgw==}
     peerDependencies:
       typescript: '>=5.0.4'
     dependencies:
@@ -12865,7 +12806,7 @@ packages:
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
       '@wagmi/chains': 1.2.0_typescript@5.1.3
-      abitype: 0.8.7_typescript@5.1.3
+      abitype: 0.8.11_typescript@5.1.3
       isomorphic-ws: 5.0.0_ws@8.12.0
       typescript: 5.1.3
       ws: 8.12.0
@@ -12873,7 +12814,6 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
-    dev: false
 
   /vite-node/0.29.2_@types+node@18.16.18:
     resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
@@ -13224,6 +13164,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
       tsc-alias: ^1.8.2
       tsup: ^6.7.0
       typescript: ^5.1.3
-      viem: 0.3.50
+      viem: 1.2.2
       vite: ^4.1.4
       vitest: ^0.29.2
     dependencies:
@@ -232,7 +232,7 @@ importers:
       retry: 0.13.1
       stacktrace-parser: 0.1.10
       tsc-alias: 1.8.2
-      viem: 0.3.50_typescript@5.1.3
+      viem: 1.2.2_typescript@5.1.3
     devDependencies:
       '@types/babel__code-frame': 7.0.3
       '@types/better-sqlite3': 7.6.0
@@ -270,7 +270,7 @@ importers:
       picocolors: ^1.0.0
       prettier: ^2.6.2
       prompts: ^2.4.2
-      rimraf: ^4.1.2
+      rimraf: ^5.0.1
       tsup: ^6.6.3
       typescript: ^4.5.5
       vitest: ^0.29.2
@@ -283,7 +283,7 @@ importers:
       picocolors: 1.0.0
       prettier: 2.8.2
       prompts: 2.4.2
-      rimraf: 4.1.2
+      rimraf: 5.0.1
       yaml: 2.1.1
     devDependencies:
       '@ponder/core': link:../core
@@ -2753,6 +2753,18 @@ packages:
       multiformats: 9.9.0
     dev: true
 
+  /@isaacs/cliui/8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width/4.2.3
+      strip-ansi: 7.0.1
+      strip-ansi-cjs: /strip-ansi/6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi/7.0.0
+    dev: false
+
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -3207,6 +3219,13 @@ packages:
       tslib: 2.5.3
       webcrypto-core: 1.7.7
     dev: true
+
+  /@pkgjs/parseargs/0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@pkgr/utils/2.3.1:
     resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
@@ -4063,6 +4082,18 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.3
+    dev: true
+
+  /@wagmi/chains/1.2.0_typescript@5.1.3:
+    resolution: {integrity: sha512-dmDRipsE54JfyudOBkuhEexqQWcrZqxn/qiujG8SBzMh/az/AH5xlJSA+j1CPWTx9+QofSMF3B7A4gb6XRmSaQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+    dev: false
 
   /@whatwg-node/events/0.0.3:
     resolution: {integrity: sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==}
@@ -4225,7 +4256,6 @@ packages:
   /ansi-regex/6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -4247,7 +4277,6 @@ packages:
   /ansi-styles/6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansicolors/0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
@@ -5660,7 +5689,6 @@ packages:
 
   /eastasianwidth/0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /ecc-jsbn/0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -5722,7 +5750,6 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /encodeurl/1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -7129,6 +7156,14 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /foreground-child/3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.0.2
+    dev: false
+
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
@@ -7373,6 +7408,18 @@ packages:
     dependencies:
       is-glob: 4.0.3
     dev: true
+
+  /glob/10.3.1:
+    resolution: {integrity: sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.2.1
+      minimatch: 9.0.2
+      minipass: 6.0.2
+      path-scurry: 1.10.0
+    dev: false
 
   /glob/7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -8406,6 +8453,15 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /jackspeak/2.2.1:
+    resolution: {integrity: sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: false
+
   /jake/10.8.7:
     resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
     engines: {node: '>=10'}
@@ -8782,7 +8838,6 @@ packages:
   /lru-cache/9.1.2:
     resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -9447,6 +9502,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch/9.0.2:
+    resolution: {integrity: sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -9483,7 +9545,6 @@ packages:
   /minipass/6.0.2:
     resolution: {integrity: sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /minizlib/2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -10210,6 +10271,14 @@ packages:
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
+
+  /path-scurry/1.10.0:
+    resolution: {integrity: sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 9.1.2
+      minipass: 6.0.2
+    dev: false
 
   /path-scurry/1.9.2:
     resolution: {integrity: sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==}
@@ -11119,11 +11188,12 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rimraf/4.1.2:
-    resolution: {integrity: sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==}
+  /rimraf/5.0.1:
+    resolution: {integrity: sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==}
     engines: {node: '>=14'}
-    deprecated: Please upgrade to 4.3.1 or higher to fix a potentially damaging issue regarding symbolic link following. See https://github.com/isaacs/rimraf/issues/259 for details.
     hasBin: true
+    dependencies:
+      glob: 10.3.1
     dev: false
 
   /ripemd160/2.0.2:
@@ -11392,6 +11462,11 @@ packages:
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  /signal-exit/4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
+    dev: false
+
   /simple-concat/1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
     dev: false
@@ -11616,7 +11691,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.0.1
-    dev: true
 
   /string.prototype.matchall/4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
@@ -11712,7 +11786,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom-string/1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -12784,6 +12857,28 @@ packages:
       - typescript
       - utf-8-validate
       - zod
+    dev: true
+
+  /viem/1.2.2_typescript@5.1.3:
+    resolution: {integrity: sha512-wpYGUSlY++XSMBoY4vKq8XKWNeKlv0EpEHiooElSZ6XNoh8txE+FJR+Hutlnak1uCS8X1DG3Xhmhppac53YLsA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.0
+      '@noble/curves': 1.0.0
+      '@noble/hashes': 1.3.0
+      '@scure/bip32': 1.3.0
+      '@scure/bip39': 1.2.0
+      '@wagmi/chains': 1.2.0_typescript@5.1.3
+      abitype: 0.8.7_typescript@5.1.3
+      isomorphic-ws: 5.0.0_ws@8.12.0
+      typescript: 5.1.3
+      ws: 8.12.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
 
   /vite-node/0.29.2_@types+node@18.16.18:
     resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
@@ -13086,7 +13181,15 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
+
+  /wrap-ansi/8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.0.1
+    dev: false
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,6 @@ importers:
       chokidar: ^3.5.3
       cors: ^2.8.5
       data-uri-to-buffer: 3.0.1
-      detect-port: ^1.5.1
       dotenv: ^16.0.1
       emittery: ^0.13.1
       esbuild: ^0.15.2
@@ -208,7 +207,6 @@ importers:
       chokidar: 3.5.3
       cors: 2.8.5
       data-uri-to-buffer: 3.0.1
-      detect-port: 1.5.1
       dotenv: 16.0.1
       emittery: 0.13.1
       esbuild: 0.15.4
@@ -4227,11 +4225,6 @@ packages:
     hasBin: true
     dev: true
 
-  /address/1.2.2:
-    resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
-    engines: {node: '>= 10.0.0'}
-    dev: false
-
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -5573,16 +5566,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       execa: 5.1.1
-    dev: false
-
-  /detect-port/1.5.1:
-    resolution: {integrity: sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==}
-    hasBin: true
-    dependencies:
-      address: 1.2.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /dezalgo/1.0.4:


### PR DESCRIPTION
This PR bumps viem to `1.2.2` and abitype to `0.8.11` for both `@ponder/core` internals and in the development dependencies of projects created using `create-ponder`.

### Other bugfixes
- Fixed a bug where the Ponder server would occasionally fail to start due to a port detection race condition.
