### PR TITLE
Fix historical sync race condition

### DIFF
--- a/.changeset/metal-boats-protect.md
+++ b/.changeset/metal-boats-protect.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a race condition bug in the historical sync service

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -53,17 +53,17 @@ export async function setupEventStore(context: TestContext) {
     const pool = new Pool({ connectionString: process.env.DATABASE_URL });
     const databaseSchema = `vitest_pool_${process.pid}_${poolId}`;
     context.eventStore = new PostgresEventStore({ pool, databaseSchema });
+    await context.eventStore.migrateUp();
+
+    return async () => {
+      await pool.query(`DROP SCHEMA IF EXISTS "${databaseSchema}" CASCADE`);
+    };
   } else {
     const rawSqliteDb = new SqliteDatabase(":memory:");
     const db = patchSqliteDatabase({ db: rawSqliteDb });
     context.eventStore = new SqliteEventStore({ db });
+    await context.eventStore.migrateUp();
   }
-
-  await context.eventStore.migrateUp();
-
-  return async () => {
-    await context.eventStore.migrateDown();
-  };
 }
 
 /**

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -46,9 +46,17 @@ export interface EventStore {
     logFilterRange: {
       logFilterKey: string;
       blockNumberToCacheFrom: number;
-      logFilterStartBlockNumber: number;
     };
+  }): Promise<void>;
+
+  mergeLogFilterCachedRanges(options: {
+    logFilterKey: string;
+    logFilterStartBlockNumber: number;
   }): Promise<{ startingRangeEndTimestamp: number }>;
+
+  getLogFilterCachedRanges(options: {
+    filterKey: string;
+  }): Promise<LogFilterCachedRange[]>;
 
   insertUnfinalizedBlock(options: {
     chainId: number;
@@ -66,10 +74,6 @@ export interface EventStore {
     chainId: number;
     toBlockNumber: number;
   }): Promise<void>;
-
-  getLogFilterCachedRanges(options: {
-    filterKey: string;
-  }): Promise<LogFilterCachedRange[]>;
 
   insertContractReadResult(options: {
     address: string;

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -11,7 +11,6 @@ import { publicClient, testResources } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { Network } from "@/config/networks";
-import { wait } from "@/utils/wait";
 
 import { HistoricalSyncService } from "./service";
 
@@ -316,14 +315,6 @@ test("start() emits historicalCheckpoint event", async (context) => {
   service.start();
 
   await service.onIdle();
-
-  // TODO: Remove this. It's just a test to see if there's indeed a
-  // a race condition happening here.
-  await wait(300);
-  const logFilterCachedRanges = await eventStore.getLogFilterCachedRanges({
-    filterKey: logFilters[0].filter.key,
-  });
-  console.log(logFilterCachedRanges);
 
   expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
     timestamp: 1673275859, // Block timestamp of block 16369955

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -293,10 +293,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       // Merge all cached ranges once last time before emitting the `syncComplete` event.
       await Promise.all(
         this.logFilters.map((logFilter) =>
-          this.eventStore.mergeLogFilterCachedRanges({
-            logFilterKey: logFilter.filter.key,
-            logFilterStartBlockNumber: logFilter.filter.startBlock,
-          })
+          this.updateHistoricalCheckpoint({ logFilter })
         )
       );
 
@@ -623,6 +620,14 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       },
     });
 
+    await this.updateHistoricalCheckpoint({ logFilter });
+  };
+
+  updateHistoricalCheckpoint = async ({
+    logFilter,
+  }: {
+    logFilter: LogFilter;
+  }) => {
     const { startingRangeEndTimestamp } =
       await this.eventStore.mergeLogFilterCachedRanges({
         logFilterKey: logFilter.filter.key,

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -14,7 +14,7 @@ import type { EventStore } from "@/event-store/store";
 import { LoggerService } from "@/logs/service";
 import { MetricsService } from "@/metrics/service";
 import { formatEta, formatPercentage } from "@/utils/format";
-import { type Queue, createQueue } from "@/utils/queue";
+import { type Queue, type Worker, createQueue } from "@/utils/queue";
 import { startClock } from "@/utils/timer";
 
 import { findMissingIntervals } from "./intervals";
@@ -273,18 +273,47 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
   };
 
   private buildQueue = () => {
-    const worker = async ({ task }: { task: LogSyncTask | BlockSyncTask }) => {
-      switch (task.kind) {
-        case "LOG_SYNC": {
-          return this.logTaskWorker({ task });
-        }
-        case "BLOCK_SYNC": {
-          return this.blockTaskWorker({ task });
-        }
+    const worker: Worker<LogSyncTask | BlockSyncTask> = async ({
+      task,
+      queue,
+    }) => {
+      if (task.kind === "LOG_SYNC") {
+        await this.logTaskWorker({ task });
+      } else {
+        await this.blockTaskWorker({ task });
       }
+
+      // If this is not the final task, return.
+      if (queue.size > 0 || queue.pending > 1) return;
+
+      // If this is the final task, run the cleanup/completion logic.
+
+      // It's possible for multiple block sync tasks to run simultaneously,
+      // resulting in a scenario where cached ranges are not fully merged.
+      // Merge all cached ranges once last time before emitting the `syncComplete` event.
+      await Promise.all(
+        this.logFilters.map((logFilter) =>
+          this.eventStore.mergeLogFilterCachedRanges({
+            logFilterKey: logFilter.filter.key,
+            logFilterStartBlockNumber: logFilter.filter.startBlock,
+          })
+        )
+      );
+
+      this.stats.duration = this.stats.endDuration();
+      this.stats.isComplete = true;
+      this.emit("syncComplete");
+      this.logger.info({
+        service: "historical",
+        msg: `Completed sync in ${formatEta(this.stats.duration)} (network=${
+          this.network.name
+        })`,
+        network: this.network.name,
+        duration: this.stats.duration,
+      });
     };
 
-    const queue = createQueue<LogSyncTask | BlockSyncTask, unknown, any>({
+    const queue = createQueue<LogSyncTask | BlockSyncTask>({
       worker,
       options: { concurrency: 10, autoStart: false },
       onAdd: ({ task }) => {
@@ -471,20 +500,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
             : task.blockNumberToCacheFrom);
         queue.addTask(task, { priority, retry: true });
       },
-      onIdle: () => {
-        if (this.stats.isComplete) return;
-        this.stats.duration = this.stats.endDuration();
-        this.stats.isComplete = true;
-        this.emit("syncComplete");
-        this.logger.info({
-          service: "historical",
-          msg: `Completed sync in ${formatEta(this.stats.duration)} (network=${
-            this.network.name
-          })`,
-          network: this.network.name,
-          duration: this.stats.duration,
-        });
-      },
     });
 
     return queue;
@@ -598,16 +613,20 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       requiredTxHashes.has(tx.hash)
     );
 
+    await this.eventStore.insertFinalizedBlock({
+      chainId: this.network.chainId,
+      block,
+      transactions,
+      logFilterRange: {
+        logFilterKey: logFilter.filter.key,
+        blockNumberToCacheFrom,
+      },
+    });
+
     const { startingRangeEndTimestamp } =
-      await this.eventStore.insertFinalizedBlock({
-        chainId: this.network.chainId,
-        block,
-        transactions,
-        logFilterRange: {
-          logFilterKey: logFilter.filter.key,
-          blockNumberToCacheFrom,
-          logFilterStartBlockNumber: logFilter.filter.startBlock,
-        },
+      await this.eventStore.mergeLogFilterCachedRanges({
+        logFilterKey: logFilter.filter.key,
+        logFilterStartBlockNumber: logFilter.filter.startBlock,
       });
 
     this.logFilterCheckpoints[logFilter.name] = Math.max(


### PR DESCRIPTION
Flaky tests made it clear that the historical sync service was occasionally failing to fully merge log filter cached intervals before emitting the `syncComplete` event. This was caused by a race condition. The previous design was relying on the block task worker to merge cached intervals after inserting the new one, which was unsafe because the multiple merge operations could occur at the same time. The fix introduced here adds some logic to the queue worker to merge all intervals on the last task in the queue.