### PR TITLE
Reorg reconciliation tests

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -293,10 +293,12 @@ export class Ponder {
       this.serverService.reload({ graphqlSchema });
 
       await this.eventHandlerService.reset({ schema });
+      await this.eventHandlerService.processEvents();
     });
 
     this.reloadService.on("newHandlers", async ({ handlers }) => {
       await this.eventHandlerService.reset({ handlers });
+      await this.eventHandlerService.processEvents();
     });
 
     this.networkSyncServices.forEach((networkSyncService) => {
@@ -342,6 +344,7 @@ export class Ponder {
       "reorg",
       async ({ commonAncestorTimestamp }) => {
         await this.eventHandlerService.handleReorg({ commonAncestorTimestamp });
+        await this.eventHandlerService.processEvents();
       }
     );
 

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { CodegenService } from "@/codegen/service";
 import { buildContracts } from "@/config/contracts";
 import { buildDatabase } from "@/config/database";
-import { buildLogFilters, LogFilter } from "@/config/logFilters";
+import { type LogFilter, buildLogFilters } from "@/config/logFilters";
 import { type Network, buildNetwork } from "@/config/networks";
 import { type PonderOptions } from "@/config/options";
 import { type ResolvedPonderConfig } from "@/config/ponderConfig";
@@ -292,11 +292,11 @@ export class Ponder {
 
       this.serverService.reload({ graphqlSchema });
 
-      this.eventHandlerService.reset({ schema });
+      await this.eventHandlerService.reset({ schema });
     });
 
     this.reloadService.on("newHandlers", async ({ handlers }) => {
-      this.eventHandlerService.reset({ handlers });
+      await this.eventHandlerService.reset({ handlers });
     });
 
     this.networkSyncServices.forEach((networkSyncService) => {

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -9,8 +9,8 @@ import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
-beforeEach(setupEventStore);
-beforeEach(setupUserStore);
+beforeEach((context) => setupEventStore(context));
+beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -9,8 +9,8 @@ import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
-beforeEach(async (context) => await setupEventStore(context));
-beforeEach(async (context) => await setupUserStore(context));
+beforeEach(setupEventStore);
+beforeEach(setupUserStore);
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -9,8 +9,8 @@ import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
-beforeEach(setupEventStore);
-beforeEach(setupUserStore);
+beforeEach((context) => setupEventStore(context));
+beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -9,8 +9,8 @@ import { buildOptions } from "@/config/options";
 import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
-beforeEach(async (context) => await setupEventStore(context));
-beforeEach(async (context) => await setupUserStore(context));
+beforeEach(setupEventStore);
+beforeEach(setupUserStore);
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildPonderConfig({

--- a/packages/core/src/event-aggregator/service.test.ts
+++ b/packages/core/src/event-aggregator/service.test.ts
@@ -9,7 +9,7 @@ import { Network } from "@/config/networks";
 
 import { EventAggregatorService } from "./service";
 
-beforeEach(setupEventStore);
+beforeEach((context) => setupEventStore(context));
 
 const mainnet: Network = {
   name: "mainnet",

--- a/packages/core/src/event-aggregator/service.test.ts
+++ b/packages/core/src/event-aggregator/service.test.ts
@@ -9,7 +9,7 @@ import { Network } from "@/config/networks";
 
 import { EventAggregatorService } from "./service";
 
-beforeEach(async (context) => await setupEventStore(context));
+beforeEach(setupEventStore);
 
 const mainnet: Network = {
   name: "mainnet",

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -212,8 +212,12 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
     this.recalculateFinalityCheckpoint();
   };
 
-  handleReorg = ({ timestamp }: { timestamp: number }) => {
-    this.emit("reorg", { commonAncestorTimestamp: timestamp });
+  handleReorg = ({
+    commonAncestorTimestamp,
+  }: {
+    commonAncestorTimestamp: number;
+  }) => {
+    this.emit("reorg", { commonAncestorTimestamp });
   };
 
   private recalculateCheckpoint = () => {

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -13,7 +13,7 @@ import {
 import { setupEventStore } from "@/_test/setup";
 import { blobToBigInt } from "@/utils/decode";
 
-beforeEach(setupEventStore);
+beforeEach((context) => setupEventStore(context));
 
 test("setup creates tables", async (context) => {
   const { eventStore } = context;

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -13,12 +13,7 @@ import {
 import { setupEventStore } from "@/_test/setup";
 import { blobToBigInt } from "@/utils/decode";
 
-/**
- * This test suite uses the `store` object injected during setup.
- * At the moment, this could be either a PostgresEventStore or a
- * SqliteEventStore; the tests run as expected either way.
- */
-beforeEach(async (context) => await setupEventStore(context));
+beforeEach(setupEventStore);
 
 test("setup creates tables", async (context) => {
   const { eventStore } = context;

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -14,7 +14,7 @@ import { Network } from "@/config/networks";
 
 import { HistoricalSyncService } from "./service";
 
-beforeEach(setupEventStore);
+beforeEach((context) => setupEventStore(context));
 
 const { metrics, logger } = testResources;
 const network: Network = {

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -14,7 +14,7 @@ import { Network } from "@/config/networks";
 
 import { HistoricalSyncService } from "./service";
 
-beforeEach(async (context) => await setupEventStore(context));
+beforeEach(setupEventStore);
 
 const { metrics, logger } = testResources;
 const network: Network = {

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -15,15 +15,21 @@ export class MetricsService {
   ponder_historical_total_blocks: prometheus.Gauge<"network" | "logFilter">;
   ponder_historical_cached_blocks: prometheus.Gauge<"network" | "logFilter">;
   ponder_historical_completed_blocks: prometheus.Gauge<"network" | "logFilter">;
-
   ponder_historical_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
   >;
+
   ponder_realtime_latest_block_number: prometheus.Gauge<"network">;
   ponder_realtime_latest_block_timestamp: prometheus.Gauge<"network">;
   ponder_realtime_rpc_request_duration: prometheus.Histogram<
     "network" | "method"
   >;
+
+  ponder_handlers_matched_events: prometheus.Gauge<"eventName">;
+  ponder_handlers_handled_events: prometheus.Gauge<"eventName">;
+  ponder_handlers_processed_events: prometheus.Gauge<"eventName">;
+  ponder_handlers_has_error: prometheus.Gauge;
+  ponder_handlers_latest_processed_timestamp: prometheus.Gauge;
 
   constructor() {
     this.registry = new prometheus.Registry();
@@ -91,6 +97,36 @@ export class MetricsService {
       help: "Duration of RPC requests completed during the realtime sync",
       labelNames: ["network", "method"] as const,
       buckets: httpRequestBucketsInMs,
+      registers: [this.registry],
+    });
+
+    // Handlers metrics
+    this.ponder_handlers_matched_events = new prometheus.Gauge({
+      name: "ponder_handlers_matched_events",
+      help: "Number of available events for all log filters",
+      labelNames: ["eventName"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_handlers_handled_events = new prometheus.Gauge({
+      name: "ponder_handlers_handled_events",
+      help: "Number of available events for which there is a handler function registered",
+      labelNames: ["eventName"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_handlers_processed_events = new prometheus.Gauge({
+      name: "ponder_handlers_processed_events",
+      help: "Number of available events that have been processed",
+      labelNames: ["eventName"] as const,
+      registers: [this.registry],
+    });
+    this.ponder_handlers_has_error = new prometheus.Gauge({
+      name: "ponder_handlers_has_error",
+      help: "Boolean (0 or 1) indicating if an error was encountered while running handlers",
+      registers: [this.registry],
+    });
+    this.ponder_handlers_latest_processed_timestamp = new prometheus.Gauge({
+      name: "ponder_handlers_latest_processed_timestamp",
+      help: "Block timestamp of the latest processed event",
       registers: [this.registry],
     });
   }

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -17,7 +17,7 @@ import { range } from "@/utils/range";
 
 import { RealtimeSyncService } from "./service";
 
-beforeEach(setupEventStore);
+beforeEach((context) => setupEventStore(context));
 beforeEach(async () => await resetTestClient());
 
 const network: Network = {

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -17,7 +17,7 @@ import { range } from "@/utils/range";
 
 import { RealtimeSyncService } from "./service";
 
-beforeEach(async (context) => await setupEventStore(context));
+beforeEach(setupEventStore);
 beforeEach(async () => await resetTestClient());
 
 const network: Network = {

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -12,7 +12,7 @@ import { range } from "@/utils/range";
 import { buildGqlSchema } from "./graphql/buildGqlSchema";
 import { ServerService } from "./service";
 
-beforeEach(setupUserStore);
+beforeEach((context) => setupUserStore(context));
 
 const userSchema = buildGraphqlSchema(`
   ${schemaHeader}

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -12,7 +12,7 @@ import { range } from "@/utils/range";
 import { buildGqlSchema } from "./graphql/buildGqlSchema";
 import { ServerService } from "./service";
 
-beforeEach(async (context) => await setupUserStore(context));
+beforeEach(setupUserStore);
 
 const userSchema = buildGraphqlSchema(`
   ${schemaHeader}

--- a/packages/core/src/ui/service.ts
+++ b/packages/core/src/ui/service.ts
@@ -1,6 +1,5 @@
 import { LogFilter } from "@/config/logFilters";
 import { Resources } from "@/Ponder";
-import { formatEta } from "@/utils/format";
 
 import { buildUiState, setupInkApp, UiState } from "./app";
 
@@ -10,7 +9,6 @@ export class UiService {
 
   ui: UiState;
   renderInterval: NodeJS.Timer;
-  etaInterval: NodeJS.Timer;
   render: () => void;
   unmount: () => void;
 
@@ -36,6 +34,7 @@ export class UiService {
     }
 
     this.renderInterval = setInterval(async () => {
+      // Historical sync
       const totalBlocksMetric =
         await this.resources.metrics.ponder_historical_total_blocks.get();
       const cachedBlocksMetric =
@@ -60,48 +59,40 @@ export class UiService {
           completedBlocks;
       });
 
+      // Handlers
+      const matchedEventsMetric =
+        await this.resources.metrics.ponder_handlers_matched_events.get();
+      const handledEventsMetric =
+        await this.resources.metrics.ponder_handlers_handled_events.get();
+      const processedEventsMetric =
+        await this.resources.metrics.ponder_handlers_processed_events.get();
+      const latestProcessedTimestampMetric =
+        await this.resources.metrics.ponder_handlers_latest_processed_timestamp.get();
+
+      this.ui.handlersTotal = matchedEventsMetric.values.reduce(
+        (a, v) => a + v.value,
+        0
+      );
+      this.ui.handlersHandledTotal = handledEventsMetric.values.reduce(
+        (a, v) => a + v.value,
+        0
+      );
+      this.ui.handlersCurrent = processedEventsMetric.values.reduce(
+        (a, v) => a + v.value,
+        0
+      );
+      this.ui.handlersToTimestamp =
+        latestProcessedTimestampMetric.values[0].value ?? 0;
+
+      // Errors
+      this.ui.handlerError = this.resources.errors.hasUserError;
+
       this.render();
     }, 17);
-
-    this.etaInterval = setInterval(() => {
-      if (!this.resources.options.uiEnabled) this.logHistoricalSyncProgress();
-    }, 1000);
   }
 
   kill() {
-    this.unmount();
     clearInterval(this.renderInterval);
-    clearInterval(this.etaInterval);
-  }
-
-  private logHistoricalSyncProgress() {
-    if (this.ui.isHistoricalSyncComplete) return;
-
-    this.logFilters.forEach((contract) => {
-      const stat = this.ui.historicalSyncLogFilterStats[contract.name];
-      const { startTimestamp, cachedBlocks, totalBlocks, completedBlocks } =
-        stat;
-
-      const currentCompletionRate =
-        (cachedBlocks + completedBlocks) / totalBlocks;
-
-      const eta =
-        (Date.now() - startTimestamp * 1000) / // Elapsed time in seconds
-        (completedBlocks / (totalBlocks - cachedBlocks)); // Progress
-
-      const isDone = currentCompletionRate === 1;
-      if (isDone) return;
-      const etaText =
-        stat.completedBlocks > 5 && eta > 0
-          ? `~${formatEta(eta)}`
-          : "not started";
-
-      const countText = `${cachedBlocks + completedBlocks}/${totalBlocks}`;
-
-      // this.resources.logger.info(
-      //   "historical",
-      //   `${contract.name}: ${`(${etaText + " | " + countText})`}`
-      // );
-    });
+    this.unmount();
   }
 }

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -9,7 +9,7 @@ import { Network } from "@/config/networks";
 
 import { getInjectedContract } from "./contract";
 
-beforeEach(async (context) => await setupEventStore(context));
+beforeEach(setupEventStore);
 
 const network: Network = {
   name: "mainnet",

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -7,9 +7,9 @@ import { publicClient } from "@/_test/utils";
 import { Contract } from "@/config/contracts";
 import { Network } from "@/config/networks";
 
-import { getInjectedContract } from "./contract";
+import { buildReadOnlyContracts } from "./contract";
 
-beforeEach(setupEventStore);
+beforeEach((context) => setupEventStore(context));
 
 const network: Network = {
   name: "mainnet",
@@ -20,12 +20,14 @@ const network: Network = {
   finalityBlockCount: 10,
 };
 
-const contract: Contract = {
-  name: "USDC",
-  address: usdcContractConfig.address,
-  abi: usdcContractConfig.abi,
-  network: network,
-};
+const contracts: Contract[] = [
+  {
+    name: "USDC",
+    address: usdcContractConfig.address,
+    abi: usdcContractConfig.abi,
+    network: network,
+  },
+];
 
 // Test data generated from Alchemy Composer.
 const usdcTotalSupply16375000 = 40921687992499550n;
@@ -34,26 +36,28 @@ const usdcTotalSupply16380000 = 40695630049769550n; // This is "latest" for our 
 test("getInjectedContract() returns data", async (context) => {
   const { eventStore } = context;
 
-  const injectedContract = getInjectedContract({
-    contract,
+  const readOnlyContracts = buildReadOnlyContracts({
+    contracts,
     getCurrentBlockNumber: () => 16375000n,
     eventStore,
   });
+  const contract = readOnlyContracts["USDC"];
 
-  const decimals = await injectedContract.read.decimals();
+  const decimals = await contract.read.decimals();
   expect(decimals).toBe(6);
 });
 
 test("getInjectedContract() uses current block number if no overrides are provided", async (context) => {
   const { eventStore } = context;
 
-  const injectedContract = getInjectedContract({
-    contract,
+  const readOnlyContracts = buildReadOnlyContracts({
+    contracts,
     getCurrentBlockNumber: () => 16375000n,
     eventStore,
   });
+  const contract = readOnlyContracts["USDC"];
 
-  const totalSupply = await injectedContract.read.totalSupply();
+  const totalSupply = await contract.read.totalSupply();
 
   expect(totalSupply).toBe(usdcTotalSupply16375000);
 });
@@ -61,15 +65,16 @@ test("getInjectedContract() uses current block number if no overrides are provid
 test("getInjectedContract() caches the read result if no overrides are provided", async (context) => {
   const { eventStore } = context;
 
-  const callSpy = vi.spyOn(contract.network.client, "call");
+  const callSpy = vi.spyOn(network.client, "call");
 
-  const injectedContract = getInjectedContract({
-    contract,
+  const readOnlyContracts = buildReadOnlyContracts({
+    contracts,
     getCurrentBlockNumber: () => 16375000n,
     eventStore,
   });
+  const contract = readOnlyContracts["USDC"];
 
-  await injectedContract.read.totalSupply();
+  await contract.read.totalSupply();
 
   expect(callSpy).toHaveBeenCalledTimes(1);
 
@@ -91,13 +96,14 @@ test("getInjectedContract() caches the read result if no overrides are provided"
 test("getInjectedContract() uses blockTag override if provided", async (context) => {
   const { eventStore } = context;
 
-  const injectedContract = getInjectedContract({
-    contract,
+  const readOnlyContracts = buildReadOnlyContracts({
+    contracts,
     getCurrentBlockNumber: () => 16375000n,
     eventStore,
   });
+  const contract = readOnlyContracts["USDC"];
 
-  const totalSupply = await injectedContract.read.totalSupply({
+  const totalSupply = await contract.read.totalSupply({
     blockTag: "latest",
   });
 
@@ -107,13 +113,14 @@ test("getInjectedContract() uses blockTag override if provided", async (context)
 test("getInjectedContract() does not cache data if blockTag override is provided", async (context) => {
   const { eventStore } = context;
 
-  const injectedContract = getInjectedContract({
-    contract,
+  const readOnlyContracts = buildReadOnlyContracts({
+    contracts,
     getCurrentBlockNumber: () => 16375000n,
     eventStore,
   });
+  const contract = readOnlyContracts["USDC"];
 
-  await injectedContract.read.totalSupply({
+  await contract.read.totalSupply({
     blockTag: "latest",
   });
 

--- a/packages/core/src/user-handlers/contract.ts
+++ b/packages/core/src/user-handlers/contract.ts
@@ -15,60 +15,99 @@ import {
 import type { Contract } from "@/config/contracts";
 import type { EventStore } from "@/event-store/store";
 
-export function getInjectedContract({
-  contract,
-  getCurrentBlockNumber,
+export function buildReadOnlyContracts({
+  contracts,
   eventStore,
+  getCurrentBlockNumber,
 }: {
-  contract: Contract;
-  getCurrentBlockNumber: () => bigint;
+  contracts: Contract[];
   eventStore: EventStore;
-}): GetContractReturnType<Abi, PublicClient> {
-  const { abi, address } = contract;
-  const { chainId, client: publicClient } = contract.network;
+  getCurrentBlockNumber: () => bigint;
+}) {
+  return contracts.reduce<
+    Record<string, GetContractReturnType<Abi, PublicClient>>
+  >((acc, { name, abi, address, network }) => {
+    const { chainId, client: publicClient } = network;
 
-  const injectedContract = getContract({ abi, address, publicClient });
+    const readOnlyContract = getContract({ abi, address, publicClient });
 
-  injectedContract.read = new Proxy(
-    {},
-    {
-      get(_, functionName: string) {
-        return async (
-          ...parameters: [
-            args?: readonly unknown[],
-            options?: Omit<
-              ReadContractParameters,
-              "abi" | "address" | "functionName" | "args"
-            >
-          ]
-        ) => {
-          const { args, options } = getFunctionParameters(parameters);
+    readOnlyContract.read = new Proxy(
+      {},
+      {
+        get(_, functionName: string) {
+          return async (
+            ...parameters: [
+              args?: readonly unknown[],
+              options?: Omit<
+                ReadContractParameters,
+                "abi" | "address" | "functionName" | "args"
+              >
+            ]
+          ) => {
+            const { args, options } = getFunctionParameters(parameters);
 
-          // If the user specified a block tag, serve the request as normal (no caching).
-          if (options?.blockTag) {
-            return publicClient.readContract({
-              abi,
-              address,
-              functionName,
-              args,
-              ...options,
-            } as ReadContractParameters);
-          }
-
-          // If the user specified a block number, use it, otherwise use the
-          // block number of the current event being handled.
-          const blockNumber = options?.blockNumber ?? getCurrentBlockNumber();
-
-          const calldata = encodeFunctionData({ abi, args, functionName });
-
-          const decodeRawResult = (rawResult: Hex) => {
-            try {
-              return decodeFunctionResult({
+            // If the user specified a block tag, serve the request as normal (no caching).
+            if (options?.blockTag) {
+              return publicClient.readContract({
                 abi,
-                args,
+                address,
                 functionName,
-                data: rawResult,
+                args,
+                ...options,
+              } as ReadContractParameters);
+            }
+
+            // If the user specified a block number, use it, otherwise use the
+            // block number of the current event being handled.
+            const blockNumber = options?.blockNumber ?? getCurrentBlockNumber();
+
+            const calldata = encodeFunctionData({ abi, args, functionName });
+
+            const decodeRawResult = (rawResult: Hex) => {
+              try {
+                return decodeFunctionResult({
+                  abi,
+                  args,
+                  functionName,
+                  data: rawResult,
+                });
+              } catch (err) {
+                throw getContractError(err as BaseError, {
+                  abi,
+                  address,
+                  args,
+                  docsPath: "/docs/contract/readContract",
+                  functionName,
+                });
+              }
+            };
+
+            // Check if this request can be served from the cache.
+            const cachedContractReadResult =
+              await eventStore.getContractReadResult({
+                address,
+                blockNumber,
+                chainId,
+                data: calldata,
               });
+
+            if (cachedContractReadResult) {
+              return decodeRawResult(cachedContractReadResult.result);
+            }
+
+            // Cache miss. Make the RPC request, then add to the cache.
+            let rawResult: Hex;
+            try {
+              const { data } = await publicClient.call({
+                data: calldata,
+                to: address,
+                ...{
+                  ...options,
+                  blockNumber,
+                },
+              } as unknown as CallParameters);
+
+              rawResult = data || "0x";
             } catch (err) {
               throw getContractError(err as BaseError, {
                 abi,
@@ -78,60 +117,26 @@ export function getInjectedContract({
                 functionName,
               });
             }
-          };
 
-          // Check if this request can be served from the cache.
-          const cachedContractReadResult =
-            await eventStore.getContractReadResult({
+            await eventStore.insertContractReadResult({
               address,
               blockNumber,
               chainId,
               data: calldata,
+              finalized: false,
+              result: rawResult,
             });
 
-          if (cachedContractReadResult) {
-            return decodeRawResult(cachedContractReadResult.result);
-          }
+            return decodeRawResult(rawResult);
+          };
+        },
+      }
+    );
 
-          // Cache miss. Make the RPC request, then add to the cache.
-          let rawResult: Hex;
-          try {
-            const { data } = await publicClient.call({
-              data: calldata,
-              to: address,
-              ...{
-                ...options,
-                blockNumber,
-              },
-            } as unknown as CallParameters);
+    acc[name] = readOnlyContract;
 
-            rawResult = data || "0x";
-          } catch (err) {
-            throw getContractError(err as BaseError, {
-              abi,
-              address,
-              args,
-              docsPath: "/docs/contract/readContract",
-              functionName,
-            });
-          }
-
-          await eventStore.insertContractReadResult({
-            address,
-            blockNumber,
-            chainId,
-            data: calldata,
-            finalized: false,
-            result: rawResult,
-          });
-
-          return decodeRawResult(rawResult);
-        };
-      },
-    }
-  );
-
-  return injectedContract;
+    return acc;
+  }, {});
 }
 
 function getFunctionParameters(

--- a/packages/core/src/user-handlers/model.ts
+++ b/packages/core/src/user-handlers/model.ts
@@ -1,0 +1,56 @@
+import { Schema } from "@/schema/types";
+import { Model } from "@/types/model";
+import { ModelInstance, UserStore } from "@/user-store/store";
+
+export function buildModels({
+  userStore,
+  schema,
+  getCurrentEventTimestamp,
+}: {
+  userStore: UserStore;
+  schema: Schema;
+  getCurrentEventTimestamp: () => number;
+}) {
+  return schema.entities.reduce<Record<string, Model<ModelInstance>>>(
+    (acc, { name: modelName }) => {
+      acc[modelName] = {
+        findUnique: ({ id }) =>
+          userStore.findUnique({
+            modelName,
+            timestamp: getCurrentEventTimestamp(),
+            id,
+          }),
+        create: ({ id, data }) =>
+          userStore.create({
+            modelName,
+            timestamp: getCurrentEventTimestamp(),
+            id,
+            data,
+          }),
+        update: ({ id, data }) =>
+          userStore.update({
+            modelName,
+            timestamp: getCurrentEventTimestamp(),
+            id,
+            data,
+          }),
+        upsert: ({ id, create, update }) =>
+          userStore.upsert({
+            modelName,
+            timestamp: getCurrentEventTimestamp(),
+            id,
+            create,
+            update,
+          }),
+        delete: ({ id }) =>
+          userStore.delete({
+            modelName,
+            timestamp: getCurrentEventTimestamp(),
+            id,
+          }),
+      };
+      return acc;
+    },
+    {}
+  );
+}

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -13,8 +13,8 @@ import { buildSchema } from "@/schema/schema";
 
 import { EventHandlerService } from "./service";
 
-beforeEach(setupEventStore);
-beforeEach(setupUserStore);
+beforeEach((context) => setupEventStore(context));
+beforeEach((context) => setupUserStore(context));
 
 const network = {
   name: "mainnet",

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -1,0 +1,263 @@
+import { buildSchema as buildGraphqlSchema } from "graphql";
+import { getAbiItem, getEventSelector } from "viem";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { usdcContractConfig } from "@/_test/constants";
+import { setupEventStore, setupUserStore } from "@/_test/setup";
+import { publicClient, testResources } from "@/_test/utils";
+import { encodeLogFilterKey } from "@/config/logFilterKey";
+import { LogFilter } from "@/config/logFilters";
+import { EventAggregatorService } from "@/event-aggregator/service";
+import { schemaHeader } from "@/reload/readGraphqlSchema";
+import { buildSchema } from "@/schema/schema";
+
+import { EventHandlerService } from "./service";
+
+beforeEach(setupEventStore);
+beforeEach(setupUserStore);
+
+const network = {
+  name: "mainnet",
+  chainId: 1,
+  client: publicClient,
+  pollingInterval: 1_000,
+  defaultMaxBlockRange: 3,
+  finalityBlockCount: 10,
+};
+
+const logFilters: LogFilter[] = [
+  {
+    name: "USDC",
+    ...usdcContractConfig,
+    network: network.name,
+    filter: {
+      key: encodeLogFilterKey({
+        chainId: network.chainId,
+        address: usdcContractConfig.address,
+      }),
+      chainId: network.chainId,
+      startBlock: 16369950,
+      // Note: the service uses the `finalizedBlockNumber` as the end block if undefined.
+      endBlock: undefined,
+    },
+  },
+];
+
+const contracts = [{ name: "USDC", ...usdcContractConfig, network }];
+
+const schema = buildSchema(
+  buildGraphqlSchema(`${schemaHeader}
+    type TestEntity @entity {
+      id: String!
+    }
+  `)
+);
+
+const transferHandler = vi.fn();
+
+const handlers = {
+  USDC: {
+    Transfer: transferHandler,
+  },
+};
+
+const handledLogFilters = {
+  USDC: [
+    {
+      eventName: "Transfer",
+      topic0: getEventSelector(
+        "Transfer(address indexed from, address indexed to, uint256 amount)"
+      ),
+      abiItem: getAbiItem({
+        abi: usdcContractConfig.abi,
+        name: "Transfer",
+      }),
+    },
+  ],
+};
+
+const getEvents = vi.fn(() => ({
+  totalEventCount: 5,
+  events: [
+    {
+      logFilterName: "USDC",
+      eventName: "Transfer",
+      params: {},
+      log: {},
+      block: {},
+      transaction: {},
+    },
+  ],
+}));
+
+const eventAggregatorService = {
+  getEvents,
+  checkpoint: 0,
+} as unknown as EventAggregatorService;
+
+beforeEach(() => {
+  // Restore getEvents to the initial implementation.
+  vi.restoreAllMocks();
+  eventAggregatorService.checkpoint = 0;
+});
+
+test("processEvents() calls event handler functions", async (context) => {
+  const { eventStore, userStore } = context;
+
+  const service = new EventHandlerService({
+    resources: testResources,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+
+  await service.reset({ schema, handlers });
+
+  await service.processEvents({ toTimestamp: 10 });
+
+  expect(transferHandler).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event: {
+        logFilterName: "USDC",
+        eventName: "Transfer",
+        params: {},
+        log: {},
+        block: {},
+        transaction: {},
+        name: "Transfer",
+      },
+      context: {
+        contracts: expect.anything(),
+        entities: expect.anything(),
+      },
+    })
+  );
+
+  service.kill();
+});
+
+test("processEvents() calls getEvents with expected parameters", async (context) => {
+  const { eventStore, userStore } = context;
+
+  const service = new EventHandlerService({
+    resources: testResources,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+
+  await service.reset({ schema, handlers });
+
+  await service.processEvents({ toTimestamp: 10 });
+
+  expect(getEvents).toHaveBeenLastCalledWith({
+    fromTimestamp: 0,
+    toTimestamp: 10,
+    handledLogFilters,
+  });
+
+  await service.processEvents({ toTimestamp: 50 });
+
+  expect(getEvents).toHaveBeenLastCalledWith({
+    fromTimestamp: 11,
+    toTimestamp: 50,
+    handledLogFilters,
+  });
+
+  service.kill();
+});
+
+test("reset() processes events after resetting", async (context) => {
+  const { eventStore, userStore } = context;
+
+  const service = new EventHandlerService({
+    resources: testResources,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+
+  await service.reset({ schema, handlers });
+
+  eventAggregatorService.checkpoint = 10;
+  await service.processEvents({ toTimestamp: 10 });
+
+  expect(getEvents).toHaveBeenLastCalledWith({
+    fromTimestamp: 0,
+    toTimestamp: 10,
+    handledLogFilters,
+  });
+
+  eventAggregatorService.checkpoint = 15;
+  await service.reset({ schema, handlers });
+
+  expect(getEvents).toHaveBeenLastCalledWith({
+    fromTimestamp: 0,
+    toTimestamp: 15,
+    handledLogFilters,
+  });
+
+  service.kill();
+});
+
+test("handleReorg() reverts the user store", async (context) => {
+  const { eventStore, userStore } = context;
+
+  const userStoreRevertSpy = vi.spyOn(userStore, "revert");
+
+  const service = new EventHandlerService({
+    resources: testResources,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+
+  await service.reset({ schema, handlers });
+
+  await service.processEvents({ toTimestamp: 10 });
+
+  await service.handleReorg({ commonAncestorTimestamp: 6 });
+
+  expect(userStoreRevertSpy).toHaveBeenLastCalledWith({ safeTimestamp: 6 });
+
+  service.kill();
+});
+
+test("handleReorg() processes events between the reorg timestamp and the checkpoint", async (context) => {
+  const { eventStore, userStore } = context;
+
+  const service = new EventHandlerService({
+    resources: testResources,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+
+  await service.reset({ schema, handlers });
+
+  eventAggregatorService.checkpoint = 10;
+  await service.processEvents({ toTimestamp: 10 });
+
+  // This simulates a scenario where there was a reorg back to 6
+  // and the new latest block is 9.
+  eventAggregatorService.checkpoint = 9;
+  await service.handleReorg({ commonAncestorTimestamp: 6 });
+
+  expect(getEvents).toHaveBeenLastCalledWith({
+    fromTimestamp: 7,
+    toTimestamp: 9,
+    handledLogFilters,
+  });
+
+  service.kill();
+});

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -115,7 +115,8 @@ test("processEvents() calls event handler functions", async (context) => {
 
   await service.reset({ schema, handlers });
 
-  await service.processEvents({ toTimestamp: 10 });
+  eventAggregatorService.checkpoint = 10;
+  await service.processEvents();
 
   expect(transferHandler).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -152,7 +153,8 @@ test("processEvents() calls getEvents with expected parameters", async (context)
 
   await service.reset({ schema, handlers });
 
-  await service.processEvents({ toTimestamp: 10 });
+  eventAggregatorService.checkpoint = 10;
+  await service.processEvents();
 
   expect(getEvents).toHaveBeenLastCalledWith({
     fromTimestamp: 0,
@@ -160,7 +162,8 @@ test("processEvents() calls getEvents with expected parameters", async (context)
     handledLogFilters,
   });
 
-  await service.processEvents({ toTimestamp: 50 });
+  eventAggregatorService.checkpoint = 50;
+  await service.processEvents();
 
   expect(getEvents).toHaveBeenLastCalledWith({
     fromTimestamp: 11,
@@ -186,7 +189,7 @@ test("reset() processes events after resetting", async (context) => {
   await service.reset({ schema, handlers });
 
   eventAggregatorService.checkpoint = 10;
-  await service.processEvents({ toTimestamp: 10 });
+  await service.processEvents();
 
   expect(getEvents).toHaveBeenLastCalledWith({
     fromTimestamp: 0,
@@ -222,7 +225,8 @@ test("handleReorg() reverts the user store", async (context) => {
 
   await service.reset({ schema, handlers });
 
-  await service.processEvents({ toTimestamp: 10 });
+  eventAggregatorService.checkpoint = 10;
+  await service.processEvents();
 
   await service.handleReorg({ commonAncestorTimestamp: 6 });
 
@@ -246,7 +250,7 @@ test("handleReorg() processes events between the reorg timestamp and the checkpo
   await service.reset({ schema, handlers });
 
   eventAggregatorService.checkpoint = 10;
-  await service.processEvents({ toTimestamp: 10 });
+  await service.processEvents();
 
   // This simulates a scenario where there was a reorg back to 6
   // and the new latest block is 9.

--- a/packages/core/src/user-handlers/service.ts
+++ b/packages/core/src/user-handlers/service.ts
@@ -21,23 +21,12 @@ import type { ModelInstance, UserStore } from "@/user-store/store";
 import { prettyPrint } from "@/utils/print";
 import { type Queue, type Worker, createQueue } from "@/utils/queue";
 
-import { getInjectedContract } from "./contract";
+import { buildReadOnlyContracts } from "./contract";
+import { buildModels } from "./model";
 import { getStackTrace } from "./trace";
 
 type EventHandlerEvents = {
-  reset: undefined;
-  eventsProcessed: { count: number; toTimestamp: number };
-  taskCompleted: undefined;
-};
-
-type EventHandlerMetrics = {
-  error: boolean;
-
-  eventsAddedToQueue: number;
-  eventsProcessedFromQueue: number;
-  totalMatchedEvents: number;
-
-  latestHandledEventTimestamp: number;
+  eventsProcessed: { toTimestamp: number };
 };
 
 type SetupTask = { kind: "SETUP" };
@@ -51,13 +40,10 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
   private eventAggregatorService: EventAggregatorService;
   private logFilters: LogFilter[];
 
-  metrics: EventHandlerMetrics = {
-    error: false,
-    eventsAddedToQueue: 0,
-    eventsProcessedFromQueue: 0,
-    totalMatchedEvents: 0,
-    latestHandledEventTimestamp: 0,
-  };
+  private readOnlyContracts: Record<string, ReadOnlyContract> = {};
+
+  private schema?: Schema;
+  private models: Record<string, Model<ModelInstance>> = {};
 
   private handlers?: Handlers;
   private handledLogFilters: Record<
@@ -69,17 +55,14 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
     }[]
   > = {};
 
-  private schema?: Schema;
+  private eventProcessingMutex: Mutex;
   private queue?: EventHandlerQueue;
 
-  private injectedContracts: Record<string, ReadOnlyContract> = {};
-
-  private eventProcessingMutex: Mutex;
-  private eventsHandledToTimestamp = 0;
+  private eventsProcessedToTimestamp = 0;
+  private hasError = false;
 
   private currentEventBlockNumber = 0n;
   private currentEventTimestamp = 0;
-  private hasEventHandlerError = false;
 
   constructor({
     resources,
@@ -102,14 +85,12 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
     this.eventAggregatorService = eventAggregatorService;
     this.logFilters = logFilters;
 
-    // Build the injected contract objects here.
-    // They depend only on contract config, so they can't be hot reloaded.
-    contracts.forEach((contract) => {
-      this.injectedContracts[contract.name] = getInjectedContract({
-        contract,
-        getCurrentBlockNumber: () => this.currentEventBlockNumber,
-        eventStore,
-      });
+    // The read-only contract objects only depend on config, so they can
+    // be built in the constructor (they can't be hot-reloaded).
+    this.readOnlyContracts = buildReadOnlyContracts({
+      contracts,
+      getCurrentBlockNumber: () => this.currentEventBlockNumber,
+      eventStore,
     });
 
     this.eventProcessingMutex = new Mutex();
@@ -134,6 +115,11 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
   } = {}) => {
     if (newSchema) {
       this.schema = newSchema;
+      this.models = buildModels({
+        userStore: this.userStore,
+        schema: this.schema,
+        getCurrentEventTimestamp: () => this.currentEventTimestamp,
+      });
     }
 
     if (newHandlers) {
@@ -164,10 +150,21 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
     }
 
     // If either the schema or handlers have not been provided yet,
-    // we're not ready to process events, so it's safe to return early.
+    // we're not ready to process events. Just return early.
     if (!this.schema || !this.handlers) return;
 
-    this.resetEventQueue();
+    // Cancel all pending calls to processEvents, reset the mutex, and create
+    // a new queue using the latest available handlers and schema.
+    this.eventProcessingMutex.cancel();
+    this.eventProcessingMutex = new Mutex();
+    this.queue = this.createEventQueue({ handlers: this.handlers });
+
+    this.hasError = false;
+    this.resources.metrics.ponder_handlers_has_error.set(0);
+
+    this.resources.metrics.ponder_handlers_matched_events.reset();
+    this.resources.metrics.ponder_handlers_handled_events.reset();
+    this.resources.metrics.ponder_handlers_processed_events.reset();
 
     await this.userStore.reload({ schema: this.schema });
     this.resources.logger.debug({
@@ -175,12 +172,12 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
       msg: `Reset user store (versionId=${this.userStore.versionId})`,
     });
 
-    this.eventsHandledToTimestamp = 0;
-    this.metrics.latestHandledEventTimestamp = 0;
+    // When we call userStore.reload() above, the user store is dropped.
+    // Set the latest processed timestamp to zero accordingly.
+    this.eventsProcessedToTimestamp = 0;
+    this.resources.metrics.ponder_handlers_latest_processed_timestamp.set(0);
 
-    await this.processEvents({
-      toTimestamp: this.eventAggregatorService.checkpoint,
-    });
+    await this.processEvents();
   };
 
   handleReorg = async ({
@@ -188,36 +185,95 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
   }: {
     commonAncestorTimestamp: number;
   }) => {
-    this.resetEventQueue();
-
-    await this.userStore.revert({ safeTimestamp: commonAncestorTimestamp });
-    this.resources.logger.debug({
-      service: "handlers",
-      msg: `Reverted user store to safe timestamp ${commonAncestorTimestamp}`,
-    });
-
-    this.eventsHandledToTimestamp = commonAncestorTimestamp;
-    this.metrics.latestHandledEventTimestamp = commonAncestorTimestamp;
-
-    await this.processEvents({
-      toTimestamp: this.eventAggregatorService.checkpoint,
-    });
-  };
-
-  processEvents = async ({ toTimestamp }: { toTimestamp: number }) => {
-    if (this.hasEventHandlerError) return;
-    if (toTimestamp === 0) return;
+    /**
+     * This method is triggered by the realtime sync service detecting a reorg,
+     * which can happen at any time. The event queue and the user store can be
+     * in one of several different states that we need to keep in mind:
+     *
+     * 1) No events have been added to the queue yet.
+     * 2) No unsafe events have been processed (eventsProcessedToTimestamp <= commonAncestorTimestamp).
+     * 3) Unsafe events may have been processed (eventsProcessedToTimestamp > commonAncestorTimestamp).
+     * 4) The queue has encountered a user error and is waiting for a reload.
+     *
+     * Note: It's crucial that we acquire a mutex lock while handling the reorg.
+     * This will only ever run while the queue is idle, so we can be confident
+     * that eventsProcessedToTimestamp matches the current state of the user store,
+     * and that no unsafe events will get processed after handling the reorg.
+     */
 
     try {
       await this.eventProcessingMutex.runExclusive(async () => {
-        if (!this.queue) return;
+        // If there is a user error, the queue & user store will be wiped on reload (case 4).
+        if (this.hasError) return;
+
+        if (this.eventsProcessedToTimestamp <= commonAncestorTimestamp) {
+          // No unsafe events have been processed, so no need to revert (case 1 & case 2).
+          this.resources.logger.debug({
+            service: "handlers",
+            msg: `No unsafe events were detected while reconciling a reorg, no-op`,
+          });
+        } else {
+          // Unsafe events have been processed, must revert the user store and update
+          // eventsProcessedToTimestamp accordingly (case 3).
+          await this.userStore.revert({
+            safeTimestamp: commonAncestorTimestamp,
+          });
+
+          this.eventsProcessedToTimestamp = commonAncestorTimestamp;
+          this.resources.metrics.ponder_handlers_latest_processed_timestamp.set(
+            commonAncestorTimestamp
+          );
+
+          // Note: There's currently no way to know how many events are "thrown out"
+          // during the reorg reconciliation, so the event count metrics
+          // (e.g. ponder_handlers_processed_events) will be slightly inflated.
+
+          this.resources.logger.debug({
+            service: "handlers",
+            msg: `Reverted user store to safe timestamp ${commonAncestorTimestamp}`,
+          });
+        }
+      });
+    } catch (error) {
+      // Pending locks get cancelled in reset(). This is expected, so it's safe to
+      // ignore the error that is thrown when a pending lock is cancelled.
+      if (error !== E_CANCELED) throw error;
+    }
+
+    await this.processEvents();
+  };
+
+  /**
+   * Processes all newly available events.
+   *
+   * Acquires a lock on the event processing mutex, then gets the latest checkpoint
+   * from the event aggregator service. Fetches events between previous checkpoint
+   * and the new checkpoint, adds them to the queue, then processes them.
+   *
+   */
+  processEvents = async () => {
+    try {
+      await this.eventProcessingMutex.runExclusive(async () => {
+        if (this.hasError || !this.queue) return;
+
+        const eventsAvailableTo = this.eventAggregatorService.checkpoint;
+
+        // If we have already added events to the queue for the current checkpoint,
+        // do nothing and return. This can happen if a number of calls to processEvents
+        // "stack up" while one is being processed, and then they all run sequentially
+        // but the event aggregator service checkpoint has not moved.
+        if (this.eventsProcessedToTimestamp >= eventsAvailableTo) {
+          return;
+        }
 
         // The getEvents method is inclusive on both sides, so we need to add 1 here
         // to avoid fetching the same event twice.
         const fromTimestamp =
-          this.eventsHandledToTimestamp === 0
+          this.eventsProcessedToTimestamp === 0
             ? 0
-            : this.eventsHandledToTimestamp + 1;
+            : this.eventsProcessedToTimestamp + 1;
+
+        const toTimestamp = eventsAvailableTo;
 
         const { events, totalEventCount } =
           await this.eventAggregatorService.getEvents({
@@ -226,12 +282,19 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
             handledLogFilters: this.handledLogFilters,
           });
 
-        this.metrics.eventsAddedToQueue += events.length;
-        this.metrics.totalMatchedEvents += totalEventCount;
+        // TODO: Add the "eventName" label here by updating getEvents
+        // implementation to return a count for each event name rather
+        // than all lumped together.
+        this.resources.metrics.ponder_handlers_matched_events.inc(
+          totalEventCount
+        );
 
-        // If no events have been handled yet, add the setup event.
-        if (this.eventsHandledToTimestamp === 0 && this.handlers?.setup) {
+        // If no events have been added yet, add the setup event.
+        if (this.eventsProcessedToTimestamp === 0 && this.handlers?.setup) {
           this.queue.addTask({ kind: "SETUP" });
+          this.resources.metrics.ponder_handlers_handled_events.inc({
+            eventName: "setup",
+          });
         }
 
         // Add new events to the queue.
@@ -240,6 +303,9 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
             kind: "LOG",
             event,
           });
+          this.resources.metrics.ponder_handlers_handled_events.inc({
+            eventName: `${event.logFilterName}:${event.eventName}`,
+          });
         }
 
         // Process new events that were added to the queue.
@@ -247,110 +313,35 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
         await this.queue.onIdle();
         this.queue.pause();
 
-        this.eventsHandledToTimestamp = toTimestamp;
+        this.eventsProcessedToTimestamp = toTimestamp;
 
-        this.emit("eventsProcessed", {
-          count: events.length,
-          toTimestamp: toTimestamp,
-        });
+        this.emit("eventsProcessed", { toTimestamp });
+
+        this.resources.metrics.ponder_handlers_latest_processed_timestamp.set(
+          toTimestamp
+        );
 
         if (events.length > 0) {
           this.resources.logger.info({
             service: "handlers",
             msg: `Processed ${
               events.length === 1 ? "1 event" : `${events.length} events`
-            } in timestamp range [${fromTimestamp}, ${toTimestamp + 1})`,
+            }`,
           });
         }
       });
     } catch (error) {
-      // Pending locks get cancelled in resetEventQueue. This is expected, so it's safe to
+      // Pending locks get cancelled in reset(). This is expected, so it's safe to
       // ignore the error that is thrown when a pending lock is cancelled.
       if (error !== E_CANCELED) throw error;
     }
   };
 
-  private resetEventQueue = () => {
-    if (!this.handlers || !this.schema) return;
-
-    this.eventProcessingMutex.cancel();
-    this.eventProcessingMutex = new Mutex();
-
-    this.hasEventHandlerError = false;
-
-    this.metrics = {
-      ...this.metrics,
-      error: false,
-      eventsAddedToQueue: 0,
-      eventsProcessedFromQueue: 0,
-      totalMatchedEvents: 0,
+  private createEventQueue = ({ handlers }: { handlers: Handlers }) => {
+    const context = {
+      contracts: this.readOnlyContracts,
+      entities: this.models,
     };
-
-    this.queue = this.createEventQueue({
-      handlers: this.handlers,
-      schema: this.schema,
-    });
-
-    this.emit("reset");
-  };
-
-  private createEventQueue = ({
-    handlers,
-    schema,
-  }: {
-    handlers: Handlers;
-    schema: Schema;
-  }) => {
-    // Build entity models for event handler context.
-    const models = schema.entities.reduce<Record<string, Model<ModelInstance>>>(
-      (acc, { name: modelName }) => {
-        acc[modelName] = {
-          findUnique: ({ id }) => {
-            return this.userStore.findUnique({
-              modelName,
-              timestamp: this.currentEventTimestamp,
-              id,
-            });
-          },
-          create: ({ id, data }) => {
-            return this.userStore.create({
-              modelName,
-              timestamp: this.currentEventTimestamp,
-              id,
-              data,
-            });
-          },
-          update: ({ id, data }) => {
-            return this.userStore.update({
-              modelName,
-              timestamp: this.currentEventTimestamp,
-              id,
-              data,
-            });
-          },
-          upsert: ({ id, create, update }) => {
-            return this.userStore.upsert({
-              modelName,
-              timestamp: this.currentEventTimestamp,
-              id,
-              create,
-              update,
-            });
-          },
-          delete: ({ id }) => {
-            return this.userStore.delete({
-              modelName,
-              timestamp: this.currentEventTimestamp,
-              id,
-            });
-          },
-        };
-        return acc;
-      },
-      {}
-    );
-
-    const context = { contracts: this.injectedContracts, entities: models };
 
     const eventHandlerWorker: Worker<EventHandlerTask> = async ({
       task,
@@ -359,19 +350,21 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
       switch (task.kind) {
         case "SETUP": {
           const setupHandler = handlers["setup"];
-          if (!setupHandler) {
-            return;
-          }
+          if (!setupHandler) return;
 
           try {
             // Running user code here!
             await setupHandler({ context });
+
+            this.resources.metrics.ponder_handlers_processed_events.inc({
+              eventName: "setup",
+            });
           } catch (error_) {
             // Remove all remaining tasks from the queue.
             queue.clear();
 
-            this.hasEventHandlerError = true;
-            this.metrics.error = true;
+            this.hasError = true;
+            this.resources.metrics.ponder_handlers_has_error.set(1);
 
             const error = error_ as Error;
             const trace = getStackTrace(error, this.resources.options);
@@ -390,17 +383,13 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
             this.resources.errors.submitUserError({ error: userError });
           }
 
-          this.emit("taskCompleted");
-
           break;
         }
         case "LOG": {
           const event = task.event;
 
           const handler = handlers[event.logFilterName]?.[event.eventName];
-          if (!handler) {
-            return;
-          }
+          if (!handler) return;
 
           // This enables contract calls occurring within the
           // handler code to use the event block number by default.
@@ -416,12 +405,16 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
               },
               context,
             });
+
+            this.resources.metrics.ponder_handlers_processed_events.inc({
+              eventName: `${event.logFilterName}:${event.eventName}`,
+            });
           } catch (error_) {
             // Remove all remaining tasks from the queue.
             queue.clear();
 
-            this.hasEventHandlerError = true;
-            this.metrics.error = true;
+            this.hasError = true;
+            this.resources.metrics.ponder_handlers_has_error.set(1);
 
             const error = error_ as Error;
             const trace = getStackTrace(error, this.resources.options);
@@ -445,15 +438,9 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
             this.resources.errors.submitUserError({ error: userError });
           }
 
-          this.metrics.latestHandledEventTimestamp = this.currentEventTimestamp;
-
-          this.emit("taskCompleted");
-
           break;
         }
       }
-
-      this.metrics.eventsProcessedFromQueue += 1;
     };
 
     const queue = createQueue({

--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -482,7 +482,7 @@ export class PostgresUserStore implements UserStore {
   };
 
   revert = async ({ safeTimestamp }: { safeTimestamp: number }) => {
-    this.db.transaction().execute(async (tx) => {
+    await this.db.transaction().execute(async (tx) => {
       await Promise.all(
         (this.schema?.entities ?? []).map(async (entity) => {
           const modelName = entity.name;

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -456,7 +456,7 @@ export class SqliteUserStore implements UserStore {
   };
 
   revert = async ({ safeTimestamp }: { safeTimestamp: number }) => {
-    this.db.transaction().execute(async (tx) => {
+    await this.db.transaction().execute(async (tx) => {
       await Promise.all(
         (this.schema?.entities ?? []).map(async (entity) => {
           const modelName = entity.name;

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -5,7 +5,7 @@ import { setupUserStore } from "@/_test/setup";
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 
-beforeEach(setupUserStore);
+beforeEach((context) => setupUserStore(context));
 
 const graphqlSchema = buildGraphqlSchema(`
   ${schemaHeader}

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -5,12 +5,7 @@ import { setupUserStore } from "@/_test/setup";
 import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 
-/**
- * This test suite uses the `store` object injected during setup.
- * At the moment, this could be either a PostgresUserStore or a
- * SqliteUserStore; the tests run as expected either way.
- */
-beforeEach(async (context) => await setupUserStore(context));
+beforeEach(setupUserStore);
 
 const graphqlSchema = buildGraphqlSchema(`
   ${schemaHeader}


### PR DESCRIPTION
This PR introduces a test suite for the user handlers service focused on reorg reconciliation.

It also adds a few metrics for the service:

```typescript
type EventHandlerServiceMetrics = {
  ponder_handlers_matched_events: prometheus.Gauge<"eventName">;
  ponder_handlers_handled_events: prometheus.Gauge<"eventName">;
  ponder_handlers_processed_events: prometheus.Gauge<"eventName">;
  ponder_handlers_has_error: prometheus.Gauge; // Boolean
  ponder_handlers_latest_processed_timestamp: prometheus.Gauge;
}
```

