### PR TITLE
Add `update`/`upsert` function option

### DIFF
--- a/.changeset/few-teachers-run.md
+++ b/.changeset/few-teachers-run.md
@@ -1,0 +1,19 @@
+---
+"@ponder/core": patch
+---
+
+Added support for update functions in the entity store `update` and `upsert` API methods. This allows you to update an entity based on its current state, and solves a common ergonomics issue where users were manually constructing this operation using a combination of `findUnique`, `create`, and `update`.
+
+```ts filename="src/index.ts"
+ponder.on("ERC20:Transfer", async ({ event, context }) => {
+  const { Account } = context.entities;
+
+  const recipient = await Account.update({
+    id: event.params.to,
+    data: ({ current }) => ({
+      balance: current.balance + event.params.value,
+    }),
+  });
+  // { id: "0x5D92..", balance: 11800000005n }
+});
+```

--- a/docs/pages/guides/create-update-entities.mdx
+++ b/docs/pages/guides/create-update-entities.mdx
@@ -116,7 +116,7 @@ type Account @entity {
 ```
 
 ```ts filename="src/index.ts"
-ponder.on("Blitmap:Transfer", async ({ event, context }) => {
+ponder.on("ERC20:Transfer", async ({ event, context }) => {
   const { Account } = context.entities;
 
   const recipient = await Account.update({

--- a/docs/pages/guides/create-update-entities.mdx
+++ b/docs/pages/guides/create-update-entities.mdx
@@ -16,18 +16,18 @@ Ponder's entity store API is inspired by the [Prisma Client API](https://www.pri
 
 ## `create`
 
-`create` inserts an entity into the store.
+Insert a new entity into the store.
 
 ### Options
 
-| name     | type                         |                                                |
-| :------- | :--------------------------- | :--------------------------------------------- |
-| **id**   | `string \| number \| bigint` | ID of the new entity                           |
-| **data** | `Omit<TEntity, 'id'>`        | Data for all required fields of the new entity |
+| name     | type                              |                                |
+| :------- | :-------------------------------- | :----------------------------- |
+| **id**   | `string \| number \| bigint{:ts}` | ID of the new entity           |
+| **data** | `TEntity{:ts}`                    | Data required for a new entity |
 
 ### Returns
 
-`Promise<TEntity>`
+`Promise<TEntity>{:ts}`
 
 ### Example
 
@@ -60,18 +60,19 @@ ponder.on("Blitmap:Mint", async ({ event, context }) => {
 
 ## `update`
 
-`update` updates an existing entity in the store.
+Update an entity that already exists.
 
 ### Options
 
-| name     | type                           |                                           |
-| :------- | :----------------------------- | :---------------------------------------- |
-| **id**   | `string \| number \| bigint`   | ID of the updated entity                  |
-| **data** | `Omit<Partial<TEntity>, 'id'>` | Data for all updated fields of the entity |
+| name                | type                                                    |                                   |
+| :------------------ | :------------------------------------------------------ | :-------------------------------- |
+| **id**              | `string \| number \| bigint{:ts}`                       | ID of the updated entity          |
+| **data**            | `Partial<TEntity>{:ts}`                                 | Data to update                    |
+| **data** (function) | `(args: { current: TEntity }) => Partial<TEntity>{:ts}` | Function returning data to update |
 
 ### Returns
 
-`Promise<TEntity>`
+`Promise<TEntity>{:ts}`
 
 ### Example
 
@@ -101,25 +102,55 @@ ponder.on("Blitmap:MetadataUpdate", async ({ event, context }) => {
 
 </div>
 
+#### Update function
+
+You can optionally pass a function to the `data` field that receives the current entity as an argument and returns the update object. This is useful for updates that depend on the current entity, like an incrementing count or balance.
+
+<div className="code-columns">
+
+```graphql filename="schema.graphql"
+type Account @entity {
+  id: Int!
+  balance: BigInt!
+}
+```
+
+```ts filename="src/index.ts"
+ponder.on("Blitmap:Transfer", async ({ event, context }) => {
+  const { Account } = context.entities;
+
+  const recipient = await Account.update({
+    id: event.params.to,
+    data: ({ current }) => ({
+      balance: current.balance + event.params.value,
+    }),
+  });
+  // { id: "0x5D92..", balance: 11800000005n }
+});
+```
+
+</div>
+
 ## `upsert`
 
-`upsert` updates an entity if one already exists with the specified `id`, or creates a new entity.
+Update an entity if one already exists with the specified `id`, or create a new entity.
 
 ### Options
 
-| name       | type                           |                                                   |
-| :--------- | :----------------------------- | :------------------------------------------------ |
-| **id**     | `string \| number \| bigint`   | ID of the entity to create or update              |
-| **create** | `Omit<TEntity, 'id'>`          | Data for all required fields of a new entity      |
-| **update** | `Omit<Partial<TEntity>, 'id'>` | Data for all updated fields of an existing entity |
+| name                  | type                                                    |                                      |
+| :-------------------- | :------------------------------------------------------ | :----------------------------------- |
+| **id**                | `string \| number \| bigint{:ts}`                       | ID of the entity to create or update |
+| **create**            | `TEntity{:ts}`                                          | Data required for a new entity       |
+| **update**            | `Partial<TEntity>{:ts}`                                 | Data to update                       |
+| **update** (function) | `(args: { current: TEntity }) => Partial<TEntity>{:ts}` | Function returning data to update    |
 
 ### Returns
 
-`Promise<TEntity>`
+`Promise<TEntity>{:ts}`
 
-### Example
+### Examples
 
-`upsert` can be useful for events like the ERC721 `Transfer` event, which is emitted when a token is minted _and_ whenever a token is transferred.
+Upsert can be useful for events like the ERC721 `Transfer` event, which is emitted when a token is minted _and_ whenever a token is transferred.
 
 <div className="code-columns">
 
@@ -140,6 +171,7 @@ ponder.on("Blitmap:Transfer", async ({ event, context }) => {
     create: {
       mintedBy: event.params.to,
       ownedBy: event.params.to,
+      transferCount: 0,
     },
     update: {
       ownedBy: event.params.to,
@@ -151,19 +183,54 @@ ponder.on("Blitmap:Transfer", async ({ event, context }) => {
 
 </div>
 
+#### Update function
+
+You can optionally pass a function to the `update` field that receives the current entity as an argument and returns the update object. This is useful for updates that depend on the current entity, like an incrementing count or balance.
+
+<div className="code-columns">
+
+```graphql filename="schema.graphql"
+type Token @entity {
+  id: Int!
+  ownedBy: String!
+  transferCount: Int!
+}
+```
+
+```ts filename="src/index.ts"
+ponder.on("Blitmap:Transfer", async ({ event, context }) => {
+  const { Token } = context.entities;
+
+  const token = await Token.upsert({
+    id: event.params.tokenId,
+    create: {
+      ownedBy: event.params.to,
+      transferCount: 0,
+    },
+    update: ({ current }) => ({
+      ownedBy: event.params.to,
+      transferCount: current.transferCount + 1,
+    }),
+  });
+  // { id: 7777, ownedBy: "0x7F4d...", transferCount: 1 }
+});
+```
+
+</div>
+
 ## `findUnique`
 
 `findUnique` finds and returns an entity by `id`.
 
 ### Options
 
-| name   | type                         |                                     |
-| :----- | :--------------------------- | :---------------------------------- |
-| **id** | `string \| number \| bigint` | ID of the entity to find and return |
+| name   | type                              |                                     |
+| :----- | :-------------------------------- | :---------------------------------- |
+| **id** | `string \| number \| bigint{:ts}` | ID of the entity to find and return |
 
 ### Returns
 
-`Promise<TEntity | null>`
+`Promise<TEntity | null>{:ts}`
 
 ### Example
 
@@ -190,17 +257,17 @@ const sara = await Player.findUnique({ id: "Sara" });
 
 ## `delete`
 
-`findUnique` deletes an entity by `id`.
+`delete` deletes an entity by `id`.
 
 ### Options
 
-| name   | type                         |                            |
-| :----- | :--------------------------- | :------------------------- |
-| **id** | `string \| number \| bigint` | ID of the entity to delete |
+| name   | type                              |                            |
+| :----- | :-------------------------------- | :------------------------- |
+| **id** | `string \| number \| bigint{:ts}` | ID of the entity to delete |
 
 ### Returns
 
-`Promise<boolean>` (`true` if an entity was deleted, `false` if it was not found)
+`Promise<boolean>{:ts}` (`true{:ts}` if the entity was deleted, `false{:ts}` if it was not found)
 
 ### Example
 

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -24,7 +24,7 @@ export type Model<T extends { id: string | number | bigint }> = {
         ? { data: Prettify<Omit<T, "id">> }
         : { data?: Prettify<Omit<T, "id">> })
     >
-  ) => Promise<T>;
+  ) => Promise<Prettify<T>>;
 
   update: (
     options: Prettify<
@@ -33,10 +33,22 @@ export type Model<T extends { id: string | number | bigint }> = {
       } & (HasOnlyIdProperty<T> extends true
         ? { data?: never }
         : HasRequiredPropertiesOtherThanId<T> extends true
-        ? { data: Prettify<Omit<Partial<T>, "id">> }
-        : { data?: Prettify<Omit<Partial<T>, "id">> })
+        ? {
+            data:
+              | Prettify<Omit<Partial<T>, "id">>
+              | ((options: {
+                  current: Prettify<T>;
+                }) => Prettify<Omit<Partial<T>, "id">>);
+          }
+        : {
+            data?:
+              | Prettify<Omit<Partial<T>, "id">>
+              | ((options: {
+                  current: Prettify<T>;
+                }) => Prettify<Omit<Partial<T>, "id">>);
+          })
     >
-  ) => Promise<T>;
+  ) => Promise<Prettify<T>>;
 
   upsert: (
     options: Prettify<
@@ -47,16 +59,24 @@ export type Model<T extends { id: string | number | bigint }> = {
         : HasRequiredPropertiesOtherThanId<T> extends true
         ? {
             create: Prettify<Omit<T, "id">>;
-            update: Prettify<Omit<Partial<T>, "id">>;
+            update:
+              | Prettify<Omit<Partial<T>, "id">>
+              | ((options: {
+                  current: Prettify<T>;
+                }) => Prettify<Omit<Partial<T>, "id">>);
           }
         : {
             create?: Prettify<Omit<T, "id">>;
-            update?: Prettify<Omit<Partial<T>, "id">>;
+            update?:
+              | Prettify<Omit<Partial<T>, "id">>
+              | ((options: {
+                  current: Prettify<T>;
+                }) => Prettify<Omit<Partial<T>, "id">>);
           })
     >
-  ) => Promise<T>;
+  ) => Promise<Prettify<T>>;
 
-  findUnique: (options: { id: T["id"] }) => Promise<T | null>;
+  findUnique: (options: { id: T["id"] }) => Promise<Prettify<T> | null>;
 
   delete: (options: { id: T["id"] }) => Promise<boolean>;
 };

--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -268,7 +268,10 @@ export class PostgresUserStore implements UserStore {
       let updateInstance: ReturnType<typeof formatModelInstance>;
       if (typeof data === "function") {
         const updateObject = data({
-          current: this.deserializeInstance({ modelName, instance }),
+          current: this.deserializeInstance({
+            modelName,
+            instance: latestInstance,
+          }),
         });
         updateInstance = formatModelInstance({ id, data: updateObject });
       } else {
@@ -362,7 +365,10 @@ export class PostgresUserStore implements UserStore {
       let updateInstance: ReturnType<typeof formatModelInstance>;
       if (typeof update === "function") {
         const updateObject = update({
-          current: this.deserializeInstance({ modelName, instance }),
+          current: this.deserializeInstance({
+            modelName,
+            instance: latestInstance,
+          }),
         });
         updateInstance = formatModelInstance({ id, data: updateObject });
       } else {

--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -246,11 +246,14 @@ export class PostgresUserStore implements UserStore {
     modelName: string;
     timestamp: number;
     id: string | number | bigint;
-    data?: Partial<Omit<ModelInstance, "id">>;
+    data?:
+      | Partial<Omit<ModelInstance, "id">>
+      | ((args: {
+          current: ModelInstance;
+        }) => Partial<Omit<ModelInstance, "id">>);
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
-    const updateInstance = formatModelInstance({ id, data });
 
     const instance = await this.db.transaction().execute(async (tx) => {
       // Find the latest version of this instance.
@@ -260,6 +263,17 @@ export class PostgresUserStore implements UserStore {
         .where("id", "=", formattedId)
         .orderBy("effectiveTo", "desc")
         .executeTakeFirstOrThrow();
+
+      // If the user passed an update function, call it with the current instance.
+      let updateInstance: ReturnType<typeof formatModelInstance>;
+      if (typeof data === "function") {
+        const updateObject = data({
+          current: this.deserializeInstance({ modelName, instance }),
+        });
+        updateInstance = formatModelInstance({ id, data: updateObject });
+      } else {
+        updateInstance = formatModelInstance({ id, data });
+      }
 
       // If the latest version has the same effectiveFrom timestamp as the update,
       // this update is occurring within the same block/second. Update in place.
@@ -312,12 +326,15 @@ export class PostgresUserStore implements UserStore {
     timestamp: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
-    update?: Partial<Omit<ModelInstance, "id">>;
+    update?:
+      | Partial<Omit<ModelInstance, "id">>
+      | ((args: {
+          current: ModelInstance;
+        }) => Partial<Omit<ModelInstance, "id">>);
   }) => {
     const tableName = `${modelName}_${this.versionId}`;
     const formattedId = formatModelFieldValue({ value: id });
     const createInstance = formatModelInstance({ id, data: create });
-    const updateInstance = formatModelInstance({ id, data: update });
 
     const instance = await this.db.transaction().execute(async (tx) => {
       // Attempt to find the latest version of this instance.
@@ -339,6 +356,17 @@ export class PostgresUserStore implements UserStore {
           })
           .returningAll()
           .executeTakeFirstOrThrow();
+      }
+
+      // If the user passed an update function, call it with the current instance.
+      let updateInstance: ReturnType<typeof formatModelInstance>;
+      if (typeof update === "function") {
+        const updateObject = update({
+          current: this.deserializeInstance({ modelName, instance }),
+        });
+        updateInstance = formatModelInstance({ id, data: updateObject });
+      } else {
+        updateInstance = formatModelInstance({ id, data: update });
       }
 
       // If the latest version has the same effectiveFrom timestamp as the update,

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -240,6 +240,44 @@ test("update() updates a record", async (context) => {
   await userStore.teardown();
 });
 
+test("update() updates a record using an update function", async (context) => {
+  const { userStore } = context;
+  await userStore.reload({ schema });
+
+  await userStore.create({
+    modelName: "Pet",
+    timestamp: 10,
+    id: "id1",
+    data: { name: "Skip", bigAge: 100n },
+  });
+
+  const instance = await userStore.findUnique({
+    modelName: "Pet",
+    id: "id1",
+  });
+  expect(instance).toMatchObject({ id: "id1", name: "Skip", bigAge: 100n });
+
+  await userStore.update({
+    modelName: "Pet",
+    timestamp: 11,
+    id: "id1",
+    data: ({ current }) => ({
+      name: current.name + " and Skipper",
+    }),
+  });
+
+  const updatedInstance = await userStore.findUnique({
+    modelName: "Pet",
+    id: "id1",
+  });
+  expect(updatedInstance).toMatchObject({
+    id: "id1",
+    name: "Skip and Skipper",
+  });
+
+  await userStore.teardown();
+});
+
 test("update() updates a record and maintains older version", async (context) => {
   const { userStore } = context;
   await userStore.reload({ schema });
@@ -365,6 +403,38 @@ test("upsert() updates a record", async (context) => {
     id: "id1",
   });
   expect(updatedInstance).toMatchObject({ id: "id1", name: "Jelly", age: 12 });
+
+  await userStore.teardown();
+});
+
+test("upsert() updates a record using an update function", async (context) => {
+  const { userStore } = context;
+  await userStore.reload({ schema });
+
+  await userStore.create({
+    modelName: "Pet",
+    timestamp: 10,
+    id: "id1",
+    data: { name: "Skip", age: 12 },
+  });
+  const instance = await userStore.findUnique({ modelName: "Pet", id: "id1" });
+  expect(instance).toMatchObject({ id: "id1", name: "Skip", age: 12 });
+
+  await userStore.upsert({
+    modelName: "Pet",
+    timestamp: 12,
+    id: "id1",
+    create: { name: "Skip", age: 24 },
+    update: ({ current }) => ({
+      age: (current.age as number) - 5,
+    }),
+  });
+
+  const updatedInstance = await userStore.findUnique({
+    modelName: "Pet",
+    id: "id1",
+  });
+  expect(updatedInstance).toMatchObject({ id: "id1", name: "Skip", age: 7 });
 
   await userStore.teardown();
 });

--- a/packages/core/src/user-store/store.ts
+++ b/packages/core/src/user-store/store.ts
@@ -64,7 +64,11 @@ export interface UserStore {
     modelName: string;
     timestamp: number;
     id: string | number | bigint;
-    data?: Partial<Omit<ModelInstance, "id">>;
+    data?:
+      | Partial<Omit<ModelInstance, "id">>
+      | ((args: {
+          current: ModelInstance;
+        }) => Partial<Omit<ModelInstance, "id">>);
   }): Promise<ModelInstance>;
 
   upsert(options: {
@@ -72,7 +76,11 @@ export interface UserStore {
     timestamp: number;
     id: string | number | bigint;
     create?: Omit<ModelInstance, "id">;
-    update?: Partial<Omit<ModelInstance, "id">>;
+    update?:
+      | Partial<Omit<ModelInstance, "id">>
+      | ((args: {
+          current: ModelInstance;
+        }) => Partial<Omit<ModelInstance, "id">>);
   }): Promise<ModelInstance>;
 
   delete(options: {


### PR DESCRIPTION
This PR updates the entity `update` and `upsert` methods to optionally accept a function for the update object. This is useful for updates that require data from the existing entity, such as balance or counter increments.