### PR TITLE
Improve SQL query performance

### DIFF
--- a/.changeset/few-apples-punch.md
+++ b/.changeset/few-apples-punch.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Improved internal SQL query performance.

--- a/packages/core/src/event-store/postgres/migrations.ts
+++ b/packages/core/src/event-store/postgres/migrations.ts
@@ -125,11 +125,61 @@ const migrations: Record<string, Migration> = {
         .columns(["filterKey"])
         .execute();
     },
-
     async down(db: Kysely<any>) {
       await db.schema.dropIndex("log_events_index").execute();
-      await db.schema.dropIndex("logFilterCachedRanges_index").execute();
       await db.schema.dropIndex("blocks_index").execute();
+      await db.schema.dropIndex("logFilterCachedRanges_index").execute();
+    },
+  },
+  ["2023_07_18_0_better_indices"]: {
+    async up(db: Kysely<any>) {
+      // Drop old indices.
+      await db.schema.dropIndex("log_events_index").execute();
+      await db.schema.dropIndex("blocks_index").execute();
+
+      // Block hash is a join key.
+      await db.schema
+        .createIndex("log_block_hash_index")
+        .on("logs")
+        .column("blockHash")
+        .execute();
+
+      // Chain ID, address and topic0 are all used in WHERE clauses.
+      await db.schema
+        .createIndex("log_chain_id_index")
+        .on("logs")
+        .column("chainId")
+        .execute();
+      await db.schema
+        .createIndex("log_address_index")
+        .on("logs")
+        .column("address")
+        .execute();
+      await db.schema
+        .createIndex("log_topic0_index")
+        .on("logs")
+        .column("topic0")
+        .execute();
+
+      // Block timestamp and number are both used in WHERE and SORT clauses.
+      await db.schema
+        .createIndex("block_timestamp_index")
+        .on("blocks")
+        .column("timestamp")
+        .execute();
+      await db.schema
+        .createIndex("block_number_index")
+        .on("blocks")
+        .column("number")
+        .execute();
+    },
+    async down(db: Kysely<any>) {
+      await db.schema.dropIndex("log_block_hash_index").execute();
+      await db.schema.dropIndex("log_chain_id_index").execute();
+      await db.schema.dropIndex("log_address_index").execute();
+      await db.schema.dropIndex("log_topic0_index").execute();
+      await db.schema.dropIndex("block_timestamp_index").execute();
+      await db.schema.dropIndex("block_number_index").execute();
     },
   },
 };

--- a/packages/core/src/event-store/sqlite/migrations.ts
+++ b/packages/core/src/event-store/sqlite/migrations.ts
@@ -125,11 +125,61 @@ const migrations: Record<string, Migration> = {
         .columns(["filterKey"])
         .execute();
     },
-
     async down(db: Kysely<any>) {
       await db.schema.dropIndex("log_events_index").execute();
-      await db.schema.dropIndex("logFilterCachedRanges_index").execute();
       await db.schema.dropIndex("blocks_index").execute();
+      await db.schema.dropIndex("logFilterCachedRanges_index").execute();
+    },
+  },
+  ["2023_07_18_0_better_indices"]: {
+    async up(db: Kysely<any>) {
+      // Drop old indices.
+      await db.schema.dropIndex("log_events_index").execute();
+      await db.schema.dropIndex("blocks_index").execute();
+
+      // Block hash is a join key.
+      await db.schema
+        .createIndex("log_block_hash_index")
+        .on("logs")
+        .column("blockHash")
+        .execute();
+
+      // Chain ID, address and topic0 are all used in WHERE clauses.
+      await db.schema
+        .createIndex("log_chain_id_index")
+        .on("logs")
+        .column("chainId")
+        .execute();
+      await db.schema
+        .createIndex("log_address_index")
+        .on("logs")
+        .column("address")
+        .execute();
+      await db.schema
+        .createIndex("log_topic0_index")
+        .on("logs")
+        .column("topic0")
+        .execute();
+
+      // Block timestamp and number are both used in WHERE and SORT clauses.
+      await db.schema
+        .createIndex("block_timestamp_index")
+        .on("blocks")
+        .column("timestamp")
+        .execute();
+      await db.schema
+        .createIndex("block_number_index")
+        .on("blocks")
+        .column("number")
+        .execute();
+    },
+    async down(db: Kysely<any>) {
+      await db.schema.dropIndex("log_block_hash_index").execute();
+      await db.schema.dropIndex("log_chain_id_index").execute();
+      await db.schema.dropIndex("log_address_index").execute();
+      await db.schema.dropIndex("log_topic0_index").execute();
+      await db.schema.dropIndex("block_timestamp_index").execute();
+      await db.schema.dropIndex("block_number_index").execute();
     },
   },
 };

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -1,5 +1,12 @@
 import type Sqlite from "better-sqlite3";
-import { Kysely, Migrator, NO_MIGRATIONS, sql, SqliteDialect } from "kysely";
+import {
+  type ExpressionBuilder,
+  Kysely,
+  Migrator,
+  NO_MIGRATIONS,
+  sql,
+  SqliteDialect,
+} from "kysely";
 import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
 
 import type { Block } from "@/types/block";
@@ -9,6 +16,7 @@ import type { NonNull } from "@/types/utils";
 import { blobToBigInt } from "@/utils/decode";
 import { intToBlob } from "@/utils/encode";
 import { mergeIntervals } from "@/utils/intervals";
+import { range } from "@/utils/range";
 
 import type { EventStore } from "../store";
 import {
@@ -410,10 +418,13 @@ export class SqliteEventStore implements EventStore {
     }[];
     pageSize: number;
   }) {
-    const includedLogQueryBase = this.db
+    const baseQuery = this.db
       .with(
-        "logFilters(logFilter_name, logFilter_chainId, logFilter_address, logFilter_topic0, logFilter_topic1, logFilter_topic2, logFilter_topic3, logFilter_fromBlock, logFilter_toBlock, logFilter_includeEventSelectors)",
-        () => sql`( values ${sql.join(filters.map(buildLogFilterValues))} )`
+        "logFilters(logFilter_name)",
+        () =>
+          sql`( values ${sql.join(
+            filters.map((f) => sql`( ${sql.val(f.name)} )`)
+          )} )`
       )
       .selectFrom("logs")
       .leftJoin("blocks", "blocks.hash", "logs.blockHash")
@@ -480,49 +491,6 @@ export class SqliteEventStore implements EventStore {
         "transactions.value as tx_value",
         "transactions.v as tx_v",
       ])
-      .where(({ and, or, cmpr, ref }) =>
-        and([
-          cmpr("logs.chainId", "=", ref("logFilter_chainId")),
-          or([
-            cmpr("logFilter_address", "is", null),
-            cmpr("logFilter_address", "like", sql`'%' || logs.address || '%'`),
-          ]),
-          and([
-            or([
-              cmpr("logFilter_topic0", "is", null),
-              cmpr("logFilter_topic0", "like", sql`'%' || logs.topic0 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic1", "is", null),
-              cmpr("logFilter_topic1", "like", sql`'%' || logs.topic1 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic2", "is", null),
-              cmpr("logFilter_topic2", "like", sql`'%' || logs.topic2 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic3", "is", null),
-              cmpr("logFilter_topic3", "like", sql`'%' || logs.topic3 || '%'`),
-            ]),
-          ]),
-          or([
-            cmpr("logFilter_fromBlock", "is", null),
-            cmpr("blocks.number", ">=", ref("logFilter_fromBlock")),
-          ]),
-          or([
-            cmpr("logFilter_toBlock", "is", null),
-            cmpr("blocks.number", "<=", ref("logFilter_toBlock")),
-          ]),
-          or([
-            cmpr("logFilter_includeEventSelectors", "is", null),
-            cmpr(
-              "logFilter_includeEventSelectors",
-              "like",
-              sql`'%' || logs.topic0 || '%'`
-            ),
-          ]),
-        ])
-      )
       .where("blocks.timestamp", ">=", intToBlob(fromTimestamp))
       .where("blocks.timestamp", "<=", intToBlob(toTimestamp))
       .orderBy("blocks.timestamp", "asc")
@@ -530,57 +498,113 @@ export class SqliteEventStore implements EventStore {
       .orderBy("blocks.number", "asc")
       .orderBy("logs.logIndex", "asc");
 
+    const buildFilterAndCmprs = (
+      where: ExpressionBuilder<any, any>,
+      filter: (typeof filters)[number]
+    ) => {
+      const { cmpr, or } = where;
+      const cmprs = [];
+
+      cmprs.push(cmpr("logFilter_name", "=", filter.name));
+      cmprs.push(
+        cmpr(
+          "logs.chainId",
+          "=",
+          sql`cast (${sql.val(filter.chainId)} as integer)`
+        )
+      );
+
+      if (filter.address) {
+        // If it's an array of length 1, collapse it.
+        const address =
+          Array.isArray(filter.address) && filter.address.length === 1
+            ? filter.address[0]
+            : filter.address;
+        if (Array.isArray(address)) {
+          cmprs.push(or(address.map((a) => cmpr("logs.address", "=", a))));
+        } else {
+          cmprs.push(cmpr("logs.address", "=", address));
+        }
+      }
+
+      if (filter.topics) {
+        for (const idx_ of range(0, 4)) {
+          const idx = idx_ as 0 | 1 | 2 | 3;
+          // If it's an array of length 1, collapse it.
+          const raw = filter.topics[idx] ?? null;
+          if (raw === null) continue;
+          const topic = Array.isArray(raw) && raw.length === 1 ? raw[0] : raw;
+          if (Array.isArray(topic)) {
+            cmprs.push(or(topic.map((a) => cmpr(`logs.topic${idx}`, "=", a))));
+          } else {
+            cmprs.push(cmpr(`logs.topic${idx}`, "=", topic));
+          }
+        }
+      }
+
+      if (filter.fromBlock) {
+        cmprs.push(
+          cmpr(
+            "blocks.number",
+            ">=",
+            sql`cast (${sql.val(intToBlob(filter.fromBlock))} as blob)`
+          )
+        );
+      }
+
+      if (filter.toBlock) {
+        cmprs.push(
+          cmpr(
+            "blocks.number",
+            "<=",
+            sql`cast (${sql.val(intToBlob(filter.toBlock))} as blob)`
+          )
+        );
+      }
+
+      return cmprs;
+    };
+    // Get full log objects, including the includeEventSelectors clause.
+    const includedLogsBaseQuery = baseQuery
+      .where((where) => {
+        const { cmpr, and, or } = where;
+        const cmprsForAllFilters = filters.map((filter) => {
+          const cmprsForFilter = buildFilterAndCmprs(where, filter);
+          if (filter.includeEventSelectors) {
+            cmprsForFilter.push(
+              or(
+                filter.includeEventSelectors.map((t) =>
+                  cmpr("logs.topic0", "=", t)
+                )
+              )
+            );
+          }
+          return and(cmprsForFilter);
+        });
+        return or(cmprsForAllFilters);
+      })
+      .orderBy("blocks.timestamp", "asc")
+      .orderBy("logs.chainId", "asc")
+      .orderBy("blocks.number", "asc")
+      .orderBy("logs.logIndex", "asc");
+
     // Get total count of matching logs, grouped by log filter and event selector.
-    const eventCountsQuery = this.db
-      .with(
-        "logFilters(logFilter_name, logFilter_chainId, logFilter_address, logFilter_topic0, logFilter_topic1, logFilter_topic2, logFilter_topic3, logFilter_fromBlock, logFilter_toBlock, logFilter_includeEventSelectors)",
-        () => sql`( values ${sql.join(filters.map(buildLogFilterValues))} )`
-      )
-      .selectFrom("logs")
-      .leftJoin("blocks", "blocks.hash", "logs.blockHash")
-      .innerJoin("logFilters", (join) => join.onTrue())
+    const eventCountsQuery = baseQuery
+      .clearSelect()
       .select([
         "logFilter_name",
         "logs.topic0",
         this.db.fn.count("logs.id").as("count"),
       ])
-      .where(({ and, or, cmpr, ref }) =>
-        and([
-          cmpr("logs.chainId", "=", ref("logFilter_chainId")),
-          or([
-            cmpr("logFilter_address", "is", null),
-            cmpr("logFilter_address", "like", sql`'%' || logs.address || '%'`),
-          ]),
-          and([
-            or([
-              cmpr("logFilter_topic0", "is", null),
-              cmpr("logFilter_topic0", "like", sql`'%' || logs.topic0 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic1", "is", null),
-              cmpr("logFilter_topic1", "like", sql`'%' || logs.topic1 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic2", "is", null),
-              cmpr("logFilter_topic2", "like", sql`'%' || logs.topic2 || '%'`),
-            ]),
-            or([
-              cmpr("logFilter_topic3", "is", null),
-              cmpr("logFilter_topic3", "like", sql`'%' || logs.topic3 || '%'`),
-            ]),
-          ]),
-          or([
-            cmpr("logFilter_fromBlock", "is", null),
-            cmpr("blocks.number", ">=", ref("logFilter_fromBlock")),
-          ]),
-          or([
-            cmpr("logFilter_toBlock", "is", null),
-            cmpr("blocks.number", "<=", ref("logFilter_toBlock")),
-          ]),
-        ])
-      )
-      .where("blocks.timestamp", ">=", intToBlob(fromTimestamp))
-      .where("blocks.timestamp", "<=", intToBlob(toTimestamp))
+      .where((where) => {
+        const { and, or } = where;
+        const cmprsForAllFilters = filters.map((filter) => {
+          const cmprsForFilter = buildFilterAndCmprs(where, filter);
+          // NOTE: Not adding the includeEventSelectors clause here.
+          return and(cmprsForFilter);
+        });
+        return or(cmprsForAllFilters);
+      })
       .groupBy(["logFilter_name", "logs.topic0"]);
 
     // Fetch the event counts once and include it in every response.
@@ -601,7 +625,7 @@ export class SqliteEventStore implements EventStore {
       | undefined = undefined;
 
     while (true) {
-      let query = includedLogQueryBase.limit(pageSize);
+      let query = includedLogsBaseQuery.limit(pageSize);
       if (cursor) {
         // See this comment for an explanation of the cursor logic.
         // https://stackoverflow.com/a/38017813
@@ -758,58 +782,4 @@ export class SqliteEventStore implements EventStore {
       if (events.length < pageSize) break;
     }
   }
-}
-
-function getLogFilterAddressOrTopic(value: Hex | Hex[] | undefined | null) {
-  if (value === undefined || value === null) return null;
-  if (typeof value === "string") return value;
-  return value.join(",");
-}
-
-function getLogFilterTopics(topics: (Hex | Hex[] | null)[] | undefined) {
-  if (!topics) return [null, null, null, null];
-  const topic0 = getLogFilterAddressOrTopic(topics[0]);
-  const topic1 = getLogFilterAddressOrTopic(topics[1]);
-  const topic2 = getLogFilterAddressOrTopic(topics[2]);
-  const topic3 = getLogFilterAddressOrTopic(topics[3]);
-  return [topic0, topic1, topic2, topic3];
-}
-
-function buildLogFilterValues(filter: {
-  name: string;
-  chainId: number;
-  address?: Address | Address[];
-  topics?: (Hex | Hex[] | null)[];
-  fromBlock?: number;
-  toBlock?: number;
-  includeEventSelectors?: Hex[];
-}) {
-  const {
-    name,
-    chainId,
-    address,
-    topics,
-    fromBlock,
-    toBlock,
-    includeEventSelectors,
-  } = filter;
-
-  const address_ = getLogFilterAddressOrTopic(address);
-  const [topic0, topic1, topic2, topic3] = getLogFilterTopics(topics);
-  const includeEventSelectors_ = getLogFilterAddressOrTopic(
-    includeEventSelectors
-  );
-
-  return sql`(${sql.join([
-    sql.val(name),
-    sql`cast (${sql.val(chainId)} as integer)`,
-    sql.val(address_),
-    sql.val(topic0),
-    sql.val(topic1),
-    sql.val(topic2),
-    sql.val(topic3),
-    sql`cast (${sql.val(fromBlock ? intToBlob(fromBlock) : null)} as blob)`,
-    sql`cast (${sql.val(toBlock ? intToBlob(toBlock) : null)} as blob)`,
-    sql.val(includeEventSelectors_),
-  ])})`;
 }


### PR DESCRIPTION
This PR improves the performance of an internal event store method (`getLogEvents`) quite a lot by adding indexes and restructuring the generated SQL query to take advantage of them.

If curious - the previous approach used `LIKE` operators for matching `address` and `topics` values, which cannot take advantage of column indexes. The new approach compares values directly, adding additional `AND`/`OR` clauses for each address and topic value present in the log filter.