### PR TITLE
Chores

### DIFF
--- a/.changeset/healthy-goats-dance.md
+++ b/.changeset/healthy-goats-dance.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Added `maxRpcRequestConcurrency` option to `networks` type in `ponder.config.ts`.

--- a/.changeset/swift-chefs-carry.md
+++ b/.changeset/swift-chefs-carry.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Renamed types `PonderConfig` to `Config`, `ResolvedPonderConfig` to `ResolvedConfig`, and `PonderOptions` to `Options`.

--- a/benchmarks/ponder/ponder.config.ts
+++ b/benchmarks/ponder/ponder.config.ts
@@ -1,9 +1,9 @@
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
 import FileStoreAbi from "./abis/FileStore.json";
 import FileStoreFrontendAbi from "./abis/FileStoreFrontend.json";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "mainnet",

--- a/docs/pages/advanced/custom-filters.mdx
+++ b/docs/pages/advanced/custom-filters.mdx
@@ -13,10 +13,10 @@ However, Ponder also supports filtering logs by event signature and indexed even
 Similarly, the [Filter](/api-reference/ponder-config#filter) object supports a string of addresses to handle multiple contracts using the same abi. For example, you can handle all `Swap` events for different Uniswap pools using the following config:
 
 ```ts filename="ponder.config.ts"
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 import { parseAbiItem } from 'viem';
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "mainnet",

--- a/docs/pages/advanced/proxy-contracts.mdx
+++ b/docs/pages/advanced/proxy-contracts.mdx
@@ -28,9 +28,9 @@ The `create-ponder` Etherscan [contract link template](/api-reference/create-pon
 
 {/* prettier-ignore */}
 ```ts filename="ponder.config.ts"
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [ /* ... */ ],
   contracts: [
     {

--- a/docs/pages/api-reference/ponder-config.mdx
+++ b/docs/pages/api-reference/ponder-config.mdx
@@ -25,12 +25,13 @@ Networks are Ethereum-based blockchains like Ethereum mainnet, Goerli, or Foundr
   development or production.
 </Callout>
 
-| field               |         type          |                                                                                                                                    |
-| :------------------ | :-------------------: | :--------------------------------------------------------------------------------------------------------------------------------- |
-| **name**            |       `string`        | A unique name for the blockchain. Must be unique across all networks.                                                              |
-| **chainId**         |       `number`        | The [chain ID](https://chainlist.org) for the network.                                                                             |
-| **rpcUrl**          | `string \| undefined` | An optional RPC URL for the network. If not provided, a public (heavily rate-limited) RPC provider will be used (not recommended). |
-| **pollingInterval** | `number \| undefined` | **Default: `1_000`**. Frequency (in ms) used when polling for new events on this network.                                          |
+| field                        |         type          |                                                                                                                                    |
+| :--------------------------- | :-------------------: | :--------------------------------------------------------------------------------------------------------------------------------- |
+| **name**                     |       `string`        | A unique name for the blockchain. Must be unique across all networks.                                                              |
+| **chainId**                  |       `number`        | The [chain ID](https://chainlist.org) for the network.                                                                             |
+| **rpcUrl**                   | `string \| undefined` | An optional RPC URL for the network. If not provided, a public (heavily rate-limited) RPC provider will be used (not recommended). |
+| **pollingInterval**          | `number \| undefined` | **Default: `1_000`**. Frequency (in ms) used when polling for new events on this network.                                          |
+| **maxRpcRequestConcurrency** | `number \| undefined` | **Default: `10`**. Maximum concurrency of RPC requests during the historical sync.                                                 |
 
 ### Contracts
 

--- a/docs/pages/api-reference/ponder-config.mdx
+++ b/docs/pages/api-reference/ponder-config.mdx
@@ -92,9 +92,9 @@ See [Deploy to production](/guides/production) for more details.
 ### Basic example
 
 ```ts filename="ponder.config.ts"
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "mainnet",
@@ -117,9 +117,9 @@ export const config: PonderConfig = {
 ### Async function
 
 ```ts filename="ponder.config.ts"
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
-export const config: PonderConfig = async () => {
+export const config: Config = async () => {
   const startBlock = await fetch("http://...");
 
   return {

--- a/examples/art-gobblers/ponder.config.ts
+++ b/examples/art-gobblers/ponder.config.ts
@@ -1,8 +1,8 @@
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
 import ArtGobblersAbi from "./abis/ArtGobblers.json";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "mainnet",

--- a/examples/ethfs/ponder.config.ts
+++ b/examples/ethfs/ponder.config.ts
@@ -1,9 +1,9 @@
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
 import FileStoreAbi from "./abis/FileStore.json";
 import FileStoreFrontendAbi from "./abis/FileStoreFrontend.json";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "mainnet",

--- a/examples/token-erc20/.env.example
+++ b/examples/token-erc20/.env.example
@@ -1,2 +1,5 @@
 # Mainnet RPC URL used for fetching blockchain data. Alchemy is recommended.
 PONDER_RPC_URL_1=https://eth-mainnet.g.alchemy.com/v2/...
+
+# (Optional) Postgres database URL. If not provided, SQLite will be used. 
+DATABASE_URL=

--- a/examples/token-erc20/ponder.config.ts
+++ b/examples/token-erc20/ponder.config.ts
@@ -1,6 +1,6 @@
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     { name: "mainnet", chainId: 1, rpcUrl: process.env.PONDER_RPC_URL_1 },
   ],

--- a/examples/token-erc721/.env.example
+++ b/examples/token-erc721/.env.example
@@ -1,2 +1,5 @@
 # Arbitrum RPC URL used for fetching blockchain data. Alchemy is recommended.
 PONDER_RPC_URL_42161=
+
+# (Optional) Postgres database URL. If not provided, SQLite will be used. 
+DATABASE_URL=

--- a/examples/token-erc721/ponder.config.ts
+++ b/examples/token-erc721/ponder.config.ts
@@ -1,6 +1,6 @@
-import type { PonderConfig } from "@ponder/core";
+import type { Config } from "@ponder/core";
 
-export const config: PonderConfig = {
+export const config: Config = {
   networks: [
     {
       name: "arbitrum",

--- a/examples/token-reth/.env.example
+++ b/examples/token-reth/.env.example
@@ -1,0 +1,5 @@
+# Mainnet RPC URL used for fetching blockchain data. Alchemy is recommended.
+PONDER_RPC_URL_1=
+
+# (Optional) Postgres database URL. If not provided, SQLite will be used. 
+DATABASE_URL=

--- a/examples/token-reth/.gitignore
+++ b/examples/token-reth/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.DS_Store
+
+.env.local
+.ponder/
+generated/

--- a/examples/token-reth/README.md
+++ b/examples/token-reth/README.md
@@ -1,0 +1,41 @@
+# Example ERC20 (rETH) token events API
+
+This example app creates a GraphQL API that serves `Transfer` and `Approval` events for the rETH (Rocket Pool) token contract on mainnet.
+
+It's designed to match the functionality of the [rETH Substreams Mainnet subgraph](https://thegraph.com/hosted-service/subgraph/data-nexus/reth-substreams-mainnet?selected=logs).
+
+## Sample queries
+
+### Get all transfer events to a specific account
+
+```graphql
+{
+  transfers(where: { receiver: "0x2B8E4729672613D69e5006a97dD56A455389FB2b" }) {
+    id
+    sender
+    receiver
+    amount
+    timestamp
+    txHash
+    blockNumber
+    logIndex
+  }
+}
+```
+
+### Get all approval events between two timestamps
+
+```graphql
+{
+  approvals(where: { timestamp_gt: 1688000000, timestamp_lt: 1688590000 }) {
+    id
+    sender
+    receiver
+    amount
+    timestamp
+    txHash
+    blockNumber
+    logIndex
+  }
+}
+```

--- a/examples/token-reth/abis/RocketTokenRETH.json
+++ b/examples/token-reth/abis/RocketTokenRETH.json
@@ -1,0 +1,332 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract RocketStorageInterface",
+        "name": "_rocketStorageAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "EtherDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokensBurned",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokensMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_rethAmount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositExcess",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositExcessCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCollateralRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_rethAmount", "type": "uint256" }
+    ],
+    "name": "getEthValue",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getExchangeRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_ethAmount", "type": "uint256" }
+    ],
+    "name": "getRethValue",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalCollateral",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_ethAmount", "type": "uint256" },
+      { "internalType": "address", "name": "_to", "type": "address" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/examples/token-reth/package.json
+++ b/examples/token-reth/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "ponder dev",
+    "start": "ponder start",
+    "codegen": "ponder codegen"
+  },
+  "dependencies": {
+    "@ponder/core": "workspace:latest"
+  },
+  "devDependencies": {
+    "abitype": "^0.8.11",
+    "typescript": "^5.1.3",
+    "viem": "^1.2.6"
+  }
+}

--- a/examples/token-reth/ponder.config.ts
+++ b/examples/token-reth/ponder.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "@ponder/core";
+
+export const config: Config = {
+  networks: [
+    {
+      name: "mainnet",
+      chainId: 1,
+      rpcUrl: process.env.PONDER_RPC_URL_1,
+      maxRpcRequestConcurrency: 25,
+    },
+  ],
+  contracts: [
+    {
+      name: "RocketTokenRETH",
+      network: "mainnet",
+      abi: "./abis/RocketTokenRETH.json",
+      address: "0xae78736cd615f374d3085123a210448e74fc6393",
+      startBlock: 13325304,
+    },
+  ],
+};

--- a/examples/token-reth/schema.graphql
+++ b/examples/token-reth/schema.graphql
@@ -1,0 +1,21 @@
+type Transfer @entity {
+  id: String!
+  sender: String!
+  receiver: String!
+  amount: BigInt!
+  timestamp: BigInt!
+  txHash: String!
+  blockNumber: BigInt!
+  logIndex: Int!
+}
+
+type Approval @entity {
+  id: String!
+  owner: String!
+  spender: String!
+  value: BigInt!
+  timestamp: BigInt!
+  txHash: String!
+  blockNumber: BigInt!
+  logIndex: Int!
+}

--- a/examples/token-reth/src/RocketTokenRETH.ts
+++ b/examples/token-reth/src/RocketTokenRETH.ts
@@ -1,0 +1,31 @@
+import { ponder } from "@/generated";
+
+ponder.on("RocketTokenRETH:Transfer", async ({ event, context }) => {
+  await context.entities.Transfer.create({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    data: {
+      sender: event.params.from,
+      receiver: event.params.to,
+      amount: event.params.value,
+      timestamp: event.block.timestamp,
+      txHash: event.transaction.hash,
+      blockNumber: event.block.number,
+      logIndex: event.log.logIndex,
+    },
+  });
+});
+
+ponder.on("RocketTokenRETH:Approval", async ({ event, context }) => {
+  await context.entities.Approval.create({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    data: {
+      owner: event.params.owner,
+      spender: event.params.spender,
+      value: event.params.value,
+      timestamp: event.block.timestamp,
+      txHash: event.transaction.hash,
+      blockNumber: event.block.number,
+      logIndex: event.log.logIndex,
+    },
+  });
+});

--- a/examples/token-reth/tsconfig.json
+++ b/examples/token-reth/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "rootDir": ".",
+    "paths": {
+      "@/generated": ["./generated/index.ts"]
+    }
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -106,10 +106,10 @@
 
   ```ts
   // ponder.config.ts
-  import type { PonderConfig } from "@ponder/core";
+  import type { Config } from "@ponder/core";
   import { parseAbiItem } from "abitype";
 
-  export const config: PonderConfig = {
+  export const config: Config = {
     networks: [
       /* ... */
     ],
@@ -133,8 +133,8 @@
 
   ```diff
   // ponder.config.ts
-  import type { PonderConfig } from "@ponder/core";
-  export const config: PonderConfig = {
+  import type { Config } from "@ponder/core";
+  export const config: Config = {
     networks: [ /* ... */ ],
     contracts: [
       {
@@ -181,7 +181,7 @@
 
     await MyEntity.create({
       id: setupData.id,
-      data: { ...setupData },
+      data: { ...setupData }
     });
   });
   ```
@@ -368,10 +368,10 @@
   ```diff
   // ponder.config.ts
 
-  import type { PonderConfig } from "@ponder/core";
+  import type { Config } from "@ponder/core";
   - import { graphqlPlugin } from "@ponder/graphql";
 
-  export const config: PonderConfig = {
+  export const config: Config = {
     networks: [
       {
         name: "mainnet",
@@ -479,23 +479,23 @@
 
 ### Patch Changes
 
-- [#57](https://github.com/0xOlias/ponder/pull/57) [`3f358dd`](https://github.com/0xOlias/ponder/commit/3f358dddbcb4c0f7dfe427a9db847bd2388be019) Thanks [@0xOlias](https://github.com/0xOlias)! - BREAKING! Updated ponder config to support typescript and to be called `ponder.ts` by default. `ponder.ts` must export a variable named `config` that is of the type `import { PonderConfig } from "@ponder/core"`. The `database` field in ponder config is now optional. By default, it uses `SQLite` with a filename of `./.ponder/cache.db`. If the environment variable `DATABASE_URL` is detected, it uses `Postgres` with that value as the `connectionString`.
+- [#57](https://github.com/0xOlias/ponder/pull/57) [`3f358dd`](https://github.com/0xOlias/ponder/commit/3f358dddbcb4c0f7dfe427a9db847bd2388be019) Thanks [@0xOlias](https://github.com/0xOlias)! - BREAKING! Updated ponder config to support typescript and to be called `ponder.ts` by default. `ponder.ts` must export a variable named `config` that is of the type `import { Config } from "@ponder/core"`. The `database` field in ponder config is now optional. By default, it uses `SQLite` with a filename of `./.ponder/cache.db`. If the environment variable `DATABASE_URL` is detected, it uses `Postgres` with that value as the `connectionString`.
 
   New sample `ponder.ts` file:
 
   ```ts
   // ponder.ts
 
-  import type { PonderConfig } from "@ponder/core";
+  import type { Config } from "@ponder/core";
   import { graphqlPlugin } from "@ponder/graphql";
 
-  export const config: PonderConfig = {
+  export const config: Config = {
     networks: [
       {
         name: "mainnet",
         chainId: 1,
-        rpcUrl: process.env.PONDER_RPC_URL_1,
-      },
+        rpcUrl: process.env.PONDER_RPC_URL_1
+      }
     ],
     sources: [
       {
@@ -503,10 +503,10 @@
         network: "mainnet",
         abi: "./abis/ArtGobblers.json",
         address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
-        startBlock: 15863321,
-      },
+        startBlock: 15863321
+      }
     ],
-    plugins: [graphqlPlugin()],
+    plugins: [graphqlPlugin()]
   };
   ```
 
@@ -515,16 +515,16 @@
   ```ts
   // ponder.ts
 
-  import type { PonderConfig } from "@ponder/core";
+  import type { Config } from "@ponder/core";
 
-  export const config: PonderConfig = async () => {
+  export const config: Config = async () => {
     return {
       networks: [
         /* ... */
       ],
       sources: [
         /* ... */
-      ],
+      ]
     };
   };
   ```

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -196,7 +196,11 @@ export class Ponder {
   async dev() {
     const setupError = await this.setup();
     if (setupError) {
-      // this.resources.logger.logMessage("error", setupError.message);
+      this.resources.logger.error({
+        service: "app",
+        msg: setupError.message,
+        error: setupError,
+      });
       return await this.kill();
     }
 

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -5,15 +5,15 @@ import { afterEach, beforeEach, expect, test, TestContext } from "vitest";
 
 import { setupEventStore, setupUserStore } from "@/_test/setup";
 import { testNetworkConfig } from "@/_test/utils";
+import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
-import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
 beforeEach((context) => setupEventStore(context));
 beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
-  const config = await buildPonderConfig({
+  const config = await buildConfig({
     configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
   });
   // Inject proxied anvil chain.

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -5,15 +5,15 @@ import { afterEach, beforeEach, expect, test, TestContext } from "vitest";
 
 import { setupEventStore, setupUserStore } from "@/_test/setup";
 import { testNetworkConfig } from "@/_test/utils";
+import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
-import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
 beforeEach((context) => setupEventStore(context));
 beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
-  const config = await buildPonderConfig({
+  const config = await buildConfig({
     configFile: path.resolve("src/_test/ens/app/ponder.config.ts"),
   });
   // Inject proxied anvil chain.

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -6,8 +6,8 @@ import { cac } from "cac";
 import dotenv from "dotenv";
 import path from "node:path";
 
+import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
-import { buildPonderConfig } from "@/config/ponderConfig";
 import { Ponder } from "@/Ponder";
 
 import packageJson from "../../package.json" assert { type: "json" };
@@ -25,7 +25,7 @@ const cli = cac("ponder")
     default: ".",
   });
 
-export type PonderCliOptions = {
+export type CliOptions = {
   help?: boolean;
   configFile: string;
   rootDir: string;
@@ -33,11 +33,11 @@ export type PonderCliOptions = {
 
 cli
   .command("dev", "Start the development server")
-  .action(async (cliOptions: PonderCliOptions) => {
+  .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
     const configFile = path.resolve(cliOptions.configFile);
-    const config = await buildPonderConfig({ configFile });
+    const config = await buildConfig({ configFile });
     const options = buildOptions({ cliOptions, configOptions: config.options });
 
     const devOptions = { ...options, uiEnabled: true };
@@ -49,11 +49,11 @@ cli
 
 cli
   .command("start", "Start the production server")
-  .action(async (cliOptions: PonderCliOptions) => {
+  .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
     const configFile = path.resolve(cliOptions.configFile);
-    const config = await buildPonderConfig({ configFile });
+    const config = await buildConfig({ configFile });
     const options = buildOptions({ cliOptions, configOptions: config.options });
 
     const startOptions = { ...options, uiEnabled: false };
@@ -65,11 +65,11 @@ cli
 
 cli
   .command("codegen", "Emit type files, then exit")
-  .action(async (cliOptions: PonderCliOptions) => {
+  .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
     const configFile = path.resolve(cliOptions.configFile);
-    const config = await buildPonderConfig({ configFile });
+    const config = await buildConfig({ configFile });
     const options = buildOptions({ cliOptions, configOptions: config.options });
 
     const codegenOptions = {

--- a/packages/core/src/build/handlers.ts
+++ b/packages/core/src/build/handlers.ts
@@ -4,7 +4,7 @@ import { existsSync, rmSync } from "node:fs";
 import path from "node:path";
 import { replaceTscAliasPaths } from "tsc-alias";
 
-import { PonderOptions } from "@/config/options";
+import { Options } from "@/config/options";
 import { Block } from "@/types/block";
 import { Log } from "@/types/log";
 import { Transaction } from "@/types/transaction";
@@ -68,7 +68,7 @@ export class PonderApp<EventHandlers = Record<string, LogEventHandler>> {
   }
 }
 
-export const readHandlers = async ({ options }: { options: PonderOptions }) => {
+export const readHandlers = async ({ options }: { options: Options }) => {
   const entryAppFilename = path.join(options.generatedDir, "index.ts");
   if (!existsSync(entryAppFilename)) {
     throw new Error(

--- a/packages/core/src/build/schema.ts
+++ b/packages/core/src/build/schema.ts
@@ -1,7 +1,7 @@
 import { buildSchema } from "graphql";
 import { readFileSync } from "node:fs";
 
-import { PonderOptions } from "@/config/options";
+import { Options } from "@/config/options";
 
 export const schemaHeader = `
 "Directs the executor to process this type as a Ponder entity."
@@ -14,7 +14,7 @@ scalar Bytes
 scalar BigInt
 `;
 
-export const readGraphqlSchema = ({ options }: { options: PonderOptions }) => {
+export const readGraphqlSchema = ({ options }: { options: Options }) => {
   const schemaBody = readFileSync(options.schemaFile);
   const schemaSource = schemaHeader + schemaBody.toString();
 

--- a/packages/core/src/codegen/service.test.ts
+++ b/packages/core/src/codegen/service.test.ts
@@ -1,8 +1,8 @@
 import { buildSchema as buildGraphqlSchema } from "graphql";
 import { expect, test } from "vitest";
 
+import { schemaHeader } from "@/build/schema";
 import { buildEntityTypes } from "@/codegen/entity";
-import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 
 const graphqlSchema = buildGraphqlSchema(`

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 import { ensureDirExists } from "@/utils/exists";
 
-export type ResolvedPonderConfig = {
+export type ResolvedConfig = {
   /** Database to use for storing blockchain & entity data. Default: `"postgres"` if `DATABASE_URL` env var is present, otherwise `"sqlite"`. */
   database?:
     | {
@@ -86,17 +86,13 @@ export type ResolvedPonderConfig = {
   };
 };
 
-export type PonderConfig =
-  | ResolvedPonderConfig
-  | Promise<ResolvedPonderConfig>
-  | (() => ResolvedPonderConfig)
-  | (() => Promise<ResolvedPonderConfig>);
+export type Config =
+  | ResolvedConfig
+  | Promise<ResolvedConfig>
+  | (() => ResolvedConfig)
+  | (() => Promise<ResolvedConfig>);
 
-export const buildPonderConfig = async ({
-  configFile,
-}: {
-  configFile: string;
-}) => {
+export const buildConfig = async ({ configFile }: { configFile: string }) => {
   if (!existsSync(configFile)) {
     throw new Error(`Ponder config file not found, expected: ${configFile}`);
   }
@@ -135,7 +131,7 @@ export const buildPonderConfig = async ({
       );
     }
 
-    let resolvedConfig: ResolvedPonderConfig;
+    let resolvedConfig: ResolvedConfig;
 
     if (typeof rawConfig === "function") {
       resolvedConfig = await rawConfig();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -28,6 +28,8 @@ export type ResolvedConfig = {
     rpcUrl?: string;
     /** Polling frequency (in ms). Default: `1_000`. */
     pollingInterval?: number;
+    /** Maximum concurrency of RPC requests during the historical sync. Default: `10`. */
+    maxRpcRequestConcurrency?: number;
   }[];
   /** List of contracts to fetch & handle events from. Contracts defined here will be present in `context.contracts`. */
   contracts?: {

--- a/packages/core/src/config/contracts.ts
+++ b/packages/core/src/config/contracts.ts
@@ -1,7 +1,7 @@
 import { Abi, Address } from "abitype";
 
-import { PonderOptions } from "@/config/options";
-import { ResolvedPonderConfig } from "@/config/ponderConfig";
+import { ResolvedConfig } from "@/config/config";
+import { Options } from "@/config/options";
 
 import { buildAbi } from "./abi";
 import { buildNetwork, Network } from "./networks";
@@ -17,8 +17,8 @@ export function buildContracts({
   config,
   options,
 }: {
-  config: ResolvedPonderConfig;
-  options: PonderOptions;
+  config: ResolvedConfig;
+  options: Options;
 }): Contract[] {
   return (config.contracts ?? []).map((contract) => {
     const address = contract.address.toLowerCase() as Address;

--- a/packages/core/src/config/database.ts
+++ b/packages/core/src/config/database.ts
@@ -2,8 +2,8 @@ import Sqlite from "better-sqlite3";
 import path from "node:path";
 import pg, { Client, DatabaseError, Pool } from "pg";
 
-import { PonderOptions } from "@/config/options";
-import { ResolvedPonderConfig } from "@/config/ponderConfig";
+import { ResolvedConfig } from "@/config/config";
+import { Options } from "@/config/options";
 import { PostgresError } from "@/errors/postgres";
 import { SqliteError } from "@/errors/sqlite";
 import { ensureDirExists } from "@/utils/exists";
@@ -89,10 +89,10 @@ export const buildDatabase = ({
   options,
   config,
 }: {
-  options: PonderOptions;
-  config: ResolvedPonderConfig;
+  options: Options;
+  config: ResolvedConfig;
 }): Database => {
-  let resolvedDatabaseConfig: NonNullable<ResolvedPonderConfig["database"]>;
+  let resolvedDatabaseConfig: NonNullable<ResolvedConfig["database"]>;
 
   const defaultSqliteFilename = path.join(options.ponderDir, "cache.db");
 

--- a/packages/core/src/config/logFilters.ts
+++ b/packages/core/src/config/logFilters.ts
@@ -1,8 +1,8 @@
 import { Abi, Address } from "abitype";
 import { encodeEventTopics } from "viem";
 
-import { PonderOptions } from "@/config/options";
-import { ResolvedPonderConfig } from "@/config/ponderConfig";
+import { ResolvedConfig } from "@/config/config";
+import { Options } from "@/config/options";
 
 import { buildAbi } from "./abi";
 import { encodeLogFilterKey } from "./logFilterKey";
@@ -26,8 +26,8 @@ export function buildLogFilters({
   config,
   options,
 }: {
-  config: ResolvedPonderConfig;
-  options: PonderOptions;
+  config: ResolvedConfig;
+  options: Options;
 }) {
   const contractLogFilters = (config.contracts ?? [])
     .filter((contract) => contract.isLogEventSource ?? true)

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -1,7 +1,7 @@
 import { createPublicClient, http, PublicClient } from "viem";
 import { mainnet } from "viem/chains";
 
-import { ResolvedPonderConfig } from "@/config/ponderConfig";
+import { ResolvedConfig } from "@/config/config";
 
 export type Network = {
   name: string;
@@ -18,7 +18,7 @@ const clients: Record<number, PublicClient | undefined> = {};
 export function buildNetwork({
   network,
 }: {
-  network: ResolvedPonderConfig["networks"][0];
+  network: ResolvedConfig["networks"][0];
 }) {
   let client = clients[network.chainId];
 

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -10,6 +10,7 @@ export type Network = {
   rpcUrl?: string;
   pollingInterval: number;
   defaultMaxBlockRange: number;
+  maxRpcRequestConcurrency: number;
   finalityBlockCount: number;
 };
 
@@ -42,6 +43,7 @@ export function buildNetwork({
     rpcUrl: network.rpcUrl,
     pollingInterval: network.pollingInterval ?? 1_000,
     defaultMaxBlockRange: getDefaultMaxBlockRange(network),
+    maxRpcRequestConcurrency: network.maxRpcRequestConcurrency ?? 10,
     finalityBlockCount: getFinalityBlockCount(network),
   };
 

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
 import type { LevelWithSilent } from "pino";
 
-import type { PonderCliOptions } from "@/bin/ponder";
+import type { CliOptions } from "@/bin/ponder";
 
-import type { ResolvedPonderConfig } from "./ponderConfig";
+import type { ResolvedConfig } from "./config";
 
-export type PonderOptions = {
+export type Options = {
   configFile: string;
   schemaFile: string;
   rootDir: string;
@@ -25,9 +25,9 @@ export const buildOptions = ({
   cliOptions,
   configOptions = {},
 }: {
-  cliOptions: PonderCliOptions;
-  configOptions?: ResolvedPonderConfig["options"];
-}): PonderOptions => {
+  cliOptions: CliOptions;
+  configOptions?: ResolvedConfig["options"];
+}): Options => {
   const railwayHealthcheckTimeout = process.env.RAILWAY_HEALTHCHECK_TIMEOUT_SEC
     ? Math.max(Number(process.env.RAILWAY_HEALTHCHECK_TIMEOUT_SEC) - 5, 0) // Add 5 seconds of buffer.
     : undefined;

--- a/packages/core/src/event-aggregator/service.test.ts
+++ b/packages/core/src/event-aggregator/service.test.ts
@@ -18,6 +18,7 @@ const mainnet: Network = {
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,
+  maxRpcRequestConcurrency: 10,
 };
 
 const optimism: Network = {

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -23,6 +23,7 @@ const network: Network = {
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,
+  maxRpcRequestConcurrency: 10,
 };
 
 const rpcRequestSpy = vi.spyOn(

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -118,11 +118,12 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         );
 
         const totalBlockCount = endBlock - startBlock + 1;
-        const cachedBlockCount = cachedRanges.reduce(
-          (acc, cur) =>
-            acc + (Number(cur.endBlock) + 1 - Number(cur.startBlock)),
+        const requiredBlockCount = requiredBlockRanges.reduce<number>(
+          (acc, range) => acc + range[1] + 1 - range[0],
           0
         );
+        const cachedBlockCount = totalBlockCount - requiredBlockCount;
+
         const cacheRate = Math.min(
           1,
           cachedBlockCount / (totalBlockCount || 1)

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -276,11 +276,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       });
     };
 
-    console.log(
-      "building queue with concurrency:",
-      this.network.maxRpcRequestConcurrency
-    );
-
     const queue = createQueue<LogSyncTask | BlockSyncTask>({
       worker,
       options: {

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -276,9 +276,17 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       });
     };
 
+    console.log(
+      "building queue with concurrency:",
+      this.network.maxRpcRequestConcurrency
+    );
+
     const queue = createQueue<LogSyncTask | BlockSyncTask>({
       worker,
-      options: { concurrency: 10, autoStart: false },
+      options: {
+        concurrency: this.network.maxRpcRequestConcurrency,
+        autoStart: false,
+      },
       onComplete: ({ task }) => {
         const { logFilter } = task;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
-export type { PonderOptions } from "@/config/options";
-export type { PonderConfig, ResolvedPonderConfig } from "@/config/ponderConfig";
+export { PonderApp } from "@/build/handlers";
+export type { Config, ResolvedConfig } from "@/config/config";
+export type { Options } from "@/config/options";
 export { Ponder } from "@/Ponder";
-export { PonderApp } from "@/reload/readHandlers";
 export type { Block } from "@/types/block";
 export type { ReadOnlyContract } from "@/types/contract";
 export type { Log } from "@/types/log";

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -22,6 +22,7 @@ const network: Network = {
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 5,
+  maxRpcRequestConcurrency: 10,
 };
 
 const logFilters: LogFilter[] = [

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -1,7 +1,7 @@
 import { buildSchema as _buildGraphqlSchema } from "graphql";
 import { describe, expect, test } from "vitest";
 
-import { schemaHeader } from "@/reload/readGraphqlSchema";
+import { schemaHeader } from "@/build/schema";
 
 import { buildSchema } from "./schema";
 import {

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -3,8 +3,8 @@ import request from "supertest";
 import { beforeEach, expect, test } from "vitest";
 
 import { setupUserStore } from "@/_test/setup";
+import { schemaHeader } from "@/build/schema";
 import { Resources } from "@/Ponder";
-import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 import { UserStore } from "@/user-store/store";
 import { range } from "@/utils/range";
@@ -166,7 +166,7 @@ test("serves all scalar types correctly", async (context) => {
     bigInt: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("serves all scalar list types correctly", async (context) => {
@@ -221,7 +221,7 @@ test("serves all scalar list types correctly", async (context) => {
     bytesList: ["2"],
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("serves enum types correctly", async (context) => {
@@ -260,7 +260,7 @@ test("serves enum types correctly", async (context) => {
     enum: "TWO",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("serves derived types correctly", async (context) => {
@@ -298,7 +298,7 @@ test("serves derived types correctly", async (context) => {
     ],
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("serves relationship types correctly", async (context) => {
@@ -342,7 +342,7 @@ test("serves relationship types correctly", async (context) => {
     },
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string field equals", async (context) => {
@@ -371,7 +371,7 @@ test("filters on string field equals", async (context) => {
     id: "123",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string field in", async (context) => {
@@ -403,7 +403,7 @@ test("filters on string field in", async (context) => {
     id: "125",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string field contains", async (context) => {
@@ -432,7 +432,7 @@ test("filters on string field contains", async (context) => {
     id: "125",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string field starts with", async (context) => {
@@ -464,7 +464,7 @@ test("filters on string field starts with", async (context) => {
     id: "125",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string field not ends with", async (context) => {
@@ -496,7 +496,7 @@ test("filters on string field not ends with", async (context) => {
     id: "130",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on integer field equals", async (context) => {
@@ -525,7 +525,7 @@ test("filters on integer field equals", async (context) => {
     id: "0",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on integer field greater than", async (context) => {
@@ -554,7 +554,7 @@ test("filters on integer field greater than", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on integer field less than or equal to", async (context) => {
@@ -586,7 +586,7 @@ test("filters on integer field less than or equal to", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on integer field in", async (context) => {
@@ -618,7 +618,7 @@ test("filters on integer field in", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on float field equals", async (context) => {
@@ -647,7 +647,7 @@ test("filters on float field equals", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on float field greater than", async (context) => {
@@ -676,7 +676,7 @@ test("filters on float field greater than", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on float field less than or equal to", async (context) => {
@@ -709,7 +709,7 @@ test("filters on float field less than or equal to", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on float field in", async (context) => {
@@ -742,7 +742,7 @@ test("filters on float field in", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test.todo("filters on bigInt field equals", async (context) => {
@@ -771,7 +771,7 @@ test.todo("filters on bigInt field equals", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test.todo("filters on bigInt field greater than", async (context) => {
@@ -800,7 +800,7 @@ test.todo("filters on bigInt field greater than", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test.todo("filters on bigInt field less than or equal to", async (context) => {
@@ -833,7 +833,7 @@ test.todo("filters on bigInt field less than or equal to", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test.todo("filters on bigInt field in", async (context) => {
@@ -866,7 +866,7 @@ test.todo("filters on bigInt field in", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string list field equals", async (context) => {
@@ -895,7 +895,7 @@ test("filters on string list field equals", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on string list field contains", async (context) => {
@@ -924,7 +924,7 @@ test("filters on string list field contains", async (context) => {
     id: "2",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on enum field equals", async (context) => {
@@ -953,7 +953,7 @@ test("filters on enum field equals", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on enum field in", async (context) => {
@@ -985,7 +985,7 @@ test("filters on enum field in", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on relationship field equals", async (context) => {
@@ -1018,7 +1018,7 @@ test("filters on relationship field equals", async (context) => {
     },
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on relationship field in", async (context) => {
@@ -1049,7 +1049,7 @@ test("filters on relationship field in", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("filters on relationship field in", async (context) => {
@@ -1080,7 +1080,7 @@ test("filters on relationship field in", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("orders by on int field ascending", async (context) => {
@@ -1115,7 +1115,7 @@ test("orders by on int field ascending", async (context) => {
     id: "123",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("orders by on int field descending", async (context) => {
@@ -1150,7 +1150,7 @@ test("orders by on int field descending", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("orders by on bigInt field ascending", async (context) => {
@@ -1185,7 +1185,7 @@ test("orders by on bigInt field ascending", async (context) => {
     id: "123",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("orders by on bigInt field descending", async (context) => {
@@ -1220,7 +1220,7 @@ test("orders by on bigInt field descending", async (context) => {
     id: "1",
   });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("limits to the first 100 by default", async (context) => {
@@ -1245,7 +1245,7 @@ test("limits to the first 100 by default", async (context) => {
   expect(testEntitys).toHaveLength(100);
   expect(testEntitys[0]).toMatchObject({ id: "0" });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("limits as expected if less than 1000", async (context) => {
@@ -1270,7 +1270,7 @@ test("limits as expected if less than 1000", async (context) => {
   expect(testEntitys).toHaveLength(15);
   expect(testEntitys[0]).toMatchObject({ id: "0" });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("throws if limit is greater than 1000", async (context) => {
@@ -1295,7 +1295,7 @@ test("throws if limit is greater than 1000", async (context) => {
   );
   expect(response.statusCode).toBe(500);
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("skips as expected", async (context) => {
@@ -1320,7 +1320,7 @@ test("skips as expected", async (context) => {
   expect(testEntitys).toHaveLength(85);
   expect(testEntitys[0]).toMatchObject({ id: "20" });
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("throws if skip is greater than 5000", async (context) => {
@@ -1343,7 +1343,7 @@ test("throws if skip is greater than 5000", async (context) => {
   );
   expect(response.statusCode).toBe(500);
 
-  await service.teardown();
+  await service.kill();
 });
 
 test("limits and skips together as expected", async (context) => {
@@ -1369,5 +1369,5 @@ test("limits and skips together as expected", async (context) => {
   expect(testEntitys[0]).toMatchObject({ id: "50" });
   expect(testEntitys[9]).toMatchObject({ id: "59" });
 
-  await service.teardown();
+  await service.kill();
 });

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -148,18 +148,16 @@ export class ServerService {
 
   reload({ graphqlSchema }: { graphqlSchema: GraphQLSchema }) {
     // This uses a small hack to update the GraphQL server on the fly.
-    this.graphqlMiddleware = graphqlHTTP({
+    const graphqlMiddleware = graphqlHTTP({
       schema: graphqlSchema,
-      context: {
-        store: this.userStore,
-      },
+      context: { store: this.userStore },
       graphiql: true,
     });
 
-    this.app?.use("/", (...args) => this.graphqlMiddleware?.(...args));
+    this.app?.use("/", graphqlMiddleware);
   }
 
-  async teardown() {
+  async kill() {
     await this.terminate?.();
     this.resources.logger.debug({
       service: "server",

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -18,6 +18,7 @@ const network: Network = {
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,
+  maxRpcRequestConcurrency: 10,
 };
 
 const contracts: Contract[] = [

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -5,10 +5,10 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { usdcContractConfig } from "@/_test/constants";
 import { setupEventStore, setupUserStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
+import { schemaHeader } from "@/build/schema";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import { LogFilter } from "@/config/logFilters";
 import { EventAggregatorService } from "@/event-aggregator/service";
-import { schemaHeader } from "@/reload/readGraphqlSchema";
 import { buildSchema } from "@/schema/schema";
 
 import { EventHandlerService } from "./service";

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -23,6 +23,7 @@ const network = {
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,
+  maxRpcRequestConcurrency: 10,
 };
 
 const logFilters: LogFilter[] = [

--- a/packages/core/src/user-handlers/service.ts
+++ b/packages/core/src/user-handlers/service.ts
@@ -4,6 +4,7 @@ import { E_CANCELED, Mutex } from "async-mutex";
 import Emittery from "emittery";
 import { encodeEventTopics, getAbiItem, Hex } from "viem";
 
+import type { Handlers } from "@/build/handlers";
 import type { Contract } from "@/config/contracts";
 import type { LogFilter } from "@/config/logFilters";
 import { UserError } from "@/errors/user";
@@ -13,7 +14,6 @@ import type {
 } from "@/event-aggregator/service";
 import type { EventStore } from "@/event-store/store";
 import type { Resources } from "@/Ponder";
-import type { Handlers } from "@/reload/readHandlers";
 import type { Schema } from "@/schema/types";
 import type { ReadOnlyContract } from "@/types/contract";
 import type { Model } from "@/types/model";

--- a/packages/core/src/user-handlers/trace.ts
+++ b/packages/core/src/user-handlers/trace.ts
@@ -11,9 +11,9 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { parse as parseStackTrace, StackFrame } from "stacktrace-parser";
 
-import { PonderOptions } from "@/config/options";
+import { Options } from "@/config/options";
 
-export const getStackTrace = (error: Error, options: PonderOptions) => {
+export const getStackTrace = (error: Error, options: Options) => {
   if (!error.stack) return undefined;
 
   const buildDir = path.join(options.ponderDir, "out");

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -2,7 +2,7 @@ import { buildSchema as buildGraphqlSchema } from "graphql";
 import { beforeEach, expect, test } from "vitest";
 
 import { setupUserStore } from "@/_test/setup";
-import { schemaHeader } from "@/reload/readGraphqlSchema";
+import { schemaHeader } from "@/build/schema";
 import { buildSchema } from "@/schema/schema";
 
 beforeEach((context) => setupUserStore(context));

--- a/packages/core/src/user-store/utils.ts
+++ b/packages/core/src/user-store/utils.ts
@@ -75,7 +75,27 @@ export const filterTypes = {
   },
 } as const;
 
-export type FilterType = keyof typeof filterTypes;
+export type FilterType =
+  | ""
+  | "in"
+  | "not"
+  | "not_in"
+  | "contains"
+  | "contains_nocase"
+  | "not_contains"
+  | "not_contains_nocase"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "starts_with"
+  | "starts_with_nocase"
+  | "ends_with"
+  | "ends_with_nocase"
+  | "not_starts_with"
+  | "not_starts_with_nocase"
+  | "not_ends_with"
+  | "not_ends_with_nocase";
 
 export function getWhereOperatorAndValue({
   filterType,

--- a/packages/create-ponder/src/templates/basic.ts
+++ b/packages/create-ponder/src/templates/basic.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "node:fs";
 import path from "node:path";
 import prettier from "prettier";
 
-import type { PartialPonderConfig } from "@/index";
+import type { PartialConfig } from "@/index";
 
 export const fromBasic = ({ rootDir }: { rootDir: string }) => {
   const abiFileContents = `[]`;
@@ -31,7 +31,7 @@ export const fromBasic = ({ rootDir }: { rootDir: string }) => {
   );
 
   // Build the partial ponder config.
-  const ponderConfig: PartialPonderConfig = {
+  const config: PartialConfig = {
     networks: [
       {
         name: "mainnet",
@@ -50,5 +50,5 @@ export const fromBasic = ({ rootDir }: { rootDir: string }) => {
     ],
   };
 
-  return ponderConfig;
+  return config;
 };

--- a/packages/create-ponder/src/templates/etherscan.ts
+++ b/packages/create-ponder/src/templates/etherscan.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "node:fs";
 import path from "node:path";
 import fetch from "node-fetch";
 import prettier from "prettier";
-import type { PartialPonderConfig } from "src/index";
+import type { PartialConfig } from "src/index";
 
 import { getNetworkByEtherscanHostname } from "@/helpers/getEtherscanChainId";
 import { wait } from "@/helpers/wait";
@@ -140,7 +140,7 @@ export const fromEtherscan = async ({
   );
 
   // Build and return the partial ponder config.
-  const ponderConfig: PartialPonderConfig = {
+  const config: PartialConfig = {
     networks: [
       {
         name: name,
@@ -159,7 +159,7 @@ export const fromEtherscan = async ({
     ],
   };
 
-  return ponderConfig;
+  return config;
 };
 
 const fetchEtherscan = async (url: string) => {

--- a/packages/create-ponder/src/templates/subgraphId.ts
+++ b/packages/create-ponder/src/templates/subgraphId.ts
@@ -2,11 +2,7 @@ import { writeFileSync } from "node:fs";
 import path from "node:path";
 import fetch from "node-fetch";
 import prettier from "prettier";
-import type {
-  PartialPonderConfig,
-  PonderContract,
-  PonderNetwork,
-} from "src/index";
+import type { Contract, Network, PartialConfig } from "src/index";
 import { parse } from "yaml";
 
 import { getGraphProtocolChainId } from "@/helpers/getGraphProtocolChainId";
@@ -26,8 +22,8 @@ export const fromSubgraphId = async ({
   rootDir: string;
   subgraphId: string;
 }) => {
-  const ponderNetworks: PonderNetwork[] = [];
-  let ponderContracts: PonderContract[] = [];
+  const ponderNetworks: Network[] = [];
+  let ponderContracts: Contract[] = [];
 
   // Fetch the manifest file.
   const manifestRaw = await fetchIpfsFile(subgraphId);
@@ -82,7 +78,7 @@ export const fromSubgraphId = async ({
 
     const abiRelativePath = `./abis/${source.source.abi}.json`;
 
-    return <PonderContract>{
+    return <Contract>{
       name: source.name,
       network: network,
       address: source.source.address,
@@ -92,10 +88,10 @@ export const fromSubgraphId = async ({
   });
 
   // Build the partial ponder config.
-  const ponderConfig: PartialPonderConfig = {
+  const config: PartialConfig = {
     networks: ponderNetworks,
     contracts: ponderContracts,
   };
 
-  return ponderConfig;
+  return config;
 };

--- a/packages/create-ponder/src/templates/subgraphRepo.ts
+++ b/packages/create-ponder/src/templates/subgraphRepo.ts
@@ -8,11 +8,7 @@ import {
   subgraphYamlFileNames,
 } from "@/helpers/getGraphProtocolChainId";
 import { validateGraphProtocolSource } from "@/helpers/validateGraphProtocolSource";
-import type {
-  PartialPonderConfig,
-  PonderContract,
-  PonderNetwork,
-} from "@/index";
+import type { Contract, Network, PartialConfig } from "@/index";
 
 export const fromSubgraphRepo = ({
   rootDir,
@@ -23,8 +19,8 @@ export const fromSubgraphRepo = ({
 }) => {
   const subgraphRootDir = path.resolve(subgraphPath);
 
-  const ponderNetworks: PonderNetwork[] = [];
-  let ponderContracts: PonderContract[] = [];
+  const ponderNetworks: Network[] = [];
+  let ponderContracts: Contract[] = [];
 
   // If the `--from-subgraph` option was passed, parse subgraph files
   const subgraphRootDirPath = path.resolve(subgraphRootDir);
@@ -101,7 +97,7 @@ export const fromSubgraphRepo = ({
 
       copyFileSync(abiAbsolutePath, ponderAbiAbsolutePath);
 
-      return <PonderContract>{
+      return <Contract>{
         name: source.name,
         network: network,
         address: source.source.address,
@@ -111,10 +107,10 @@ export const fromSubgraphRepo = ({
     });
 
   // Build the partial ponder config.
-  const ponderConfig: PartialPonderConfig = {
+  const config: PartialConfig = {
     networks: ponderNetworks,
     contracts: ponderContracts,
   };
 
-  return ponderConfig;
+  return config;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,19 @@ importers:
       typescript: 5.1.3
       viem: 1.2.6_typescript@5.1.3
 
+  examples/token-reth:
+    specifiers:
+      '@ponder/core': workspace:latest
+      abitype: ^0.8.11
+      typescript: ^5.1.3
+      viem: ^1.2.6
+    dependencies:
+      '@ponder/core': link:../../packages/core
+    devDependencies:
+      abitype: 0.8.11_typescript@5.1.3
+      typescript: 5.1.3
+      viem: 1.2.6_typescript@5.1.3
+
   packages/core:
     specifiers:
       '@babel/code-frame': ^7.18.6


### PR DESCRIPTION
- Renames `ReloadService` to `BuildService` (internal).
- Renames public types `PonderConfig` to `Config`, `ResolvedPonderConfig` to `ResolvedConfig`, and `PonderOptions` to `Options`.
- Adds a `maxRpcRequestConcurrency` option to `networks` in config