### PR TITLE
[experiment] Order events by block number (not timestamp)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "0xOlias/ponder" }],
   "commit": false,
   "fixed": [["@ponder/core", "create-ponder"]],
   "linked": [],

--- a/.changeset/khaki-ants-change.md
+++ b/.changeset/khaki-ants-change.md
@@ -1,0 +1,55 @@
+---
+"create-ponder": patch
+"@ponder/core": patch
+---
+
+Updated event ordering to use block number and log index, replacing a more complex timestamp-based ordering system that worked across chains. This means that (for now) Ponder apps must only index one chain at a time. The `ponder.config.ts` `networks` field has been renamed to `network`, and accepts a single network object instead of an array of networks. The `contracts` and `filters` objects no longer require a `network` property, because they always correspond to the single network specified in the `network` field.
+
+```diff
+// ponder.config.ts
+import type { Config } from "@ponder/core";
+
+export const config: Config = {
+-  networks: [
+-    {
+-      name: "mainnet",
+-      chainId: 1,
+-      rpcUrl: process.env.PONDER_RPC_URL_1,
+-    }
+-  ],
++  network: {
++    name: "mainnet",
++    chainId: 1,
++    rpcUrl: process.env.PONDER_RPC_URL_1,
++  },
+  contracts: [
+    {
+      name: "MyNftContract",
+-      network: "mainnet",
+      abi: ERC721Abi,
+      address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+      // ...
+    }
+  ],
+};
+```
+
+The `contracts` and `filters` objects do not require a `network` property, because they will always correspond to the single network specified in the `network` field.
+
+```diff
+// ponder.config.ts
+import type { Config } from "@ponder/core";
+
+export const config: Config = {
+  network: { /* ... */ },
+  contracts: [
+    {
+      name: "MyNftContract",
+-      network: "mainnet",
+      abi: ERC721Abi,
+      address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+      // ...
+    }
+  ],
+};
+```

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@ponder/core": "0.0.80",
+    "create-ponder": "0.0.80"
+  },
+  "changesets": ["khaki-ants-change"]
+}

--- a/benchmarks/ponder/ponder.config.ts
+++ b/benchmarks/ponder/ponder.config.ts
@@ -3,17 +3,14 @@ import type { Config } from "@ponder/core";
 import RocketTokenRETHAbi from "./abis/RocketTokenRETH.json";
 
 export const config: Config = {
-  networks: [
-    {
-      name: "mainnet",
-      chainId: 1,
-      rpcUrl: process.env.ANVIL_FORK_URL,
-    },
-  ],
+  network: {
+    name: "mainnet",
+    chainId: 1,
+    rpcUrl: process.env.ANVIL_FORK_URL,
+  },
   contracts: [
     {
       name: "RocketTokenRETH",
-      network: "mainnet",
       abi: RocketTokenRETHAbi,
       address: "0xae78736cd615f374d3085123a210448e74fc6393",
       startBlock: 17500000,

--- a/benchmarks/src/bench.ts
+++ b/benchmarks/src/bench.ts
@@ -2,7 +2,7 @@ import { ponder } from "./ponder";
 import { subgraph } from "./subgraph";
 
 const bench = async () => {
-  // await subgraph();
+  await subgraph();
   await ponder();
 };
 

--- a/benchmarks/src/ponder.ts
+++ b/benchmarks/src/ponder.ts
@@ -2,7 +2,7 @@ import execa from "execa";
 
 import { fetchWithTimeout, parsePrometheusText, startClock } from "./utils";
 
-const END_BLOCK_TIMESTAMP = 1687010711; // Mainnet block 17500010
+const END_BLOCK = 17500010;
 
 const fetchPonderMetrics = async () => {
   try {
@@ -24,15 +24,15 @@ const waitForSyncComplete = async () => {
     let timeout = undefined;
     const interval = setInterval(async () => {
       const metrics = await fetchPonderMetrics();
-      const latestProcessedTimestamp =
+      const latestProcessedBlock =
         metrics.find(
-          (m) => m.name === "ponder_handlers_latest_processed_timestamp"
+          (m) => m.name === "ponder_handlers_latest_processed_block_number"
         )?.metrics[0].value ?? 0;
       console.log(
-        `Latest processed timestamp: ${latestProcessedTimestamp}/${END_BLOCK_TIMESTAMP}`
+        `Latest processed block: ${latestProcessedBlock}/${END_BLOCK}`
       );
 
-      if (latestProcessedTimestamp >= END_BLOCK_TIMESTAMP) {
+      if (latestProcessedBlock >= END_BLOCK) {
         duration = endClock();
         clearInterval(interval);
         clearTimeout(timeout);

--- a/benchmarks/subgraph/src/mapping.ts
+++ b/benchmarks/subgraph/src/mapping.ts
@@ -1,6 +1,6 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 
-import type {
+import {
   Approval as TApprovalEvent,
   Transfer as TTransferEvent,
 } from "../generated/RocketTokenRETH/RocketTokenRETH";
@@ -12,7 +12,7 @@ import {
 } from "../generated/schema";
 
 export function handleTransfer(event: TTransferEvent): void {
-  const { params } = event;
+  const params = event.params;
 
   // Create an Account for the sender, or update the balance if it already exists.
   let sender = Account.load(params.from.toHexString());
@@ -49,7 +49,7 @@ export function handleTransfer(event: TTransferEvent): void {
 }
 
 export function handleApproval(event: TApprovalEvent): void {
-  const { params } = event;
+  const params = event.params;
   const approvalId =
     params.owner.toHexString() + "-" + params.spender.toHexString();
 

--- a/examples/art-gobblers/ponder.config.ts
+++ b/examples/art-gobblers/ponder.config.ts
@@ -3,17 +3,14 @@ import type { Config } from "@ponder/core";
 import ArtGobblersAbi from "./abis/ArtGobblers.json";
 
 export const config: Config = {
-  networks: [
-    {
-      name: "mainnet",
-      chainId: 1,
-      rpcUrl: process.env.PONDER_RPC_URL_1,
-    },
-  ],
+  network: {
+    name: "mainnet",
+    chainId: 1,
+    rpcUrl: process.env.PONDER_RPC_URL_1,
+  },
   contracts: [
     {
       name: "ArtGobblers",
-      network: "mainnet",
       abi: ArtGobblersAbi,
       address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
       startBlock: 15863321,

--- a/examples/ethfs/ponder.config.ts
+++ b/examples/ethfs/ponder.config.ts
@@ -4,24 +4,20 @@ import FileStoreAbi from "./abis/FileStore.json";
 import FileStoreFrontendAbi from "./abis/FileStoreFrontend.json";
 
 export const config: Config = {
-  networks: [
-    {
-      name: "mainnet",
-      chainId: 1,
-      rpcUrl: process.env.PONDER_RPC_URL_1,
-    },
-  ],
+  network: {
+    name: "mainnet",
+    chainId: 1,
+    rpcUrl: process.env.PONDER_RPC_URL_1,
+  },
   contracts: [
     {
       name: "FileStore",
-      network: "mainnet",
       abi: FileStoreAbi,
       address: "0x9746fD0A77829E12F8A9DBe70D7a322412325B91",
       startBlock: 15963553,
     },
     {
       name: "FileStoreFrontend",
-      network: "mainnet",
       address: "0xBc66C61BCF49Cc3fe4E321aeCEa307F61EC57C0b",
       abi: FileStoreFrontendAbi,
       isLogEventSource: false,

--- a/examples/token-erc20/ponder.config.ts
+++ b/examples/token-erc20/ponder.config.ts
@@ -1,13 +1,14 @@
 import type { Config } from "@ponder/core";
 
 export const config: Config = {
-  networks: [
-    { name: "mainnet", chainId: 1, rpcUrl: process.env.PONDER_RPC_URL_1 },
-  ],
+  network: {
+    name: "mainnet",
+    chainId: 1,
+    rpcUrl: process.env.PONDER_RPC_URL_1,
+  },
   contracts: [
     {
       name: "AdventureGold",
-      network: "mainnet",
       abi: "./abis/AdventureGold.json",
       address: "0x32353A6C91143bfd6C7d363B546e62a9A2489A20",
       startBlock: 13142655,

--- a/examples/token-erc721/ponder.config.ts
+++ b/examples/token-erc721/ponder.config.ts
@@ -1,17 +1,14 @@
 import type { Config } from "@ponder/core";
 
 export const config: Config = {
-  networks: [
-    {
-      name: "arbitrum",
-      chainId: 42161,
-      rpcUrl: process.env.PONDER_RPC_URL_42161,
-    },
-  ],
+  network: {
+    name: "arbitrum",
+    chainId: 42161,
+    rpcUrl: process.env.PONDER_RPC_URL_42161,
+  },
   contracts: [
     {
       name: "SmolBrain",
-      network: "arbitrum",
       abi: "./abis/SmolBrain.json",
       address: "0x6325439389E0797Ab35752B4F43a14C004f22A9c",
       startBlock: 3163146,

--- a/examples/token-reth/ponder.config.ts
+++ b/examples/token-reth/ponder.config.ts
@@ -1,18 +1,15 @@
 import type { Config } from "@ponder/core";
 
 export const config: Config = {
-  networks: [
-    {
-      name: "mainnet",
-      chainId: 1,
-      rpcUrl: process.env.PONDER_RPC_URL_1,
-      maxRpcRequestConcurrency: 25,
-    },
-  ],
+  network: {
+    name: "mainnet",
+    chainId: 1,
+    rpcUrl: process.env.PONDER_RPC_URL_1,
+    maxRpcRequestConcurrency: 25,
+  },
   contracts: [
     {
       name: "RocketTokenRETH",
-      network: "mainnet",
       abi: "./abis/RocketTokenRETH.json",
       address: "0xae78736cd615f374d3085123a210448e74fc6393",
       startBlock: 13325304,

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,60 @@
 # @ponder/core
 
+## 0.0.81-next.0
+
+### Patch Changes
+
+- 004dac1: Updated event ordering to use block number and log index, replacing a more complex timestamp-based ordering system that worked across chains. This means that (for now) Ponder apps must only index one chain at a time. The `ponder.config.ts` `networks` field has been renamed to `network`, and accepts a single network object instead of an array of networks. The `contracts` and `filters` objects no longer require a `network` property, because they always correspond to the single network specified in the `network` field.
+
+  ```diff
+  // ponder.config.ts
+  import type { Config } from "@ponder/core";
+
+  export const config: Config = {
+  -  networks: [
+  -    {
+  -      name: "mainnet",
+  -      chainId: 1,
+  -      rpcUrl: process.env.PONDER_RPC_URL_1,
+  -    }
+  -  ],
+  +  network: {
+  +    name: "mainnet",
+  +    chainId: 1,
+  +    rpcUrl: process.env.PONDER_RPC_URL_1,
+  +  },
+    contracts: [
+      {
+        name: "MyNftContract",
+  -      network: "mainnet",
+        abi: ERC721Abi,
+        address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+        // ...
+      }
+    ],
+  };
+  ```
+
+  The `contracts` and `filters` objects do not require a `network` property, because they will always correspond to the single network specified in the `network` field.
+
+  ```diff
+  // ponder.config.ts
+  import type { Config } from "@ponder/core";
+
+  export const config: Config = {
+    network: { /* ... */ },
+    contracts: [
+      {
+        name: "MyNftContract",
+  -      network: "mainnet",
+        abi: ERC721Abi,
+        address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+        // ...
+      }
+    ],
+  };
+  ```
+
 ## 0.0.80
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ponder/core",
-  "version": "0.0.80",
+  "version": "0.0.81-next.0",
   "description": "An open-source framework for crypto application backends",
   "license": "MIT",
   "files": [

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -333,24 +333,16 @@ export class Ponder {
 
     this.eventAggregatorService.on(
       "reorg",
-      async ({ commonAncestorTimestamp }) => {
-        await this.eventHandlerService.handleReorg({ commonAncestorTimestamp });
+      async ({ commonAncestorBlockNumber }) => {
+        await this.eventHandlerService.handleReorg({
+          commonAncestorBlockNumber,
+        });
         await this.eventHandlerService.processEvents();
       }
     );
 
-    this.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
-      if (this.serverService.isHistoricalEventProcessingComplete) return;
-
-      // If a batch of events are processed AND the historical sync is complete AND
-      // the new toTimestamp is greater than the historical sync completion timestamp,
-      // historical event processing is complete, and the server should begin responding as healthy.
-      if (
-        this.eventAggregatorService.historicalSyncCompletedAt &&
-        toTimestamp >= this.eventAggregatorService.historicalSyncCompletedAt
-      ) {
-        this.serverService.setIsHistoricalEventProcessingComplete();
-      }
+    this.eventHandlerService.on("historicalEventProcessingCompleted", () => {
+      this.serverService.setIsHistoricalEventProcessingComplete();
     });
   }
 }

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -304,8 +304,8 @@ export class Ponder {
       });
     });
 
-    this.historicalSyncService.on("syncComplete", () => {
-      this.eventAggregatorService.handleHistoricalSyncComplete();
+    this.historicalSyncService.on("syncComplete", ({ blockNumber }) => {
+      this.eventAggregatorService.handleHistoricalSyncComplete({ blockNumber });
     });
 
     this.realtimeSyncService.on("realtimeCheckpoint", ({ blockNumber }) => {

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -42,11 +42,8 @@ const setup = async ({ context }: { context: TestContext }) => {
 
   // Wait for historical sync event processing to complete.
   await new Promise<void>((resolve) => {
-    ponder.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
-      // Block 15870405
-      if (toTimestamp >= 1667247815) {
-        resolve();
-      }
+    ponder.eventHandlerService.on("historicalEventProcessingCompleted", () => {
+      resolve();
     });
   });
 

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -17,7 +17,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
   });
   // Inject proxied anvil chain.
-  const testConfig = { ...config, networks: [testNetworkConfig] };
+  const testConfig = { ...config, network: testNetworkConfig };
 
   const options = buildOptions({
     cliOptions: {
@@ -41,9 +41,17 @@ const setup = async ({ context }: { context: TestContext }) => {
   await ponder.start();
 
   // Wait for historical sync event processing to complete.
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          "Timeout: Historical event processing did not complete in 20 seconds."
+        )
+      );
+    }, 20_000);
     ponder.eventHandlerService.on("historicalEventProcessingCompleted", () => {
       resolve();
+      clearTimeout(timeout);
     });
   });
 

--- a/packages/core/src/_test/art-gobblers/app/ponder.config.ts
+++ b/packages/core/src/_test/art-gobblers/app/ponder.config.ts
@@ -1,11 +1,10 @@
 import ArtGobblersAbi from "./ArtGobblers.json";
 
 export const config = {
-  networks: [{ name: "mainnet", chainId: 1, rpcUrl: "http://127.0.0.1:8545" }],
+  network: { name: "mainnet", chainId: 1, rpcUrl: "http://127.0.0.1:8545" },
   contracts: [
     {
       name: "ArtGobblers",
-      network: "mainnet",
       abi: ArtGobblersAbi,
       address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
       startBlock: 15870400,

--- a/packages/core/src/_test/constants.ts
+++ b/packages/core/src/_test/constants.ts
@@ -437,5 +437,4 @@ export const logFilterCachedRangeOne: LogFilterCachedRange = {
   filterKey: '1-0x93d4c048f83bd7e37d49ea4c83a07267ec4203da-["0x1",null,"0x3"]',
   startBlock: 16000010,
   endBlock: 16000090,
-  endBlockTimestamp: 16000010,
 };

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -17,7 +17,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     configFile: path.resolve("src/_test/ens/app/ponder.config.ts"),
   });
   // Inject proxied anvil chain.
-  const testConfig = { ...config, networks: [testNetworkConfig] };
+  const testConfig = { ...config, network: testNetworkConfig };
 
   const options = buildOptions({
     cliOptions: {
@@ -41,9 +41,17 @@ const setup = async ({ context }: { context: TestContext }) => {
   await ponder.start();
 
   // Wait for historical sync event processing to complete.
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          "Timeout: Historical event processing did not complete in 20 seconds."
+        )
+      );
+    }, 20_000);
     ponder.eventHandlerService.on("historicalEventProcessingCompleted", () => {
       resolve();
+      clearTimeout(timeout);
     });
   });
 

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -42,11 +42,8 @@ const setup = async ({ context }: { context: TestContext }) => {
 
   // Wait for historical sync event processing to complete.
   await new Promise<void>((resolve) => {
-    ponder.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
-      // Block 16370020
-      if (toTimestamp >= 1673276663) {
-        resolve();
-      }
+    ponder.eventHandlerService.on("historicalEventProcessingCompleted", () => {
+      resolve();
     });
   });
 

--- a/packages/core/src/_test/ens/app/ponder.config.ts
+++ b/packages/core/src/_test/ens/app/ponder.config.ts
@@ -1,11 +1,10 @@
 import BaseRegistrarImplementationAbi from "./BaseRegistrarImplementation.abi.json";
 
 export const config = {
-  networks: [{ name: "mainnet", chainId: 1, rpcUrl: "http://127.0.0.1:8545" }],
+  network: { name: "mainnet", chainId: 1, rpcUrl: "http://127.0.0.1:8545" },
   contracts: [
     {
       name: "BaseRegistrarImplementation",
-      network: "mainnet",
       abi: BaseRegistrarImplementationAbi,
       address: "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
       startBlock: 16370000,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -35,8 +35,6 @@ export type ResolvedConfig = {
   contracts?: {
     /** Contract name. Must be unique across `contracts` and `filters`. */
     name: string;
-    /** Network that this contract is deployed to. Must match a network name in `networks`. */
-    network: string; // TODO: narrow this type to TNetworks[number]['name']
     /** Contract ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
     abi: string | any[] | readonly any[] | (string | any[] | readonly any[])[];
     /** Contract address. */
@@ -54,8 +52,6 @@ export type ResolvedConfig = {
   filters?: {
     /** Filter name. Must be unique across `contracts` and `filters`. */
     name: string;
-    /** Network that this filter is deployed to. Must match a network name in `networks`. */
-    network: string; // TODO: narrow this type to TNetworks[number]['name']
     /** Log filter ABI as a file path or an Array object. Accepts a single ABI or a list of ABIs to be merged. */
     abi: string | any[] | readonly any[] | (string | any[] | readonly any[])[];
     /** Log filter options. */

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -19,8 +19,8 @@ export type ResolvedConfig = {
         connectionString?: string;
       };
   /** List of blockchain networks. */
-  networks: {
-    /** Network name. Must be unique across all networks. */
+  network: {
+    /** Network name. */
     name: string;
     /** Chain ID of the network. */
     chainId: number;
@@ -30,7 +30,7 @@ export type ResolvedConfig = {
     pollingInterval?: number;
     /** Maximum concurrency of RPC requests during the historical sync. Default: `10`. */
     maxRpcRequestConcurrency?: number;
-  }[];
+  };
   /** List of contracts to fetch & handle events from. Contracts defined here will be present in `context.contracts`. */
   contracts?: {
     /** Contract name. Must be unique across `contracts` and `filters`. */

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -18,7 +18,7 @@ export type ResolvedConfig = {
         /** PostgreSQL database connection string. Default: `process.env.DATABASE_URL`. */
         connectionString?: string;
       };
-  /** List of blockchain networks. */
+  /** Blockchain network configuration. */
   network: {
     /** Network name. */
     name: string;

--- a/packages/core/src/config/contracts.ts
+++ b/packages/core/src/config/contracts.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig } from "@/config/config";
 import type { Options } from "@/config/options";
 
 import { buildAbi } from "./abi";
-import { type Network, buildNetwork } from "./networks";
+import type { Network } from "./network";
 
 export type Contract = {
   name: string;
@@ -16,9 +16,11 @@ export type Contract = {
 export function buildContracts({
   config,
   options,
+  network,
 }: {
   config: ResolvedConfig;
   options: Options;
+  network: Network;
 }): Contract[] {
   return (config.contracts ?? []).map((contract) => {
     const address = contract.address.toLowerCase() as Address;
@@ -27,16 +29,6 @@ export function buildContracts({
       abiConfig: contract.abi,
       configFilePath: options.configFile,
     });
-
-    // Get the contract network/provider.
-    const rawNetwork = config.networks.find((n) => n.name === contract.network);
-    if (!rawNetwork) {
-      throw new Error(
-        `Network [${contract.network}] not found for contract: ${contract.name}`
-      );
-    }
-
-    const network = buildNetwork({ network: rawNetwork });
 
     return {
       name: contract.name,

--- a/packages/core/src/config/logFilters.ts
+++ b/packages/core/src/config/logFilters.ts
@@ -6,6 +6,7 @@ import type { Options } from "@/config/options";
 
 import { buildAbi, getEvents } from "./abi";
 import { encodeLogFilterKey } from "./logFilterKey";
+import { Network } from "./network";
 
 type SafeEventName = string;
 
@@ -46,9 +47,11 @@ export type LogFilter = {
 export function buildLogFilters({
   config,
   options,
+  network,
 }: {
   config: ResolvedConfig;
   options: Options;
+  network: Network;
 }) {
   const contractLogFilters = (config.contracts ?? [])
     .filter((contract) => contract.isLogEventSource ?? true)
@@ -59,14 +62,6 @@ export function buildLogFilters({
       });
 
       const events = getEvents({ abi });
-
-      // Get the contract network/provider.
-      const network = config.networks.find((n) => n.name === contract.network);
-      if (!network) {
-        throw new Error(
-          `Network [${contract.network}] not found for contract: ${contract.name}`
-        );
-      }
 
       const address = contract.address.toLowerCase() as Address;
       const topics = undefined;
@@ -102,14 +97,6 @@ export function buildLogFilters({
     });
 
     const events = getEvents({ abi });
-
-    // Get the contract network/provider.
-    const network = config.networks.find((n) => n.name === filter.network);
-    if (!network) {
-      throw new Error(
-        `Network [${filter.network}] not found for filter: ${filter.name}`
-      );
-    }
 
     const address = Array.isArray(filter.filter.address)
       ? filter.filter.address.map((a) => a.toLowerCase() as Address)

--- a/packages/core/src/config/network.ts
+++ b/packages/core/src/config/network.ts
@@ -19,7 +19,7 @@ const clients: Record<number, PublicClient | undefined> = {};
 export function buildNetwork({
   network,
 }: {
-  network: ResolvedConfig["networks"][0];
+  network: ResolvedConfig["network"];
 }) {
   let client = clients[network.chainId];
 

--- a/packages/core/src/event-aggregator/service.test.ts
+++ b/packages/core/src/event-aggregator/service.test.ts
@@ -5,7 +5,7 @@ import { setupEventStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import type { LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 
 import { EventAggregatorService } from "./service";
 

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -9,7 +9,6 @@ import type { Common } from "@/Ponder";
 import type { Block } from "@/types/block";
 import type { Log } from "@/types/log";
 import type { Transaction } from "@/types/transaction";
-import { formatShortDate } from "@/utils/date";
 
 export type LogEvent = {
   logFilterName: string;
@@ -192,9 +191,9 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
   handleHistoricalSyncComplete = ({ blockNumber }: { blockNumber: number }) => {
     this.historicalCheckpoint = blockNumber;
     this.isHistoricalSyncComplete = true;
-    this.recalculateCheckpoint();
-
     this.historicalSyncFinalBlockNumber = blockNumber;
+
+    this.recalculateCheckpoint();
 
     this.common.logger.debug({
       service: "aggregator",
@@ -244,9 +243,7 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
 
       this.common.logger.trace({
         service: "aggregator",
-        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
-          this.checkpoint
-        )}]`,
+        msg: `New event checkpoint at ${this.checkpoint}`,
       });
 
       this.emit("newCheckpoint", { blockNumber: this.checkpoint });

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -126,7 +126,7 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
     });
 
     for await (const page of iterator) {
-      const { events, counts } = page;
+      const { events, counts, pageEndsAtBlockNumber } = page;
 
       const decodedEvents = events.reduce<LogEvent[]>((acc, event) => {
         const selector = event.log.topics[0];
@@ -172,7 +172,7 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
         return acc;
       }, []);
 
-      yield { events: decodedEvents, counts };
+      yield { events: decodedEvents, counts, pageEndsAtBlockNumber };
     }
   }
 

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -3,7 +3,7 @@ import { type Hex, decodeEventLog } from "viem";
 
 import type { LogFilterName } from "@/build/handlers";
 import type { LogEventMetadata, LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
 import type { Block } from "@/types/block";

--- a/packages/core/src/event-store/postgres/format.ts
+++ b/packages/core/src/event-store/postgres/format.ts
@@ -168,7 +168,6 @@ type LogFilterCachedRangesTable = {
   filterKey: string;
   startBlock: Buffer; // BigInt
   endBlock: Buffer; // BigInt
-  endBlockTimestamp: Buffer; // BigInt
 };
 
 export type EventStoreTables = {

--- a/packages/core/src/event-store/postgres/migrations.test.ts
+++ b/packages/core/src/event-store/postgres/migrations.test.ts
@@ -21,39 +21,31 @@ beforeEach((context) => setupEventStore(context, { skipMigrateUp: true }));
 const seed_2023_07_24_0_drop_finalized = async (db: Kysely<any>) => {
   await db
     .insertInto("blocks")
-    .values({ ...rpcToPostgresBlock(blockOne), chainId: 1, finalized: 0 })
+    .values({ ...rpcToPostgresBlock(blockOne), chainId: 1 })
     .execute();
 
   for (const transaction of blockOneTransactions) {
     await db
       .insertInto("transactions")
-      .values({
-        ...rpcToPostgresTransaction(transaction),
-        chainId: 1,
-        finalized: 0,
-      })
+      .values({ ...rpcToPostgresTransaction(transaction), chainId: 1 })
       .execute();
   }
 
   for (const log of blockOneLogs) {
     await db
       .insertInto("logs")
-      .values({
-        ...rpcToPostgresLog(log),
-        chainId: 1,
-        finalized: 0,
-      })
+      .values({ ...rpcToPostgresLog(log), chainId: 1 })
       .execute();
   }
 
   await db
     .insertInto("contractReadResults")
-    .values({ ...contractReadResultOne, finalized: 1 })
+    .values(contractReadResultOne)
     .execute();
 
   await db
     .insertInto("logFilterCachedRanges")
-    .values(logFilterCachedRangeOne)
+    .values({ ...logFilterCachedRangeOne, endBlockTimestamp: 1 })
     .execute();
 };
 

--- a/packages/core/src/event-store/postgres/migrations.test.ts
+++ b/packages/core/src/event-store/postgres/migrations.test.ts
@@ -18,7 +18,7 @@ import {
 
 beforeEach((context) => setupEventStore(context, { skipMigrateUp: true }));
 
-const seed_2023_07_18_0_better_indices = async (db: Kysely<any>) => {
+const seed_2023_07_24_0_drop_finalized = async (db: Kysely<any>) => {
   await db
     .insertInto("blocks")
     .values({ ...rpcToPostgresBlock(blockOne), chainId: 1, finalized: 0 })
@@ -57,20 +57,20 @@ const seed_2023_07_18_0_better_indices = async (db: Kysely<any>) => {
     .execute();
 };
 
-test("2023_07_18_0_better_indices -> 2023_07_24_0_drop_finalized succeeds", async (context) => {
+test("seed_2023_07_24_0_drop_finalized -> 2023_08_05_0_drop_cached_range_end_block_timestamp succeeds", async (context) => {
   const { eventStore } = context;
 
   if (eventStore.kind !== "postgres") return;
 
   const { error } = await eventStore.migrator.migrateTo(
-    "2023_07_18_0_better_indices"
+    "seed_2023_07_24_0_drop_finalized"
   );
   expect(error).toBeFalsy();
 
-  await seed_2023_07_18_0_better_indices(eventStore.db);
+  await seed_2023_07_24_0_drop_finalized(eventStore.db);
 
   const { error: latestError } = await eventStore.migrator.migrateTo(
-    "2023_07_24_0_drop_finalized"
+    "2023_08_05_0_drop_cached_range_end_block_timestamp"
   );
   expect(latestError).toBeFalsy();
 }, 15_000);

--- a/packages/core/src/event-store/postgres/migrations.test.ts
+++ b/packages/core/src/event-store/postgres/migrations.test.ts
@@ -55,7 +55,7 @@ test("seed_2023_07_24_0_drop_finalized -> 2023_08_05_0_drop_cached_range_end_blo
   if (eventStore.kind !== "postgres") return;
 
   const { error } = await eventStore.migrator.migrateTo(
-    "seed_2023_07_24_0_drop_finalized"
+    "2023_07_24_0_drop_finalized"
   );
   expect(error).toBeFalsy();
 

--- a/packages/core/src/event-store/postgres/migrations.ts
+++ b/packages/core/src/event-store/postgres/migrations.ts
@@ -214,6 +214,20 @@ const migrations: Record<string, Migration> = {
         .execute();
     },
   },
+  ["2023_08_05_0_drop_cached_range_end_block_timestamp"]: {
+    async up(db: Kysely<any>) {
+      await db.schema
+        .alterTable("logFilterCachedRanges")
+        .dropColumn("endBlockTimestamp")
+        .execute();
+    },
+    async down(db: Kysely<any>) {
+      await db.schema
+        .alterTable("logFilterCachedRanges")
+        .addColumn("endBlockTimestamp", "blob", (col) => col.notNull()) // BigInt
+        .execute();
+    },
+  },
 };
 
 class StaticMigrationProvider implements MigrationProvider {

--- a/packages/core/src/event-store/sqlite/format.ts
+++ b/packages/core/src/event-store/sqlite/format.ts
@@ -168,7 +168,6 @@ type LogFilterCachedRangesTable = {
   filterKey: string;
   startBlock: Buffer; // BigInt
   endBlock: Buffer; // BigInt
-  endBlockTimestamp: Buffer; // BigInt
 };
 
 export type EventStoreTables = {

--- a/packages/core/src/event-store/sqlite/migrations.test.ts
+++ b/packages/core/src/event-store/sqlite/migrations.test.ts
@@ -21,39 +21,31 @@ beforeEach((context) => setupEventStore(context, { skipMigrateUp: true }));
 const seed_2023_07_24_0_drop_finalized = async (db: Kysely<any>) => {
   await db
     .insertInto("blocks")
-    .values({ ...rpcToSqliteBlock(blockOne), chainId: 1, finalized: 0 })
+    .values({ ...rpcToSqliteBlock(blockOne), chainId: 1 })
     .execute();
 
   for (const transaction of blockOneTransactions) {
     await db
       .insertInto("transactions")
-      .values({
-        ...rpcToSqliteTransaction(transaction),
-        chainId: 1,
-        finalized: 0,
-      })
+      .values({ ...rpcToSqliteTransaction(transaction), chainId: 1 })
       .execute();
   }
 
   for (const log of blockOneLogs) {
     await db
       .insertInto("logs")
-      .values({
-        ...rpcToSqliteLog(log),
-        chainId: 1,
-        finalized: 0,
-      })
+      .values({ ...rpcToSqliteLog(log), chainId: 1 })
       .execute();
   }
 
   await db
     .insertInto("contractReadResults")
-    .values({ ...contractReadResultOne, finalized: 1 })
+    .values(contractReadResultOne)
     .execute();
 
   await db
     .insertInto("logFilterCachedRanges")
-    .values(logFilterCachedRangeOne)
+    .values({ ...logFilterCachedRangeOne, endBlockTimestamp: 1 })
     .execute();
 };
 

--- a/packages/core/src/event-store/sqlite/migrations.test.ts
+++ b/packages/core/src/event-store/sqlite/migrations.test.ts
@@ -18,7 +18,7 @@ import {
 
 beforeEach((context) => setupEventStore(context, { skipMigrateUp: true }));
 
-const seed_2023_07_18_0_better_indices = async (db: Kysely<any>) => {
+const seed_2023_07_24_0_drop_finalized = async (db: Kysely<any>) => {
   await db
     .insertInto("blocks")
     .values({ ...rpcToSqliteBlock(blockOne), chainId: 1, finalized: 0 })
@@ -58,21 +58,21 @@ const seed_2023_07_18_0_better_indices = async (db: Kysely<any>) => {
 };
 
 test(
-  "2023_07_18_0_better_indices -> 2023_07_24_0_drop_finalized succeeds",
+  "2023_07_24_0_drop_finalized succeeds -> 2023_08_05_0_drop_cached_range_end_block_timestamp",
   async (context) => {
     const { eventStore } = context;
 
     if (eventStore.kind !== "sqlite") return;
 
     const { error } = await eventStore.migrator.migrateTo(
-      "2023_07_18_0_better_indices"
+      "2023_07_24_0_drop_finalized"
     );
     expect(error).toBeFalsy();
 
-    await seed_2023_07_18_0_better_indices(eventStore.db);
+    await seed_2023_07_24_0_drop_finalized(eventStore.db);
 
     const { error: latestError } = await eventStore.migrator.migrateTo(
-      "2023_07_24_0_drop_finalized"
+      "2023_08_05_0_drop_cached_range_end_block_timestamp"
     );
     expect(latestError).toBeFalsy();
   },

--- a/packages/core/src/event-store/sqlite/migrations.ts
+++ b/packages/core/src/event-store/sqlite/migrations.ts
@@ -214,6 +214,20 @@ const migrations: Record<string, Migration> = {
         .execute();
     },
   },
+  ["2023_08_05_0_drop_cached_range_end_block_timestamp"]: {
+    async up(db: Kysely<any>) {
+      await db.schema
+        .alterTable("logFilterCachedRanges")
+        .dropColumn("endBlockTimestamp")
+        .execute();
+    },
+    async down(db: Kysely<any>) {
+      await db.schema
+        .alterTable("logFilterCachedRanges")
+        .addColumn("endBlockTimestamp", "blob", (col) => col.notNull()) // BigInt
+        .execute();
+    },
+  },
 };
 
 class StaticMigrationProvider implements MigrationProvider {

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -350,9 +350,10 @@ test("getLogEvents returns log events", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ name: "noFilter", chainId: 1 }],
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter" }],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);
@@ -501,11 +502,10 @@ test("getLogEvents filters on log address", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [
-      { name: "singleAddress", chainId: 1, address: blockOneLogs[0].address },
-    ],
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "singleAddress", address: blockOneLogs[0].address }],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);
@@ -532,12 +532,12 @@ test("getLogEvents filters on multiple addresses", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "multipleAddress",
-        chainId: 1,
         address: [blockOneLogs[0].address, blockOneLogs[1].address],
       },
     ],
@@ -578,12 +578,12 @@ test("getLogEvents filters on single topic", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "singleTopic",
-        chainId: 1,
         topics: [blockOneLogs[0].topics[0] as `0x${string}`],
       },
     ],
@@ -624,12 +624,12 @@ test("getLogEvents filters on multiple topics", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "multipleTopics",
-        chainId: 1,
         topics: [
           blockOneLogs[0].topics[0] as `0x${string}`,
           blockOneLogs[0].topics[1] as `0x${string}`,
@@ -667,12 +667,12 @@ test("getLogEvents filters on fromBlock", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "fromBlock",
-        chainId: 1,
         fromBlock: 15495111,
       },
     ],
@@ -707,17 +707,16 @@ test("getLogEvents filters on multiple filters", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "singleAddress", // This should match blockOneLogs[0]
-        chainId: 1,
         address: blockOneLogs[0].address,
       },
       {
         name: "singleTopic", // This should match blockOneLogs[0] AND blockTwoLogs[0]
-        chainId: 1,
         topics: [blockOneLogs[0].topics[0] as `0x${string}`],
       },
     ],
@@ -763,9 +762,10 @@ test("getLogEvents filters on fromTimestamp (inclusive)", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: hexToNumber(blockTwo.timestamp!),
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ name: "noFilter", chainId: 1 }],
+    chainId: 1,
+    fromBlockNumber: hexToNumber(blockTwo.number!),
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter" }],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);
@@ -792,9 +792,10 @@ test("getLogEvents filters on toTimestamp (inclusive)", async (context) => {
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: hexToNumber(blockOne.timestamp!),
-    filters: [{ name: "noFilter", chainId: 1 }],
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: hexToNumber(blockOne.number!),
+    filters: [{ name: "noFilter" }],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);
@@ -824,9 +825,10 @@ test("getLogEvents returns no events if includeEventSelectors is an empty array"
   });
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
-    filters: [{ name: "noFilter", chainId: 1, includeEventSelectors: [] }],
+    chainId: 1,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
+    filters: [{ name: "noFilter", includeEventSelectors: [] }],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);

--- a/packages/core/src/event-store/store.test.ts
+++ b/packages/core/src/event-store/store.test.ts
@@ -90,7 +90,6 @@ test("insertHistoricalBlock inserts a log filter cached interval", async (contex
 
   expect(logFilterCachedRanges[0]).toMatchObject({
     endBlock: 15495110,
-    endBlockTimestamp: 1662619503,
     filterKey: "test-filter-key",
     startBlock: 15131900,
   });
@@ -104,7 +103,6 @@ test("insertLogFilterCachedRanges inserts many cached intervals", async (context
     logFilterKeys: ["test-filter-key-1", "test-filter-key-2"],
     startBlock: 15131900,
     endBlock: 15495111,
-    endBlockTimestamp: 1662619504,
   });
 
   const logFilterCachedRanges1 = await eventStore.getLogFilterCachedRanges({
@@ -114,7 +112,6 @@ test("insertLogFilterCachedRanges inserts many cached intervals", async (context
   expect(logFilterCachedRanges1).toHaveLength(1);
   expect(logFilterCachedRanges1[0]).toMatchObject({
     endBlock: 15495111,
-    endBlockTimestamp: 1662619504,
     filterKey: "test-filter-key-1",
     startBlock: 15131900,
   });
@@ -126,7 +123,6 @@ test("insertLogFilterCachedRanges inserts many cached intervals", async (context
   expect(logFilterCachedRanges2).toHaveLength(1);
   expect(logFilterCachedRanges2[0]).toMatchObject({
     endBlock: 15495111,
-    endBlockTimestamp: 1662619504,
     filterKey: "test-filter-key-2",
     startBlock: 15131900,
   });
@@ -139,7 +135,6 @@ test("insertLogFilterCachedRanges inserts zero cached intervals without error", 
     logFilterKeys: [],
     startBlock: 15131900,
     endBlock: 15495111,
-    endBlockTimestamp: 1662619504,
   });
 
   const logFilterCachedRanges = await eventStore.getLogFilterCachedRanges({
@@ -183,14 +178,13 @@ test("mergeLogFilterCachedRanges merges cached intervals", async (context) => {
 
   expect(logFilterCachedRanges[0]).toMatchObject({
     endBlock: 15495111,
-    endBlockTimestamp: 1662619504,
     filterKey: "test-filter-key",
     startBlock: 15131900,
   });
   expect(logFilterCachedRanges).toHaveLength(1);
 });
 
-test("mergeLogFilterCachedRanges returns the startingRangeEndTimestamp", async (context) => {
+test("mergeLogFilterCachedRanges returns the startingRangeEndBlockNumber", async (context) => {
   const { eventStore } = context;
 
   await eventStore.insertHistoricalBlock({
@@ -203,13 +197,13 @@ test("mergeLogFilterCachedRanges returns the startingRangeEndTimestamp", async (
     },
   });
 
-  const { startingRangeEndTimestamp } =
+  const { startingRangeEndBlockNumber } =
     await eventStore.mergeLogFilterCachedRanges({
       logFilterKey: "test-filter-key",
       logFilterStartBlockNumber: 15131900,
     });
 
-  expect(startingRangeEndTimestamp).toBe(hexToNumber(blockOne.timestamp));
+  expect(startingRangeEndBlockNumber).toBe(hexToNumber(blockOne.number!));
 
   await eventStore.insertHistoricalBlock({
     chainId: 1,
@@ -221,13 +215,13 @@ test("mergeLogFilterCachedRanges returns the startingRangeEndTimestamp", async (
     },
   });
 
-  const { startingRangeEndTimestamp: startingRangeEndTimestamp2 } =
+  const { startingRangeEndBlockNumber: startingRangeEndBlockNumber2 } =
     await eventStore.mergeLogFilterCachedRanges({
       logFilterKey: "test-filter-key",
       logFilterStartBlockNumber: 15131900,
     });
 
-  expect(startingRangeEndTimestamp2).toBe(hexToNumber(blockTwo.timestamp));
+  expect(startingRangeEndBlockNumber2).toBe(hexToNumber(blockTwo.number!));
 });
 
 test("insertContractReadResult inserts a contract call", async (context) => {

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -92,11 +92,11 @@ export interface EventStore {
   }): Promise<ContractReadResult | null>;
 
   getLogEvents(arg: {
-    fromTimestamp: number;
-    toTimestamp: number;
+    chainId: number;
+    fromBlockNumber: number;
+    toBlockNumber: number;
     filters?: {
       name: string;
-      chainId: number;
       address?: Address | Address[];
       topics?: (Hex | Hex[] | null)[];
       fromBlock?: number;
@@ -104,6 +104,10 @@ export interface EventStore {
       includeEventSelectors?: Hex[];
     }[];
     pageSize?: number;
+    cursor?: {
+      blockNumber: number;
+      logIndex: number;
+    };
   }): AsyncGenerator<{
     events: {
       logFilterName: string;
@@ -111,13 +115,16 @@ export interface EventStore {
       block: Block;
       transaction: Transaction;
     }[];
-    metadata: {
-      pageEndsAtTimestamp: number;
-      counts: {
-        logFilterName: string;
-        selector: Hex;
-        count: number;
-      }[];
-    };
+    counts: {
+      logFilterName: string;
+      selector: Hex;
+      count: number;
+    }[];
+    cursor:
+      | {
+          blockNumber: number;
+          logIndex: number;
+        }
+      | undefined;
   }>;
 }

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -13,7 +13,6 @@ export type LogFilterCachedRange = {
   filterKey: string;
   startBlock: number;
   endBlock: number;
-  endBlockTimestamp: number;
 };
 
 /**
@@ -66,13 +65,12 @@ export interface EventStore {
     logFilterKeys: string[];
     startBlock: number;
     endBlock: number;
-    endBlockTimestamp: number;
   }): Promise<void>;
 
   mergeLogFilterCachedRanges(options: {
     logFilterKey: string;
     logFilterStartBlockNumber: number;
-  }): Promise<{ startingRangeEndTimestamp: number }>;
+  }): Promise<{ startingRangeEndBlockNumber: number }>;
 
   getLogFilterCachedRanges(options: {
     logFilterKey: string;

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -104,11 +104,8 @@ export interface EventStore {
       includeEventSelectors?: Hex[];
     }[];
     pageSize?: number;
-    cursor?: {
-      blockNumber: number;
-      logIndex: number;
-    };
   }): AsyncGenerator<{
+    pageEndsAtBlockNumber: number | undefined;
     events: {
       logFilterName: string;
       log: Log;
@@ -120,11 +117,5 @@ export interface EventStore {
       selector: Hex;
       count: number;
     }[];
-    cursor:
-      | {
-          blockNumber: number;
-          logIndex: number;
-        }
-      | undefined;
   }>;
 }

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -95,7 +95,7 @@ test("setup() succeeds if log filter start block is greater than finalized block
     await common.metrics.ponder_historical_total_blocks.get()
   ).values;
   expect(totalBlocksMetric).toMatchObject([
-    { labels: { network: "mainnet", logFilter: "USDC" }, value: 0 },
+    { labels: { logFilter: "USDC" }, value: 0 },
   ]);
 
   await service.kill();
@@ -204,21 +204,21 @@ test("setup() updates cached block, total block, and scheduled task metrics", as
     await common.metrics.ponder_historical_cached_blocks.get()
   ).values;
   expect(cachedBlocksMetric).toMatchObject([
-    { labels: { network: "mainnet", logFilter: "USDC" }, value: 0 },
+    { labels: { logFilter: "USDC" }, value: 0 },
   ]);
 
   const totalBlocksMetric = (
     await common.metrics.ponder_historical_total_blocks.get()
   ).values;
   expect(totalBlocksMetric).toMatchObject([
-    { labels: { network: "mainnet", logFilter: "USDC" }, value: 6 },
+    { labels: { logFilter: "USDC" }, value: 6 },
   ]);
 
   const scheduledTaskMetric = (
     await common.metrics.ponder_historical_scheduled_tasks.get()
   ).values;
   expect(scheduledTaskMetric).toMatchObject([
-    { labels: { network: "mainnet", kind: "log" }, value: 2 },
+    { labels: { kind: "log" }, value: 2 },
   ]);
 
   await service.kill();
@@ -242,21 +242,15 @@ test("start() updates completed tasks and completed blocks metrics", async (cont
     await common.metrics.ponder_historical_completed_tasks.get()
   ).values;
   expect(completedTasksMetric).toMatchObject([
-    {
-      labels: { network: "mainnet", kind: "log", status: "success" },
-      value: 2,
-    },
-    {
-      labels: { network: "mainnet", kind: "block", status: "success" },
-      value: 6,
-    },
+    { labels: { kind: "log", status: "success" }, value: 2 },
+    { labels: { kind: "block", status: "success" }, value: 6 },
   ]);
 
   const totalBlocksMetric = (
     await common.metrics.ponder_historical_completed_blocks.get()
   ).values;
   expect(totalBlocksMetric).toMatchObject([
-    { labels: { network: "mainnet", logFilter: "USDC" }, value: 6 },
+    { labels: { logFilter: "USDC" }, value: 6 },
   ]);
 
   await service.kill();
@@ -283,16 +277,10 @@ test("start() updates rpc request duration metrics", async (context) => {
   expect(requestsDurationMetric).toMatchObject(
     expect.arrayContaining([
       expect.objectContaining({
-        labels: expect.objectContaining({
-          network: "mainnet",
-          method: "eth_getLogs",
-        }),
+        labels: expect.objectContaining({ method: "eth_getLogs" }),
       }),
       expect.objectContaining({
-        labels: expect.objectContaining({
-          network: "mainnet",
-          method: "eth_getBlockByNumber",
-        }),
+        labels: expect.objectContaining({ method: "eth_getBlockByNumber" }),
       }),
     ])
   );
@@ -431,18 +419,9 @@ test("start() updates failed task metrics", async (context) => {
     await common.metrics.ponder_historical_completed_tasks.get()
   ).values;
   expect(completedTasksMetric).toMatchObject([
-    {
-      labels: { network: "mainnet", kind: "log", status: "failure" },
-      value: 1,
-    },
-    {
-      labels: { network: "mainnet", kind: "log", status: "success" },
-      value: 1,
-    },
-    {
-      labels: { network: "mainnet", kind: "block", status: "success" },
-      value: 2,
-    },
+    { labels: { kind: "log", status: "failure" }, value: 1 },
+    { labels: { kind: "log", status: "success" }, value: 1 },
+    { labels: { kind: "block", status: "success" }, value: 2 },
   ]);
 
   await service.kill();

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -10,7 +10,7 @@ import { setupEventStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import type { LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 
 import { HistoricalSyncService } from "./service";
 

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -314,12 +314,12 @@ test("start() adds events to event store", async (context) => {
   await service.onIdle();
 
   const iterator = eventStore.getLogEvents({
-    fromTimestamp: 0,
-    toTimestamp: Number.MAX_SAFE_INTEGER,
+    chainId: network.chainId,
+    fromBlockNumber: 0,
+    toBlockNumber: Number.MAX_SAFE_INTEGER,
     filters: [
       {
         name: "usdc",
-        chainId: network.chainId,
         address: usdcContractConfig.address,
       },
     ],
@@ -377,7 +377,6 @@ test("start() inserts cached ranges", async (context) => {
     filterKey: '1-"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"-null',
     startBlock: 16369950,
     endBlock: 16369955,
-    endBlockTimestamp: 1673275859,
   });
   expect(logFilterCachedRanges).toHaveLength(1);
 
@@ -565,7 +564,7 @@ test("start() emits checkpoit and sync completed event if 100% cached", async (c
   await service.onIdle();
 
   expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
-    timestamp: expect.any(Number),
+    blockNumber: blockNumbers.finalizedBlockNumber,
   });
   expect(emitSpy).toHaveBeenCalledWith("syncComplete");
   expect(emitSpy).toHaveBeenCalledTimes(2);
@@ -590,7 +589,7 @@ test("start() emits historicalCheckpoint event", async (context) => {
   await service.onIdle();
 
   expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
-    timestamp: 1673275859, // Block timestamp of block 16369955
+    blockNumber: 16369955,
   });
 
   await service.kill();

--- a/packages/core/src/historical-sync/service.test.ts
+++ b/packages/core/src/historical-sync/service.test.ts
@@ -530,12 +530,14 @@ test("start() emits sync completed event", async (context) => {
   service.start();
 
   await service.onIdle();
-  expect(emitSpy).toHaveBeenCalledWith("syncComplete");
+  expect(emitSpy).toHaveBeenCalledWith("syncComplete", {
+    blockNumber: blockNumbers.finalizedBlockNumber,
+  });
 
   await service.kill();
 });
 
-test("start() emits checkpoit and sync completed event if 100% cached", async (context) => {
+test("start() emits sync completed event if 100% cached", async (context) => {
   const { common, eventStore } = context;
 
   let service = new HistoricalSyncService({
@@ -563,11 +565,10 @@ test("start() emits checkpoit and sync completed event if 100% cached", async (c
   service.start();
   await service.onIdle();
 
-  expect(emitSpy).toHaveBeenCalledWith("historicalCheckpoint", {
+  expect(emitSpy).toHaveBeenCalledWith("syncComplete", {
     blockNumber: blockNumbers.finalizedBlockNumber,
   });
-  expect(emitSpy).toHaveBeenCalledWith("syncComplete");
-  expect(emitSpy).toHaveBeenCalledTimes(2);
+  expect(emitSpy).toHaveBeenCalledTimes(1);
 
   await service.kill();
 });

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -122,10 +122,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           const now = Math.round(Date.now() / 1000);
           this.logFilterCheckpoints[logFilter.name] = now;
           this.common.metrics.ponder_historical_total_blocks.set(
-            {
-              network: this.network.name,
-              logFilter: logFilter.name,
-            },
+            { logFilter: logFilter.name },
             0
           );
           this.common.logger.warn({
@@ -185,17 +182,11 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         );
 
         this.common.metrics.ponder_historical_total_blocks.set(
-          {
-            network: this.network.name,
-            logFilter: logFilter.name,
-          },
+          { logFilter: logFilter.name },
           totalBlockCount
         );
         this.common.metrics.ponder_historical_cached_blocks.set(
-          {
-            network: this.network.name,
-            logFilter: logFilter.name,
-          },
+          { logFilter: logFilter.name },
           cachedBlockCount
         );
 
@@ -217,18 +208,10 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
 
           while (fromBlock <= endBlock) {
             this.queue.addTask(
-              {
-                kind: "LOG_SYNC",
-                logFilter,
-                fromBlock,
-                toBlock,
-              },
-              {
-                priority: Number.MAX_SAFE_INTEGER - fromBlock,
-              }
+              { kind: "LOG_SYNC", logFilter, fromBlock, toBlock },
+              { priority: Number.MAX_SAFE_INTEGER - fromBlock }
             );
             this.common.metrics.ponder_historical_scheduled_tasks.inc({
-              network: this.network.name,
               kind: "log",
             });
 
@@ -342,7 +325,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
 
         if (task.kind === "BLOCK_SYNC") {
           this.common.metrics.ponder_historical_completed_tasks.inc({
-            network: this.network.name,
             kind: "block",
             status: "success",
           });
@@ -359,17 +341,13 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           // When a block task completes, a cached range record gets inserted.
           // Update the block range progress metric accordingly.
           this.common.metrics.ponder_historical_completed_blocks.inc(
-            {
-              network: this.network.name,
-              logFilter: logFilter.name,
-            },
+            { logFilter: logFilter.name },
             task.blockNumber - task.blockNumberToCacheFrom + 1
           );
         }
 
         if (task.kind === "LOG_SYNC") {
           this.common.metrics.ponder_historical_completed_tasks.inc({
-            network: this.network.name,
             kind: "log",
             status: "success",
           });
@@ -387,7 +365,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         const { logFilter } = task;
 
         this.common.metrics.ponder_historical_completed_tasks.inc({
-          network: this.network.name,
           kind: task.kind === "LOG_SYNC" ? "log" : "block",
           status: "failure",
         });
@@ -404,9 +381,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
 
           queue.addTask(
             { ...task, fromBlock: safeStart, toBlock: safeEnd },
-            {
-              priority: Number.MAX_SAFE_INTEGER - safeStart,
-            }
+            { priority: Number.MAX_SAFE_INTEGER - safeStart }
           );
           queue.addTask(
             { ...task, fromBlock: safeEnd + 1 },
@@ -414,7 +389,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           );
           // Splitting the task into two parts increases the total count by 1.
           this.common.metrics.ponder_historical_scheduled_tasks.inc({
-            network: this.network.name,
             kind: "log",
           });
           return;
@@ -439,7 +413,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           );
           // Splitting the task into two parts increases the total count by 1.
           this.common.metrics.ponder_historical_scheduled_tasks.inc({
-            network: this.network.name,
             kind: "log",
           });
           return;
@@ -466,7 +439,6 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
           );
           // Splitting the task into two parts increases the total count by 1.
           this.common.metrics.ponder_historical_scheduled_tasks.inc({
-            network: this.network.name,
             kind: "log",
           });
           return;
@@ -535,10 +507,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       ],
     });
     this.common.metrics.ponder_historical_rpc_request_duration.observe(
-      {
-        method: "eth_getLogs",
-        network: this.network.name,
-      },
+      { method: "eth_getLogs" },
       stopClock()
     );
 
@@ -594,10 +563,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     }
 
     this.common.metrics.ponder_historical_scheduled_tasks.inc(
-      {
-        network: this.network.name,
-        kind: "block",
-      },
+      { kind: "block" },
       blockTasks.length
     );
   };
@@ -613,10 +579,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     });
 
     this.common.metrics.ponder_historical_rpc_request_duration.observe(
-      {
-        method: "eth_getBlockByNumber",
-        network: this.network.name,
-      },
+      { method: "eth_getBlockByNumber" },
       stopClock()
     );
 
@@ -733,7 +696,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         const completionStats = await this.getCompletionStats();
         completionStats.forEach(({ logFilter, rate }) => {
           this.common.metrics.ponder_historical_completion_rate.set(
-            { logFilter, network: this.network.name },
+            { logFilter },
             rate
           );
         });
@@ -747,7 +710,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         // If no progress has been made, can't calculate an accurate ETA.
         if (eta) {
           this.common.metrics.ponder_historical_completion_eta.set(
-            { logFilter, network: this.network.name },
+            { logFilter },
             eta
           );
         }

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -306,8 +306,8 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         await this.blockTaskWorker({ task });
       }
 
-      // If this was the final task, run the cleanup/completion logic.
-      if (queue.size === 0 && queue.pending === 0) {
+      // If this is the final task, run the cleanup/completion logic.
+      if (queue.size === 0 && queue.pending === 1) {
         // It's possible for multiple block sync tasks to run simultaneously,
         // resulting in a scenario where cached ranges are not fully merged.
         // Merge all cached ranges once last time before emitting the `syncComplete` event.

--- a/packages/core/src/historical-sync/service.ts
+++ b/packages/core/src/historical-sync/service.ts
@@ -8,7 +8,7 @@ import {
 } from "viem";
 
 import type { LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 import { QueueError } from "@/errors/queue";
 import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -13,25 +13,19 @@ const httpRequestSizeInBytes = [
 export class MetricsService {
   private registry: prometheus.Registry;
 
-  ponder_historical_scheduled_tasks: prometheus.Counter<"network" | "kind">;
-  ponder_historical_completed_tasks: prometheus.Counter<
-    "network" | "kind" | "status"
-  >;
-  ponder_historical_rpc_request_duration: prometheus.Histogram<
-    "network" | "method"
-  >;
-  ponder_historical_total_blocks: prometheus.Gauge<"network" | "logFilter">;
-  ponder_historical_cached_blocks: prometheus.Gauge<"network" | "logFilter">;
-  ponder_historical_completed_blocks: prometheus.Gauge<"network" | "logFilter">;
-  ponder_historical_completion_rate: prometheus.Gauge<"network" | "logFilter">;
-  ponder_historical_completion_eta: prometheus.Gauge<"network" | "logFilter">;
+  ponder_historical_scheduled_tasks: prometheus.Counter<"kind">;
+  ponder_historical_completed_tasks: prometheus.Counter<"kind" | "status">;
+  ponder_historical_rpc_request_duration: prometheus.Histogram<"method">;
+  ponder_historical_total_blocks: prometheus.Gauge<"logFilter">;
+  ponder_historical_cached_blocks: prometheus.Gauge<"logFilter">;
+  ponder_historical_completed_blocks: prometheus.Gauge<"logFilter">;
+  ponder_historical_completion_rate: prometheus.Gauge<"logFilter">;
+  ponder_historical_completion_eta: prometheus.Gauge<"logFilter">;
 
   ponder_realtime_is_connected: prometheus.Gauge<"network">;
-  ponder_realtime_latest_block_number: prometheus.Gauge<"network">;
-  ponder_realtime_latest_block_timestamp: prometheus.Gauge<"network">;
-  ponder_realtime_rpc_request_duration: prometheus.Histogram<
-    "network" | "method"
-  >;
+  ponder_realtime_latest_block_number: prometheus.Gauge;
+  ponder_realtime_latest_block_timestamp: prometheus.Gauge;
+  ponder_realtime_rpc_request_duration: prometheus.Histogram<"method">;
 
   ponder_handlers_matched_events: prometheus.Gauge<"eventName">;
   ponder_handlers_handled_events: prometheus.Gauge<"eventName">;
@@ -61,75 +55,73 @@ export class MetricsService {
     this.ponder_historical_scheduled_tasks = new prometheus.Counter({
       name: "ponder_historical_scheduled_tasks",
       help: "Number of historical sync tasks that have been scheduled",
-      labelNames: ["network", "kind"] as const,
+      labelNames: ["kind"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_completed_tasks = new prometheus.Counter({
       name: "ponder_historical_completed_tasks",
       help: "Number of historical sync tasks that have been processed",
-      labelNames: ["network", "kind", "status"] as const,
+      labelNames: ["kind", "status"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_rpc_request_duration = new prometheus.Histogram({
       name: "ponder_historical_rpc_request_duration",
       help: "Duration of RPC requests completed during the historical sync",
-      labelNames: ["network", "method"] as const,
+      labelNames: ["method"] as const,
       buckets: httpRequestBucketsInMs,
       registers: [this.registry],
     });
     this.ponder_historical_total_blocks = new prometheus.Gauge({
       name: "ponder_historical_total_blocks",
       help: "Number of blocks required for the historical sync",
-      labelNames: ["network", "logFilter"] as const,
+      labelNames: ["logFilter"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_cached_blocks = new prometheus.Gauge({
       name: "ponder_historical_cached_blocks",
       help: "Number of blocks that were found in the cache for the historical sync",
-      labelNames: ["network", "logFilter"] as const,
+      labelNames: ["logFilter"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_completed_blocks = new prometheus.Gauge({
       name: "ponder_historical_completed_blocks",
       help: "Number of blocks that have been processed for the historical sync",
-      labelNames: ["network", "logFilter"] as const,
+      labelNames: ["logFilter"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_completion_rate = new prometheus.Gauge({
       name: "ponder_historical_completion_rate",
       help: "Completion rate (0 to 1) of the historical sync",
-      labelNames: ["network", "logFilter"] as const,
+      labelNames: ["logFilter"] as const,
       registers: [this.registry],
     });
     this.ponder_historical_completion_eta = new prometheus.Gauge({
       name: "ponder_historical_completion_eta",
       help: "Estimated number of milliseconds remaining to complete the historical sync",
-      labelNames: ["network", "logFilter"] as const,
+      labelNames: ["logFilter"] as const,
       registers: [this.registry],
     });
 
     this.ponder_realtime_is_connected = new prometheus.Gauge({
       name: "ponder_realtime_is_connected",
-      help: "Boolean (0 or 1) indicating if the historical sync service is connected",
+      help: "Boolean (0 or 1) indicating if the realtime sync service is connected",
       labelNames: ["network"] as const,
       registers: [this.registry],
     });
     this.ponder_realtime_latest_block_number = new prometheus.Gauge({
       name: "ponder_realtime_latest_block_number",
       help: "Block number of the latest synced block",
-      labelNames: ["network"] as const,
       registers: [this.registry],
     });
     this.ponder_realtime_latest_block_timestamp = new prometheus.Gauge({
       name: "ponder_realtime_latest_block_timestamp",
       help: "Block timestamp of the latest synced block",
-      labelNames: ["network"] as const,
       registers: [this.registry],
     });
     this.ponder_realtime_rpc_request_duration = new prometheus.Histogram({
       name: "ponder_realtime_rpc_request_duration",
       help: "Duration of RPC requests completed during the realtime sync",
-      labelNames: ["network", "method"] as const,
+      labelNames: ["method"] as const,
       buckets: httpRequestBucketsInMs,
       registers: [this.registry],
     });

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -37,7 +37,7 @@ export class MetricsService {
   ponder_handlers_handled_events: prometheus.Gauge<"eventName">;
   ponder_handlers_processed_events: prometheus.Gauge<"eventName">;
   ponder_handlers_has_error: prometheus.Gauge;
-  ponder_handlers_latest_processed_timestamp: prometheus.Gauge;
+  ponder_handlers_latest_processed_block_number: prometheus.Gauge;
 
   ponder_server_port: prometheus.Gauge;
   ponder_server_request_size: prometheus.Histogram<
@@ -157,9 +157,9 @@ export class MetricsService {
       help: "Boolean (0 or 1) indicating if an error was encountered while running handlers",
       registers: [this.registry],
     });
-    this.ponder_handlers_latest_processed_timestamp = new prometheus.Gauge({
-      name: "ponder_handlers_latest_processed_timestamp",
-      help: "Block timestamp of the latest processed event",
+    this.ponder_handlers_latest_processed_block_number = new prometheus.Gauge({
+      name: "ponder_handlers_latest_processed_block_number",
+      help: "Block number of the latest processed event",
       registers: [this.registry],
     });
 

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -223,13 +223,13 @@ test("emits realtimeCheckpoint events", async (context) => {
   await service.onIdle();
 
   expect(emitSpy).toHaveBeenCalledWith("realtimeCheckpoint", {
-    timestamp: 1673397023, // Timestamp of 16379995
+    blockNumber: 16379996, // 16379995 is the finalized block, this is the next block.
   });
   expect(emitSpy).toHaveBeenCalledWith("realtimeCheckpoint", {
-    timestamp: 1673397071, // Timestamp of 16380000
+    blockNumber: 16380000,
   });
   expect(emitSpy).toHaveBeenCalledWith("realtimeCheckpoint", {
-    timestamp: 1673397078, // Timestamp of 16380008 (1s block time via Anvil)
+    blockNumber: 16380008,
   });
 
   await service.kill();
@@ -273,7 +273,7 @@ test("inserts cached range records for finalized blocks", async (context) => {
   ]);
 
   expect(emitSpy).toHaveBeenCalledWith("finalityCheckpoint", {
-    timestamp: 1673397071, // Timestamp of 16380000
+    blockNumber: 16380000,
   });
 
   await service.kill();
@@ -385,7 +385,7 @@ test("emits shallowReorg event after 3 block shallow reorg", async (context) => 
   await service.onIdle();
 
   expect(emitSpy).toHaveBeenCalledWith("shallowReorg", {
-    commonAncestorTimestamp: 1673397071, // Timestamp of 16380000
+    commonAncestorBlockNumber: 16380000,
   });
 
   await service.kill();
@@ -421,7 +421,7 @@ test("emits deepReorg event after deep reorg", async (context) => {
   expect(emitSpy).toHaveBeenCalledWith("finalityCheckpoint", {
     // Note that the precise number can change depending on how long it takes to
     // mine each block above.
-    timestamp: expect.any(Number),
+    blockNumber: 16380005,
   });
 
   // Now, revert to the original snapshot and mine 13 blocks, each containing 2 transactions.

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -6,7 +6,7 @@ import { resetTestClient, setupEventStore } from "@/_test/setup";
 import { publicClient, testClient, walletClient } from "@/_test/utils";
 import { encodeLogFilterKey } from "@/config/logFilterKey";
 import type { LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 import { blobToBigInt } from "@/utils/decode";
 import { range } from "@/utils/range";
 

--- a/packages/core/src/realtime-sync/service.test.ts
+++ b/packages/core/src/realtime-sync/service.test.ts
@@ -268,7 +268,6 @@ test("inserts cached range records for finalized blocks", async (context) => {
       filterKey: '1-"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"-null',
       startBlock: 16379996,
       endBlock: 16380000,
-      endBlockTimestamp: 1673397071,
     },
   ]);
 

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -362,7 +362,6 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
           logFilterKeys: this.logFilters.map((l) => l.filter.key),
           startBlock: this.finalizedBlockNumber + 1,
           endBlock: newFinalizedBlock.number,
-          endBlockTimestamp: newFinalizedBlock.timestamp,
         });
 
         this.finalizedBlockNumber = newFinalizedBlock.number;

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -73,7 +73,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     this.common.logger.info({
       service: "realtime",
-      msg: `Fetched latest block at ${latestBlockNumber} (network=${this.network.name})`,
+      msg: `Fetched latest block at ${latestBlockNumber}`,
     });
 
     this.common.metrics.ponder_realtime_is_connected.set(
@@ -110,7 +110,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     ) {
       this.common.logger.warn({
         service: "realtime",
-        msg: `No realtime log filters found (network=${this.network.name})`,
+        msg: `No realtime log filters found`,
       });
       this.common.metrics.ponder_realtime_is_connected.set(
         { network: this.network.name },
@@ -140,9 +140,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     this.common.logger.info({
       service: "realtime",
-      msg: `Fetched finalized block at ${hexToNumber(
-        finalizedBlock.number!
-      )} (network=${this.network.name})`,
+      msg: `Fetched finalized block at ${hexToNumber(finalizedBlock.number!)}`,
     });
 
     // Add the finalized block as the first element of the list of unfinalized blocks.
@@ -168,7 +166,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     this.queue.clear();
     this.common.logger.debug({
       service: "realtime",
-      msg: `Killed realtime sync service (network=${this.network.name})`,
+      msg: `Killed realtime sync service`,
     });
   };
 
@@ -237,7 +235,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     if (this.blocks.find((b) => b.hash === newBlock.hash)) {
       this.common.logger.trace({
         service: "realtime",
-        msg: `Already processed block at ${newBlock.number} (network=${this.network.name})`,
+        msg: `[${newBlock.number}] Skipped block (already processed)`,
       });
       return;
     }
@@ -249,7 +247,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     ) {
       this.common.logger.debug({
         service: "realtime",
-        msg: `Started processing new head block ${newBlock.number} (network=${this.network.name})`,
+        msg: `[${newBlock.number}] Started processing new head block`,
       });
 
       // First, check if the new block _might_ contain any logs that match the registered filters.
@@ -261,7 +259,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       if (!isMatchedLogPresentInBlock) {
         this.common.logger.debug({
           service: "realtime",
-          msg: `No logs found in block ${newBlock.number} using bloom filter (network=${this.network.name})`,
+          msg: `[${newBlock.number}] No matched logs found`,
         });
       }
 
@@ -290,7 +288,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
         this.common.logger.debug({
           service: "realtime",
-          msg: `Found ${logs.length} total and ${matchedLogCountText} in block ${newBlock.number} (network=${this.network.name})`,
+          msg: `[${newBlock.number}] Found ${logs.length} total and ${matchedLogCountText}`,
         });
 
         // Filter transactions down to those that are required by the matched logs.
@@ -313,13 +311,13 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
           this.common.logger.info({
             service: "realtime",
-            msg: `Found ${matchedLogCountText} in new head block ${newBlock.number} (network=${this.network.name})`,
+            msg: `[${newBlock.number}] Found ${matchedLogCountText} in new head block`,
           });
         } else {
           // If there are not, this was a false positive on the bloom filter.
           this.common.logger.debug({
             service: "realtime",
-            msg: `Logs bloom for block ${newBlock.number} was a false positive (network=${this.network.name})`,
+            msg: `[${newBlock.number}] Logs bloom was a false positive`,
           });
         }
       }
@@ -369,13 +367,13 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
         this.common.logger.debug({
           service: "realtime",
-          msg: `Updated finality checkpoint to ${newFinalizedBlock.number} (network=${this.network.name})`,
+          msg: `[${newBlock.number}] Updated finality checkpoint to ${newFinalizedBlock.number}`,
         });
       }
 
       this.common.logger.debug({
         service: "realtime",
-        msg: `Finished processing new head block ${newBlock.number} (network=${this.network.name})`,
+        msg: `[${newBlock.number}] Finished processing new head block`,
       });
 
       return;
@@ -421,9 +419,9 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
       this.common.logger.info({
         service: "realtime",
-        msg: `Fetched missing blocks [${missingBlockNumbers[0]}, ${
-          missingBlockNumbers[missingBlockNumbers.length - 1]
-        }] (network=${this.network.name})`,
+        msg: `[${newBlock.number}] Fetched missing block range (${
+          missingBlockNumbers[0]
+        }, ${missingBlockNumbers[missingBlockNumbers.length - 1]})`,
       });
 
       return;
@@ -447,7 +445,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     this.common.logger.warn({
       service: "realtime",
-      msg: `Detected reorg with forked block (${canonicalBlock.number}, ${canonicalBlock.hash}) (network=${this.network.name})`,
+      msg: `[${newBlock.number}] Detected reorg with forked block (${canonicalBlock.number}, ${canonicalBlock.hash})`,
     });
 
     while (canonicalBlock.number > this.finalizedBlockNumber) {
@@ -459,7 +457,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       if (commonAncestorBlock) {
         this.common.logger.warn({
           service: "realtime",
-          msg: `Found common ancestor block on local chain at height ${commonAncestorBlock.number} (network=${this.network.name})`,
+          msg: `[${newBlock.number}] Found common ancestor block on local chain at height ${commonAncestorBlock.number}`,
         });
 
         // Remove all non-canonical blocks from the local chain.
@@ -491,7 +489,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
         this.common.logger.info({
           service: "realtime",
-          msg: `Reconciled ${depth}-block reorg with common ancestor block ${commonAncestorBlock.number} (network=${this.network.name})`,
+          msg: `[${newBlock.number}] Reconciled ${depth}-block reorg with common ancestor block ${commonAncestorBlock.number}`,
         });
 
         return;
@@ -521,7 +519,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
       this.common.logger.warn({
         service: "realtime",
-        msg: `Fetched canonical block at height ${canonicalBlock.number} while reconciling reorg (network=${this.network.name})`,
+        msg: `[${newBlock.number}] Fetched canonical block at height ${canonicalBlock.number} while reconciling reorg`,
       });
     }
 
@@ -533,7 +531,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     this.common.logger.warn({
       service: "realtime",
-      msg: `Unable to reconcile >${depth}-block reorg (network=${this.network.name})`,
+      msg: `[${newBlock.number}] Unable to reconcile >${depth}-block reorg`,
     });
   };
 }

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -3,7 +3,7 @@ import pLimit from "p-limit";
 import { hexToNumber, numberToHex } from "viem";
 
 import type { LogFilter } from "@/config/logFilters";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 import { QueueError } from "@/errors/queue";
 import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -332,11 +332,9 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       this.blocks.push(newBlock);
 
       this.common.metrics.ponder_realtime_latest_block_number.set(
-        { network: this.network.name },
         newBlock.number
       );
       this.common.metrics.ponder_realtime_latest_block_timestamp.set(
-        { network: this.network.name },
         newBlock.timestamp
       );
 

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -21,9 +21,9 @@ import {
 } from "./format";
 
 type RealtimeSyncEvents = {
-  realtimeCheckpoint: { timestamp: number };
-  finalityCheckpoint: { timestamp: number };
-  shallowReorg: { commonAncestorTimestamp: number };
+  realtimeCheckpoint: { blockNumber: number };
+  finalityCheckpoint: { blockNumber: number };
+  shallowReorg: { commonAncestorBlockNumber: number };
   deepReorg: { detectedAtBlockNumber: number; minimumDepth: number };
   error: { error: Error };
 };
@@ -326,7 +326,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       }
 
       this.emit("realtimeCheckpoint", {
-        timestamp: hexToNumber(newBlockWithTransactions.timestamp),
+        blockNumber: hexToNumber(newBlockWithTransactions.number),
       });
 
       // Add this block the local chain.
@@ -368,7 +368,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         this.finalizedBlockNumber = newFinalizedBlock.number;
 
         this.emit("finalityCheckpoint", {
-          timestamp: newFinalizedBlock.timestamp,
+          blockNumber: newFinalizedBlock.number,
         });
 
         this.common.logger.debug({
@@ -493,7 +493,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         // start fetching any newer blocks on the canonical chain.
         await this.addNewLatestBlock();
         this.emit("shallowReorg", {
-          commonAncestorTimestamp: commonAncestorBlock.timestamp,
+          commonAncestorBlockNumber: commonAncestorBlock.number,
         });
 
         this.common.logger.info({

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -58,7 +58,6 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     network: Network;
   }) {
     super();
-
     this.common = common;
     this.eventStore = eventStore;
     this.logFilters = logFilters;
@@ -135,7 +134,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     });
     if (!finalizedBlock) throw new Error(`Unable to fetch finalized block`);
     this.common.metrics.ponder_realtime_rpc_request_duration.observe(
-      { method: "eth_getBlockByNumber", network: this.network.name },
+      { method: "eth_getBlockByNumber" },
       stopClock()
     );
 
@@ -186,7 +185,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     });
     if (!latestBlock_) throw new Error(`Unable to fetch latest block`);
     this.common.metrics.ponder_realtime_rpc_request_duration.observe(
-      { method: "eth_getBlockByNumber", network: this.network.name },
+      { method: "eth_getBlockByNumber" },
       stopClock()
     );
     return latestBlock_ as BlockWithTransactions;
@@ -274,7 +273,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
           params: [{ blockHash: newBlock.hash }],
         });
         this.common.metrics.ponder_realtime_rpc_request_duration.observe(
-          { method: "eth_getLogs", network: this.network.name },
+          { method: "eth_getLogs" },
           stopClock()
         );
 
@@ -407,10 +406,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
             throw new Error(`Failed to fetch block number: ${number}`);
           }
           this.common.metrics.ponder_realtime_rpc_request_duration.observe(
-            {
-              method: "eth_getBlockByNumber",
-              network: this.network.name,
-            },
+            { method: "eth_getBlockByNumber" },
             stopClock()
           );
           return block as BlockWithTransactions;
@@ -510,10 +506,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         params: [canonicalBlock.parentHash, true],
       });
       this.common.metrics.ponder_realtime_rpc_request_duration.observe(
-        {
-          method: "eth_getBlockByHash",
-          network: this.network.name,
-        },
+        { method: "eth_getBlockByHash" },
         stopClock()
       );
 

--- a/packages/core/src/server/graphql/entity.ts
+++ b/packages/core/src/server/graphql/entity.ts
@@ -97,6 +97,9 @@ export const buildEntityType = ({
 
               return await store.findMany({
                 modelName: field.derivedFromEntityName,
+                blockNumber: filter.blockNumber
+                  ? filter.blockNumber
+                  : undefined,
                 filter: {
                   where: { [field.derivedFromFieldName]: entityId },
                   skip: filter.skip,
@@ -104,7 +107,6 @@ export const buildEntityType = ({
                   orderBy: filter.orderBy,
                   orderDirection: filter.orderDirection,
                 },
-                timestamp: filter.timestamp ? filter.timestamp : undefined,
               });
             };
 
@@ -119,7 +121,7 @@ export const buildEntityType = ({
                 first: { type: GraphQLInt, defaultValue: 100 },
                 orderBy: { type: GraphQLString, defaultValue: "id" },
                 orderDirection: { type: GraphQLString, defaultValue: "asc" },
-                timestamp: { type: GraphQLInt },
+                blockNumber: { type: GraphQLInt },
               },
               resolve: resolver,
             };

--- a/packages/core/src/server/graphql/plural.ts
+++ b/packages/core/src/server/graphql/plural.ts
@@ -23,7 +23,7 @@ type PluralArgs = {
   skip?: number;
   orderBy?: string;
   orderDirection?: "asc" | "desc";
-  timestamp?: number;
+  blockNumber?: number;
 };
 type PluralResolver = GraphQLFieldResolver<Source, Context, PluralArgs>;
 
@@ -173,7 +173,7 @@ const buildPluralField = ({
         orderDirection: filter.orderDirection,
         where: filter.where,
       },
-      timestamp: filter.timestamp ? filter.timestamp : undefined,
+      blockNumber: filter.blockNumber ? filter.blockNumber : undefined,
     });
   };
 
@@ -187,7 +187,7 @@ const buildPluralField = ({
       orderBy: { type: GraphQLString, defaultValue: "id" },
       orderDirection: { type: GraphQLString, defaultValue: "asc" },
       where: { type: filterType },
-      timestamp: { type: GraphQLInt },
+      blockNumber: { type: GraphQLInt },
     },
     resolve: resolver,
   };

--- a/packages/core/src/server/graphql/singular.ts
+++ b/packages/core/src/server/graphql/singular.ts
@@ -12,7 +12,7 @@ import type { Context, Source } from "./schema";
 
 type SingularArgs = {
   id?: string;
-  timestamp?: number;
+  blockNumber?: number;
 };
 type SingularResolver = GraphQLFieldResolver<Source, Context, SingularArgs>;
 
@@ -25,14 +25,14 @@ const buildSingularField = ({
 }): GraphQLFieldConfig<Source, Context> => {
   const resolver: SingularResolver = async (_, args, context) => {
     const { store } = context;
-    const { id, timestamp } = args;
+    const { id, blockNumber } = args;
 
     if (!id) return null;
 
     const entityInstance = await store.findUnique({
       modelName: entity.name,
       id,
-      timestamp,
+      blockNumber,
     });
 
     return entityInstance;
@@ -42,7 +42,7 @@ const buildSingularField = ({
     type: entityGqlType,
     args: {
       id: { type: new GraphQLNonNull(entity.fieldByName.id.scalarGqlType) },
-      timestamp: { type: GraphQLInt },
+      blockNumber: { type: GraphQLInt },
     },
     resolve: resolver,
   };

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -71,7 +71,7 @@ const setup = async ({
   const createTestEntity = async ({ id }: { id: number }) => {
     await userStore.create({
       modelName: "TestEntity",
-      timestamp: 0,
+      blockNumber: 0,
       id: String(id),
       data: {
         string: String(id),
@@ -99,7 +99,7 @@ const setup = async ({
   }) => {
     await userStore.create({
       modelName: "EntityWithBigIntId",
-      timestamp: 0,
+      blockNumber: 0,
       id,
       data: {
         testEntity: testEntityId,
@@ -1299,7 +1299,7 @@ test("limits and skips together as expected", async (context) => {
   await service.kill();
 });
 
-test("serves singular entity versioned at specified timestamp", async (context) => {
+test("serves singular entity versioned at specified block number", async (context) => {
   const { common, userStore } = context;
   const { service, gql, createTestEntity } = await setup({
     common,
@@ -1309,7 +1309,7 @@ test("serves singular entity versioned at specified timestamp", async (context) 
   await createTestEntity({ id: 1 });
   await userStore.update({
     modelName: "TestEntity",
-    timestamp: 10,
+    blockNumber: 10,
     id: String(1),
     data: {
       string: "updated",
@@ -1317,7 +1317,7 @@ test("serves singular entity versioned at specified timestamp", async (context) 
   });
 
   const responseOld = await gql(`
-    testEntity(id: "1", timestamp: 5) {
+    testEntity(id: "1", blockNumber: 5) {
       id
       string
     }
@@ -1328,7 +1328,7 @@ test("serves singular entity versioned at specified timestamp", async (context) 
   expect(testEntityOld.string).toBe("1");
 
   const response = await gql(`
-    testEntity(id: "1", timestamp: 15) {
+    testEntity(id: "1", blockNumber: 15) {
       id
       string
     }
@@ -1342,7 +1342,7 @@ test("serves singular entity versioned at specified timestamp", async (context) 
   await userStore.teardown();
 });
 
-test("serves plural entities versioned at specified timestamp", async (context) => {
+test("serves plural entities versioned at specified block number", async (context) => {
   const { common, userStore } = context;
   const { service, gql, createTestEntity } = await setup({
     common,
@@ -1354,7 +1354,7 @@ test("serves plural entities versioned at specified timestamp", async (context) 
 
   await userStore.update({
     modelName: "TestEntity",
-    timestamp: 10,
+    blockNumber: 10,
     id: String(1),
     data: {
       string: "updated",
@@ -1362,7 +1362,7 @@ test("serves plural entities versioned at specified timestamp", async (context) 
   });
   await userStore.update({
     modelName: "TestEntity",
-    timestamp: 15,
+    blockNumber: 15,
     id: String(2),
     data: {
       string: "updated",
@@ -1370,7 +1370,7 @@ test("serves plural entities versioned at specified timestamp", async (context) 
   });
 
   const responseOld = await gql(`
-    testEntitys(timestamp: 12, orderBy: "int") {
+    testEntitys(blockNumber: 12, orderBy: "int") {
       id
       string
     }
@@ -1434,11 +1434,11 @@ test("derived field respects skip argument", async (context) => {
   await userStore.teardown();
 });
 
-// This is a known limitation for now, which is that the timestamp version of entities
-// returned in derived fields does not inherit the timestamp argument provided to the parent.
+// This is a known limitation for now, which is that the block number version of entities
+// returned in derived fields does not inherit the block number argument provided to the parent.
 // So, if you want to use time-travel queries with derived fields, you need to manually
-// include the desired timestamp at every level of the query.
-test.skip("serves derived entities versioned at provided timestamp", async (context) => {
+// include the desired block number at every level of the query.
+test.skip("serves derived entities versioned at provided block number", async (context) => {
   const { common, userStore } = context;
   const { service, gql, createTestEntity, createEntityWithBigIntId } =
     await setup({
@@ -1451,7 +1451,7 @@ test.skip("serves derived entities versioned at provided timestamp", async (cont
 
   await userStore.update({
     modelName: "EntityWithBigIntId",
-    timestamp: 10,
+    blockNumber: 10,
     id: BigInt(0),
     data: {
       testEntity: "2",
@@ -1459,7 +1459,7 @@ test.skip("serves derived entities versioned at provided timestamp", async (cont
   });
 
   const responseOld = await gql(`
-    testEntitys(timestamp: 5) {
+    testEntitys(blockNumber: 5) {
       id
       derived {
         id

--- a/packages/core/src/ui/HandlersBar.tsx
+++ b/packages/core/src/ui/HandlersBar.tsx
@@ -1,8 +1,6 @@
 import { Box, Text } from "ink";
 import React from "react";
 
-import { formatShortDate } from "@/utils/date";
-
 import type { UiState } from "./app";
 import { ProgressBar } from "./ProgressBar";
 
@@ -22,13 +20,9 @@ export const HandlersBar = ({ ui }: { ui: UiState }) => {
   const titleText = () => {
     if (!isStarted) return <Text>(not started)</Text>;
     if (!isHistoricalSyncComplete || !isUpToDate) {
-      return (
-        <Text color="yellow">
-          (up to {formatShortDate(ui.handlersToTimestamp)})
-        </Text>
-      );
+      return <Text color="yellow">(up to {ui.handlersToBlockNumber})</Text>;
     }
-    return <Text color="green">(up to date)</Text>;
+    return <Text color="green">(up to latest)</Text>;
   };
 
   const countText = () => {

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -23,7 +23,7 @@ export type UiState = {
   handlersCurrent: number;
   handlersTotal: number;
   handlersHandledTotal: number;
-  handlersToTimestamp: number;
+  handlersToBlockNumber: number;
 
   networks: string[];
 };
@@ -40,7 +40,7 @@ export const buildUiState = ({ logFilters }: { logFilters: LogFilter[] }) => {
     handlersCurrent: 0,
     handlersTotal: 0,
     handlersHandledTotal: 0,
-    handlersToTimestamp: 0,
+    handlersToBlockNumber: 0,
 
     networks: [],
   };

--- a/packages/core/src/ui/app.tsx
+++ b/packages/core/src/ui/app.tsx
@@ -9,6 +9,7 @@ import { HistoricalBar } from "./HistoricalBar";
 export type UiState = {
   port: number;
 
+  network?: string;
   historicalSyncLogFilterStats: Record<
     string,
     {
@@ -16,7 +17,6 @@ export type UiState = {
       eta?: number;
     }
   >;
-
   isHistoricalSyncComplete: boolean;
 
   handlerError: boolean;
@@ -24,8 +24,6 @@ export type UiState = {
   handlersTotal: number;
   handlersHandledTotal: number;
   handlersToBlockNumber: number;
-
-  networks: string[];
 };
 
 export const buildUiState = ({ logFilters }: { logFilters: LogFilter[] }) => {
@@ -33,7 +31,6 @@ export const buildUiState = ({ logFilters }: { logFilters: LogFilter[] }) => {
     port: 0,
 
     historicalSyncLogFilterStats: {},
-
     isHistoricalSyncComplete: false,
 
     handlerError: false,
@@ -41,8 +38,6 @@ export const buildUiState = ({ logFilters }: { logFilters: LogFilter[] }) => {
     handlersTotal: 0,
     handlersHandledTotal: 0,
     handlersToBlockNumber: 0,
-
-    networks: [],
   };
 
   logFilters.forEach((logFilter) => {
@@ -57,11 +52,11 @@ export const buildUiState = ({ logFilters }: { logFilters: LogFilter[] }) => {
 const App = (ui: UiState) => {
   const {
     port,
+    network,
     historicalSyncLogFilterStats,
     isHistoricalSyncComplete,
     handlersCurrent,
     handlerError,
-    networks,
   } = ui;
 
   if (handlerError) {
@@ -107,16 +102,14 @@ const App = (ui: UiState) => {
 
       <HandlersBar ui={ui} />
 
-      {networks.length > 0 && (
+      {network && (
         <Box flexDirection="column">
-          <Text bold={true}>Networks</Text>
-          {networks.map((network) => (
-            <Box flexDirection="row" key={network}>
-              <Text>
-                {network.slice(0, 1).toUpperCase() + network.slice(1)} (live)
-              </Text>
-            </Box>
-          ))}
+          <Text bold={true}>Network</Text>
+          <Box flexDirection="row" key={network}>
+            <Text>
+              {network.slice(0, 1).toUpperCase() + network.slice(1)} (live)
+            </Text>
+          </Box>
           <Text> </Text>
         </Box>
       )}

--- a/packages/core/src/ui/service.ts
+++ b/packages/core/src/ui/service.ts
@@ -65,14 +65,10 @@ export class UiService {
       }
 
       // Realtime sync
-      const connectedNetworks = (
+      const network = (
         await this.common.metrics.ponder_realtime_is_connected.get()
-      ).values
-        .filter((m) => m.value === 1)
-        .map((m) => m.labels.network)
-        .filter((n): n is string => typeof n === "string");
-
-      this.ui.networks = connectedNetworks;
+      ).values[0]?.labels.network;
+      this.ui.network = network ? String(network) : undefined;
 
       // Handlers
       const matchedEvents = (

--- a/packages/core/src/ui/service.ts
+++ b/packages/core/src/ui/service.ts
@@ -84,14 +84,14 @@ export class UiService {
       const processedEvents = (
         await this.common.metrics.ponder_handlers_processed_events.get()
       ).values.reduce((a, v) => a + v.value, 0);
-      const latestProcessedTimestamp =
+      const latestProcessedBlockNumber =
         (
-          await this.common.metrics.ponder_handlers_latest_processed_timestamp.get()
+          await this.common.metrics.ponder_handlers_latest_processed_block_number.get()
         ).values[0].value ?? 0;
       this.ui.handlersTotal = matchedEvents;
       this.ui.handlersHandledTotal = handledEvents;
       this.ui.handlersCurrent = processedEvents;
-      this.ui.handlersToTimestamp = latestProcessedTimestamp;
+      this.ui.handlersToBlockNumber = latestProcessedBlockNumber;
 
       // Errors
       this.ui.handlerError = this.common.errors.hasUserError;

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -39,7 +39,7 @@ test("getInjectedContract() returns data", async (context) => {
 
   const readOnlyContracts = buildReadOnlyContracts({
     contracts,
-    getCurrentBlockNumber: () => 16375000n,
+    getCurrentBlockNumber: () => 16375000,
     eventStore,
   });
   const contract = readOnlyContracts["USDC"];
@@ -53,7 +53,7 @@ test("getInjectedContract() uses current block number if no overrides are provid
 
   const readOnlyContracts = buildReadOnlyContracts({
     contracts,
-    getCurrentBlockNumber: () => 16375000n,
+    getCurrentBlockNumber: () => 16375000,
     eventStore,
   });
   const contract = readOnlyContracts["USDC"];
@@ -70,7 +70,7 @@ test("getInjectedContract() caches the read result if no overrides are provided"
 
   const readOnlyContracts = buildReadOnlyContracts({
     contracts,
-    getCurrentBlockNumber: () => 16375000n,
+    getCurrentBlockNumber: () => 16375000,
     eventStore,
   });
   const contract = readOnlyContracts["USDC"];
@@ -99,7 +99,7 @@ test("getInjectedContract() uses blockTag override if provided", async (context)
 
   const readOnlyContracts = buildReadOnlyContracts({
     contracts,
-    getCurrentBlockNumber: () => 16375000n,
+    getCurrentBlockNumber: () => 16375000,
     eventStore,
   });
   const contract = readOnlyContracts["USDC"];
@@ -116,7 +116,7 @@ test("getInjectedContract() does not cache data if blockTag override is provided
 
   const readOnlyContracts = buildReadOnlyContracts({
     contracts,
-    getCurrentBlockNumber: () => 16375000n,
+    getCurrentBlockNumber: () => 16375000,
     eventStore,
   });
   const contract = readOnlyContracts["USDC"];

--- a/packages/core/src/user-handlers/contract.test.ts
+++ b/packages/core/src/user-handlers/contract.test.ts
@@ -5,7 +5,7 @@ import { usdcContractConfig } from "@/_test/constants";
 import { setupEventStore } from "@/_test/setup";
 import { publicClient } from "@/_test/utils";
 import type { Contract } from "@/config/contracts";
-import type { Network } from "@/config/networks";
+import type { Network } from "@/config/network";
 
 import { buildReadOnlyContracts } from "./contract";
 

--- a/packages/core/src/user-handlers/contract.ts
+++ b/packages/core/src/user-handlers/contract.ts
@@ -22,7 +22,7 @@ export function buildReadOnlyContracts({
 }: {
   contracts: Contract[];
   eventStore: EventStore;
-  getCurrentBlockNumber: () => bigint;
+  getCurrentBlockNumber: () => number;
 }): Record<string, GetContractReturnType<Abi, PublicClient>> {
   return contracts.reduce<
     Record<string, GetContractReturnType<Abi, PublicClient>>
@@ -59,7 +59,8 @@ export function buildReadOnlyContracts({
 
             // If the user specified a block number, use it, otherwise use the
             // block number of the current event being handled.
-            const blockNumber = options?.blockNumber ?? getCurrentBlockNumber();
+            const blockNumber =
+              options?.blockNumber ?? BigInt(getCurrentBlockNumber());
 
             const calldata = encodeFunctionData({ abi, args, functionName });
 

--- a/packages/core/src/user-handlers/model.ts
+++ b/packages/core/src/user-handlers/model.ts
@@ -7,12 +7,12 @@ export function buildModels({
   common,
   userStore,
   schema,
-  getCurrentEventTimestamp,
+  getCurrentBlockNumber,
 }: {
   common: Common;
   userStore: UserStore;
   schema: Schema;
-  getCurrentEventTimestamp: () => number;
+  getCurrentBlockNumber: () => number;
 }) {
   return schema.entities.reduce<Record<string, Model<ModelInstance>>>(
     (acc, { name: modelName }) => {
@@ -24,7 +24,7 @@ export function buildModels({
           });
           return userStore.findUnique({
             modelName,
-            timestamp: getCurrentEventTimestamp(),
+            blockNumber: getCurrentBlockNumber(),
             id,
           });
         },
@@ -35,7 +35,7 @@ export function buildModels({
           });
           return userStore.create({
             modelName,
-            timestamp: getCurrentEventTimestamp(),
+            blockNumber: getCurrentBlockNumber(),
             id,
             data,
           });
@@ -47,7 +47,7 @@ export function buildModels({
           });
           return userStore.update({
             modelName,
-            timestamp: getCurrentEventTimestamp(),
+            blockNumber: getCurrentBlockNumber(),
             id,
             data,
           });
@@ -59,7 +59,7 @@ export function buildModels({
           });
           return userStore.upsert({
             modelName,
-            timestamp: getCurrentEventTimestamp(),
+            blockNumber: getCurrentBlockNumber(),
             id,
             create,
             update,
@@ -72,7 +72,7 @@ export function buildModels({
           });
           return userStore.delete({
             modelName,
-            timestamp: getCurrentEventTimestamp(),
+            blockNumber: getCurrentBlockNumber(),
             id,
           });
         },

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -225,6 +225,33 @@ test("processEvents() model methods insert data into the user store", async (con
   service.kill();
 });
 
+test("processEvents() emits historicalEventProcessingCompleted", async (context) => {
+  const { common, eventStore, userStore } = context;
+
+  const service = new EventHandlerService({
+    common,
+    eventStore,
+    userStore,
+    eventAggregatorService,
+    contracts,
+    logFilters,
+  });
+  const emitSpy = vi.spyOn(service, "emit");
+
+  await service.reset({ schema, handlers });
+
+  eventAggregatorService.isHistoricalSyncComplete = true;
+  eventAggregatorService.historicalSyncFinalBlockNumber = 10;
+
+  eventAggregatorService.checkpoint = 10;
+
+  await service.processEvents();
+
+  expect(emitSpy).toHaveBeenCalledWith("historicalEventProcessingCompleted");
+
+  service.kill();
+});
+
 test("processEvents() updates event count metrics", async (context) => {
   const { common, eventStore, userStore } = context;
 

--- a/packages/core/src/user-handlers/service.ts
+++ b/packages/core/src/user-handlers/service.ts
@@ -54,6 +54,7 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
 
   private eventsProcessedToBlockNumber = 0;
   private currentEventBlockNumber = 0;
+  private isHistoricalEventProcessingCompleted = false;
   private hasError = false;
 
   constructor({
@@ -353,11 +354,13 @@ export class EventHandlerService extends Emittery<EventHandlerEvents> {
 
         // If all historical events have now been processed, emit the event.
         if (
+          !this.isHistoricalEventProcessingCompleted &&
           this.eventAggregatorService.isHistoricalSyncComplete &&
           this.eventsProcessedToBlockNumber >=
             this.eventAggregatorService.historicalSyncFinalBlockNumber!
         ) {
           this.emit("historicalEventProcessingCompleted");
+          this.isHistoricalEventProcessingCompleted = true;
         }
       });
     } catch (error) {

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -120,7 +120,7 @@ export class SqliteUserStore implements UserStore {
             }
           });
 
-          // Add the effective timestamp columns.
+          // Add the effective block number columns.
           tableBuilder = tableBuilder.addColumn(
             "effectiveFrom",
             "integer",
@@ -163,11 +163,11 @@ export class SqliteUserStore implements UserStore {
 
   findUnique = async ({
     modelName,
-    timestamp = MAX_INTEGER,
+    blockNumber = MAX_INTEGER,
     id,
   }: {
     modelName: string;
-    timestamp?: number;
+    blockNumber?: number;
     id: string | number | bigint;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
@@ -177,8 +177,8 @@ export class SqliteUserStore implements UserStore {
       .selectFrom(tableName)
       .selectAll()
       .where("id", "=", formattedId)
-      .where("effectiveFrom", "<=", timestamp)
-      .where("effectiveTo", ">=", timestamp)
+      .where("effectiveFrom", "<=", blockNumber)
+      .where("effectiveTo", ">=", blockNumber)
       .execute();
 
     if (instances.length > 1) {
@@ -192,12 +192,12 @@ export class SqliteUserStore implements UserStore {
 
   create = async ({
     modelName,
-    timestamp,
+    blockNumber,
     id,
     data = {},
   }: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     data?: Omit<ModelInstance, "id">;
   }) => {
@@ -208,7 +208,7 @@ export class SqliteUserStore implements UserStore {
       .insertInto(tableName)
       .values({
         ...createInstance,
-        effectiveFrom: timestamp,
+        effectiveFrom: blockNumber,
         effectiveTo: MAX_INTEGER,
       })
       .returningAll()
@@ -219,12 +219,12 @@ export class SqliteUserStore implements UserStore {
 
   update = async ({
     modelName,
-    timestamp,
+    blockNumber,
     id,
     data = {},
   }: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     data?: Partial<Omit<ModelInstance, "id">>;
   }) => {
@@ -241,27 +241,27 @@ export class SqliteUserStore implements UserStore {
         .orderBy("effectiveTo", "desc")
         .executeTakeFirstOrThrow();
 
-      // If the latest version has the same effectiveFrom timestamp as the update,
+      // If the latest version has the same effectiveFrom block number as the update,
       // this update is occurring within the same block/second. Update in place.
-      if (latestInstance.effectiveFrom === timestamp) {
+      if (latestInstance.effectiveFrom === blockNumber) {
         return await tx
           .updateTable(tableName)
           .set(updateInstance)
           .where("id", "=", formattedId)
-          .where("effectiveFrom", "=", timestamp)
+          .where("effectiveFrom", "=", blockNumber)
           .returningAll()
           .executeTakeFirstOrThrow();
       }
 
-      if (latestInstance.effectiveFrom > timestamp) {
+      if (latestInstance.effectiveFrom > blockNumber) {
         throw new Error(`Cannot update an instance in the past`);
       }
 
-      // If the latest version has an earlier effectiveFrom timestamp than the update,
+      // If the latest version has an earlier effectiveFrom block number than the update,
       // we need to update the latest version AND insert a new version.
       await tx
         .updateTable(tableName)
-        .set({ effectiveTo: timestamp - 1 })
+        .set({ effectiveTo: blockNumber - 1 })
         .where("id", "=", formattedId)
         .where("effectiveTo", "=", MAX_INTEGER)
         .execute();
@@ -271,7 +271,7 @@ export class SqliteUserStore implements UserStore {
         .values({
           ...latestInstance,
           ...updateInstance,
-          effectiveFrom: timestamp,
+          effectiveFrom: blockNumber,
           effectiveTo: MAX_INTEGER,
         })
         .returningAll()
@@ -283,13 +283,13 @@ export class SqliteUserStore implements UserStore {
 
   upsert = async ({
     modelName,
-    timestamp,
+    blockNumber,
     id,
     create = {},
     update = {},
   }: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
     update?: Partial<Omit<ModelInstance, "id">>;
@@ -314,34 +314,34 @@ export class SqliteUserStore implements UserStore {
           .insertInto(tableName)
           .values({
             ...createInstance,
-            effectiveFrom: timestamp,
+            effectiveFrom: blockNumber,
             effectiveTo: MAX_INTEGER,
           })
           .returningAll()
           .executeTakeFirstOrThrow();
       }
 
-      // If the latest version has the same effectiveFrom timestamp as the update,
+      // If the latest version has the same effectiveFrom block number as the update,
       // this update is occurring within the same block/second. Update in place.
-      if (latestInstance.effectiveFrom === timestamp) {
+      if (latestInstance.effectiveFrom === blockNumber) {
         return await tx
           .updateTable(tableName)
           .set(updateInstance)
           .where("id", "=", formattedId)
-          .where("effectiveFrom", "=", timestamp)
+          .where("effectiveFrom", "=", blockNumber)
           .returningAll()
           .executeTakeFirstOrThrow();
       }
 
-      if (latestInstance.effectiveFrom > timestamp) {
+      if (latestInstance.effectiveFrom > blockNumber) {
         throw new Error(`Cannot update an instance in the past`);
       }
 
-      // If the latest version has an earlier effectiveFrom timestamp than the update,
+      // If the latest version has an earlier effectiveFrom block number than the update,
       // we need to update the latest version AND insert a new version.
       await tx
         .updateTable(tableName)
-        .set({ effectiveTo: timestamp - 1 })
+        .set({ effectiveTo: blockNumber - 1 })
         .where("id", "=", formattedId)
         .where("effectiveTo", "=", MAX_INTEGER)
         .execute();
@@ -351,7 +351,7 @@ export class SqliteUserStore implements UserStore {
         .values({
           ...latestInstance,
           ...updateInstance,
-          effectiveFrom: timestamp,
+          effectiveFrom: blockNumber,
           effectiveTo: MAX_INTEGER,
         })
         .returningAll()
@@ -363,33 +363,33 @@ export class SqliteUserStore implements UserStore {
 
   delete = async ({
     modelName,
-    timestamp,
+    blockNumber,
     id,
   }: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
 
     const instance = await this.db.transaction().execute(async (tx) => {
-      // Update the latest version to be effective until the delete timestamp.
+      // Update the latest version to be effective until the delete block number.
       const deletedInstance = await tx
         .updateTable(tableName)
-        .set({ effectiveTo: timestamp - 1 })
+        .set({ effectiveTo: blockNumber - 1 })
         .where("id", "=", formattedId)
         .where("effectiveTo", "=", MAX_INTEGER)
         .returning(["id", "effectiveFrom"])
         .executeTakeFirst();
 
       // If, after the update, the latest version is only effective from
-      // the delete timestamp, delete the instance in place. It "never existed".
-      if (deletedInstance?.effectiveFrom === timestamp) {
+      // the delete block number, delete the instance in place. It "never existed".
+      if (deletedInstance?.effectiveFrom === blockNumber) {
         await tx
           .deleteFrom(tableName)
           .where("id", "=", formattedId)
-          .where("effectiveFrom", "=", timestamp)
+          .where("effectiveFrom", "=", blockNumber)
           .returning(["id"])
           .executeTakeFirst();
       }
@@ -402,22 +402,22 @@ export class SqliteUserStore implements UserStore {
 
   findMany = async ({
     modelName,
-    timestamp = MAX_INTEGER,
+    blockNumber = MAX_INTEGER,
     filter = {},
   }: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     filter?: ModelFilter;
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
 
-    if (filter.timestamp) timestamp = filter.timestamp;
+    if (filter.blockNumber) blockNumber = filter.blockNumber;
 
     let query = this.db
       .selectFrom(tableName)
       .selectAll()
-      .where("effectiveFrom", "<=", timestamp)
-      .where("effectiveTo", ">=", timestamp);
+      .where("effectiveFrom", "<=", blockNumber)
+      .where("effectiveTo", ">=", blockNumber);
 
     const { where, first, skip, orderBy, orderDirection } =
       validateFilter(filter);
@@ -456,24 +456,24 @@ export class SqliteUserStore implements UserStore {
     );
   };
 
-  revert = async ({ safeTimestamp }: { safeTimestamp: number }) => {
+  revert = async ({ safeBlockNumber }: { safeBlockNumber: number }) => {
     await this.db.transaction().execute(async (tx) => {
       await Promise.all(
         (this.schema?.entities ?? []).map(async (entity) => {
           const modelName = entity.name;
           const tableName = `${modelName}_${this.versionId}`;
 
-          // Delete any versions that are newer than the safe timestamp.
+          // Delete any versions that are newer than the safe block number.
           await tx
             .deleteFrom(tableName)
-            .where("effectiveFrom", ">", safeTimestamp)
+            .where("effectiveFrom", ">", safeBlockNumber)
             .execute();
 
           // Now, any versions that have effectiveTo greater than or equal
-          // to the safe timestamp are the new latest version.
+          // to the safe block number are the new latest version.
           await tx
             .updateTable(tableName)
-            .where("effectiveTo", ">=", safeTimestamp)
+            .where("effectiveTo", ">=", safeBlockNumber)
             .set({ effectiveTo: MAX_INTEGER })
             .execute();
         })

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -45,14 +45,14 @@ test("create() inserts a record that is effective after timestamp", async (conte
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 25,
+    blockNumber: 25,
     id: "id1",
   });
   expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
@@ -66,14 +66,14 @@ test("create() inserts a record that is effective at timestamp", async (context)
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
   });
   expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
@@ -87,14 +87,14 @@ test("create() inserts a record that is not effective before timestamp", async (
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 8,
+    blockNumber: 8,
     id: "id1",
   });
   expect(instance).toBeNull();
@@ -108,7 +108,7 @@ test("create() throws on unique constraint violation", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
@@ -116,7 +116,7 @@ test("create() throws on unique constraint violation", async (context) => {
   await expect(() =>
     userStore.create({
       modelName: "Pet",
-      timestamp: 15,
+      blockNumber: 15,
       id: "id1",
       data: { name: "Skip", age: 13 },
     })
@@ -131,14 +131,14 @@ test("create() respects optional fields", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
   });
 
@@ -153,14 +153,14 @@ test("create() accepts enums", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", kind: "CAT" },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
   });
 
@@ -176,7 +176,7 @@ test("create() throws on invalid enum value", async (context) => {
   await expect(() =>
     userStore.create({
       modelName: "Pet",
-      timestamp: 10,
+      blockNumber: 10,
       id: "id1",
       data: { name: "Skip", kind: "NOTACAT" },
     })
@@ -191,14 +191,14 @@ test("create() accepts BigInt fields as bigint and returns as bigint", async (co
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", bigAge: 100n },
   });
 
   const instance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
   });
 
@@ -213,7 +213,7 @@ test("update() updates a record", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", bigAge: 100n },
   });
@@ -226,7 +226,7 @@ test("update() updates a record", async (context) => {
 
   await userStore.update({
     modelName: "Pet",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
     data: { name: "Peanut Butter" },
   });
@@ -246,21 +246,21 @@ test("update() updates a record and maintains older version", async (context) =>
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", bigAge: 100n },
   });
 
   await userStore.update({
     modelName: "Pet",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
     data: { name: "Peanut Butter" },
   });
 
   const originalInstance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
   });
   expect(originalInstance).toMatchObject({
@@ -278,7 +278,7 @@ test("update() throws if trying to update an instance in the past", async (conte
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
@@ -286,7 +286,7 @@ test("update() throws if trying to update an instance in the past", async (conte
   await expect(() =>
     userStore.update({
       modelName: "Pet",
-      timestamp: 8,
+      blockNumber: 8,
       id: "id1",
       data: { name: "Peanut Butter" },
     })
@@ -301,14 +301,14 @@ test("update() updates a record in-place within the same timestamp", async (cont
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
 
   await userStore.update({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Peanut Butter" },
   });
@@ -328,7 +328,7 @@ test("upsert() inserts a new record", async (context) => {
 
   await userStore.upsert({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     create: { name: "Skip", age: 12 },
   });
@@ -345,7 +345,7 @@ test("upsert() updates a record", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
@@ -354,7 +354,7 @@ test("upsert() updates a record", async (context) => {
 
   await userStore.upsert({
     modelName: "Pet",
-    timestamp: 12,
+    blockNumber: 12,
     id: "id1",
     create: { name: "Skip", age: 24 },
     update: { name: "Jelly" },
@@ -375,7 +375,7 @@ test("upsert() throws if trying to update an instance in the past", async (conte
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
@@ -383,7 +383,7 @@ test("upsert() throws if trying to update an instance in the past", async (conte
   await expect(() =>
     userStore.upsert({
       modelName: "Pet",
-      timestamp: 8,
+      blockNumber: 8,
       id: "id1",
       create: { name: "Jelly" },
       update: { name: "Peanut Butter" },
@@ -399,14 +399,14 @@ test("upsert() updates a record in-place within the same timestamp", async (cont
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
 
   await userStore.upsert({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     create: { name: "Jelly" },
     update: { name: "Peanut Butter" },
@@ -427,14 +427,14 @@ test("delete() removes a record", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
   const instance = await userStore.findUnique({ modelName: "Pet", id: "id1" });
   expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
 
-  await userStore.delete({ modelName: "Pet", timestamp: 15, id: "id1" });
+  await userStore.delete({ modelName: "Pet", blockNumber: 15, id: "id1" });
 
   const deletedInstance = await userStore.findUnique({
     modelName: "Pet",
@@ -451,16 +451,16 @@ test("delete() retains older version of record", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
 
-  await userStore.delete({ modelName: "Pet", timestamp: 15, id: "id1" });
+  await userStore.delete({ modelName: "Pet", blockNumber: 15, id: "id1" });
 
   const deletedInstance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 12,
+    blockNumber: 12,
     id: "id1",
   });
   expect(deletedInstance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
@@ -474,18 +474,18 @@ test("delete() removes a record entirely if only present for one timestamp", asy
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
   const instance = await userStore.findUnique({ modelName: "Pet", id: "id1" });
   expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
 
-  await userStore.delete({ modelName: "Pet", timestamp: 10, id: "id1" });
+  await userStore.delete({ modelName: "Pet", blockNumber: 10, id: "id1" });
 
   const deletedInstance = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
   });
   expect(deletedInstance).toBe(null);
@@ -499,23 +499,23 @@ test("delete() deletes versions effective in the delete timestamp", async (conte
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
 
-  await userStore.delete({ modelName: "Pet", timestamp: 15, id: "id1" });
+  await userStore.delete({ modelName: "Pet", blockNumber: 15, id: "id1" });
 
   const instanceDuringDeleteTimestamp = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 15,
+    blockNumber: 15,
     id: "id1",
   });
   expect(instanceDuringDeleteTimestamp).toBe(null);
 
   const instancePriorToDelete = await userStore.findUnique({
     modelName: "Pet",
-    timestamp: 14,
+    blockNumber: 14,
     id: "id1",
   });
   expect(instancePriorToDelete!.name).toBe("Skip");
@@ -529,25 +529,25 @@ test("findMany() returns current versions of all records", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 8,
+    blockNumber: 8,
     id: "id1",
     data: { name: "Skip", age: 12 },
   });
   await userStore.update({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "SkipUpdated" },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id2",
     data: { name: "Foo" },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id3",
     data: { name: "Bar", bigAge: 100n },
   });
@@ -569,25 +569,25 @@ test("findMany() sorts on BigInt field", async (context) => {
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip", bigAge: 105n },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id2",
     data: { name: "Foo", bigAge: 10n },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id3",
     data: { name: "Bar", bigAge: 190n },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id4",
     data: { name: "Patch" },
   });
@@ -607,36 +607,36 @@ test("revert() deletes versions newer than the safe timestamp", async (context) 
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
   await userStore.create({
     modelName: "Pet",
-    timestamp: 13,
+    blockNumber: 13,
     id: "id2",
     data: { name: "Foo" },
   });
   await userStore.update({
     modelName: "Pet",
-    timestamp: 15,
+    blockNumber: 15,
     id: "id1",
     data: { name: "SkipUpdated" },
   });
   await userStore.create({
     modelName: "Person",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Bob" },
   });
   await userStore.update({
     modelName: "Person",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
     data: { name: "Bobby" },
   });
 
-  await userStore.revert({ safeTimestamp: 12 });
+  await userStore.revert({ safeBlockNumber: 12 });
 
   const pets = await userStore.findMany({ modelName: "Pet" });
   expect(pets.length).toBe(1);
@@ -655,17 +655,17 @@ test("revert() updates versions that only existed during the safe timestamp to l
 
   await userStore.create({
     modelName: "Pet",
-    timestamp: 10,
+    blockNumber: 10,
     id: "id1",
     data: { name: "Skip" },
   });
   await userStore.delete({
     modelName: "Pet",
-    timestamp: 11,
+    blockNumber: 11,
     id: "id1",
   });
 
-  await userStore.revert({ safeTimestamp: 10 });
+  await userStore.revert({ safeBlockNumber: 10 });
 
   const pets = await userStore.findMany({ modelName: "Pet" });
   expect(pets.length).toBe(1);

--- a/packages/core/src/user-store/store.ts
+++ b/packages/core/src/user-store/store.ts
@@ -18,7 +18,7 @@ export type ModelFilter = {
   skip?: number;
   orderBy?: string;
   orderDirection?: "asc" | "desc";
-  timestamp?: number;
+  blockNumber?: number;
 };
 
 export type ModelInstance = {
@@ -39,37 +39,37 @@ export interface UserStore {
   reload(options?: { schema?: Schema }): Promise<void>;
   teardown(): Promise<void>;
 
-  revert(options: { safeTimestamp: number }): Promise<void>;
+  revert(options: { safeBlockNumber: number }): Promise<void>;
 
   findUnique(options: {
     modelName: string;
-    timestamp?: number;
+    blockNumber?: number;
     id: string | number | bigint;
   }): Promise<ModelInstance | null>;
 
   findMany(options: {
     modelName: string;
-    timestamp?: number;
+    blockNumber?: number;
     filter?: ModelFilter;
   }): Promise<ModelInstance[]>;
 
   create(options: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     data?: Omit<ModelInstance, "id">;
   }): Promise<ModelInstance>;
 
   update(options: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     data?: Partial<Omit<ModelInstance, "id">>;
   }): Promise<ModelInstance>;
 
   upsert(options: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
     update?: Partial<Omit<ModelInstance, "id">>;
@@ -77,7 +77,7 @@ export interface UserStore {
 
   delete(options: {
     modelName: string;
-    timestamp: number;
+    blockNumber: number;
     id: string | number | bigint;
   }): Promise<boolean>;
 }

--- a/packages/create-ponder/CHANGELOG.md
+++ b/packages/create-ponder/CHANGELOG.md
@@ -1,5 +1,60 @@
 # create-ponder
 
+## 0.0.81-next.0
+
+### Patch Changes
+
+- 004dac1: Updated event ordering to use block number and log index, replacing a more complex timestamp-based ordering system that worked across chains. This means that (for now) Ponder apps must only index one chain at a time. The `ponder.config.ts` `networks` field has been renamed to `network`, and accepts a single network object instead of an array of networks. The `contracts` and `filters` objects no longer require a `network` property, because they always correspond to the single network specified in the `network` field.
+
+  ```diff
+  // ponder.config.ts
+  import type { Config } from "@ponder/core";
+
+  export const config: Config = {
+  -  networks: [
+  -    {
+  -      name: "mainnet",
+  -      chainId: 1,
+  -      rpcUrl: process.env.PONDER_RPC_URL_1,
+  -    }
+  -  ],
+  +  network: {
+  +    name: "mainnet",
+  +    chainId: 1,
+  +    rpcUrl: process.env.PONDER_RPC_URL_1,
+  +  },
+    contracts: [
+      {
+        name: "MyNftContract",
+  -      network: "mainnet",
+        abi: ERC721Abi,
+        address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+        // ...
+      }
+    ],
+  };
+  ```
+
+  The `contracts` and `filters` objects do not require a `network` property, because they will always correspond to the single network specified in the `network` field.
+
+  ```diff
+  // ponder.config.ts
+  import type { Config } from "@ponder/core";
+
+  export const config: Config = {
+    network: { /* ... */ },
+    contracts: [
+      {
+        name: "MyNftContract",
+  -      network: "mainnet",
+        abi: ERC721Abi,
+        address: "0x60bb1e2aa1c9acafb4d34f71585d7e959f387769",
+        // ...
+      }
+    ],
+  };
+  ```
+
 ## 0.0.80
 
 ## 0.0.79

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ponder",
-  "version": "0.0.80",
+  "version": "0.0.81-next.0",
   "description": "A CLI tool to create Ponder apps",
   "license": "MIT",
   "files": [

--- a/packages/create-ponder/src/index.ts
+++ b/packages/create-ponder/src/index.ts
@@ -21,17 +21,14 @@ export type Network = {
 
 export type Contract = {
   name: string;
-  network: string;
   abi: string;
   address: string;
   startBlock?: number;
 };
 
 export type PartialConfig = {
-  database?: {
-    kind: string;
-  };
-  networks: Network[];
+  database?: { kind: string };
+  network: Network;
   contracts: Contract[];
 };
 
@@ -130,7 +127,7 @@ export const run = async (
     import type { Config } from "@ponder/core";
 
     export const config: Config = {
-      networks: ${JSON.stringify(config.networks).replaceAll(
+      network: ${JSON.stringify(config.network).replaceAll(
         /"process.env.PONDER_RPC_URL_(.*?)"/g,
         "process.env.PONDER_RPC_URL_$1"
       )},
@@ -144,12 +141,7 @@ export const run = async (
   );
 
   // Write the .env.local file.
-  const uniqueChainIds = Array.from(
-    new Set(config.networks.map((n) => n.chainId))
-  );
-  const envLocal = `${uniqueChainIds.map(
-    (chainId) => `PONDER_RPC_URL_${chainId}=""\n`
-  )}`;
+  const envLocal = `PONDER_RPC_URL_${config.network.chainId}=""\n`;
   writeFileSync(path.join(rootDir, ".env.local"), envLocal);
 
   // Write the package.json file.

--- a/packages/create-ponder/src/templates/basic.ts
+++ b/packages/create-ponder/src/templates/basic.ts
@@ -38,17 +38,14 @@ export const fromBasic = ({ rootDir }: { rootDir: string }) => {
 
   // Build the partial ponder config.
   const config: PartialConfig = {
-    networks: [
-      {
-        name: "mainnet",
-        chainId: 1,
-        rpcUrl: `process.env.PONDER_RPC_URL_1`,
-      },
-    ],
+    network: {
+      name: "mainnet",
+      chainId: 1,
+      rpcUrl: `process.env.PONDER_RPC_URL_1`,
+    },
     contracts: [
       {
         name: "ExampleContract",
-        network: "mainnet",
         address: "0x0",
         abi: abiRelativePath,
         startBlock: 1234567,

--- a/packages/create-ponder/src/templates/etherscan.ts
+++ b/packages/create-ponder/src/templates/etherscan.ts
@@ -141,17 +141,14 @@ export const fromEtherscan = async ({
 
   // Build and return the partial ponder config.
   const config: PartialConfig = {
-    networks: [
-      {
-        name: name,
-        chainId: chainId,
-        rpcUrl: `process.env.PONDER_RPC_URL_${chainId}`,
-      },
-    ],
+    network: {
+      name: name,
+      chainId: chainId,
+      rpcUrl: `process.env.PONDER_RPC_URL_${chainId}`,
+    },
     contracts: [
       {
         name: contractName,
-        network: name,
         abi: abiConfig,
         address: contractAddress,
         startBlock: blockNumber ?? undefined,

--- a/packages/create-ponder/src/templates/subgraphId.ts
+++ b/packages/create-ponder/src/templates/subgraphId.ts
@@ -80,16 +80,19 @@ export const fromSubgraphId = async ({
 
     return <Contract>{
       name: source.name,
-      network: network,
       address: source.source.address,
       abi: abiRelativePath,
       startBlock: source.source.startBlock,
     };
   });
 
+  if (ponderNetworks.length > 1) {
+    throw new Error("Ponder currently only supports one network per app.");
+  }
+
   // Build the partial ponder config.
   const config: PartialConfig = {
-    networks: ponderNetworks,
+    network: ponderNetworks[0],
     contracts: ponderContracts,
   };
 

--- a/packages/create-ponder/src/templates/subgraphRepo.ts
+++ b/packages/create-ponder/src/templates/subgraphRepo.ts
@@ -106,9 +106,13 @@ export const fromSubgraphRepo = ({
       };
     });
 
+  if (ponderNetworks.length > 1) {
+    throw new Error("Ponder currently only supports one network per app.");
+  }
+
   // Build the partial ponder config.
   const config: PartialConfig = {
-    networks: ponderNetworks,
+    network: ponderNetworks[0],
     contracts: ponderContracts,
   };
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
-  - benchmarks
-  - docs
-  - examples/*
+  # - benchmarks
+  # - docs
+  # - examples/*
   - packages/*
-  - tmp/*
+  # - tmp/*


### PR DESCRIPTION
This PR removes support for multiple chains in the same app, which simplifies the approach to ordering events and fixes a bug where events were sometimes skipped on chains with a sub-second block time (https://github.com/0xOlias/ponder/issues/288)

See changeset for more details.

EDIT: I built this branch locally and published it to NPM as `0.0.81-next.0`.