### PR TITLE
Stop emitting telemetry from tests and example projects

### DIFF
--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -29,6 +29,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     ...options,
     uiEnabled: false,
     logLevel: "error",
+    telemetryDisabled: true,
   } as const;
 
   const ponder = new Ponder({

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -29,6 +29,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     ...options,
     uiEnabled: false,
     logLevel: "error",
+    telemetryDisabled: true,
   } as const;
 
   const ponder = new Ponder({

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -46,7 +46,12 @@ declare module "vitest" {
 }
 
 beforeEach((context) => {
-  const options = buildOptions({ cliOptions: { configFile: "", rootDir: "" } });
+  const options = {
+    ...buildOptions({
+      cliOptions: { configFile: "", rootDir: "" },
+    }),
+    telemetryDisabled: true,
+  };
   context.common = {
     options,
     logger: new LoggerService({ level: "silent" }),

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -18,6 +18,7 @@ export type Options = {
   maxHealthcheckDuration: number;
   telemetryUrl: string;
   telemetryDisabled: boolean;
+  telemetryIsCi: boolean;
 
   logLevel: LevelWithSilent;
   uiEnabled: boolean;
@@ -58,6 +59,7 @@ export const buildOptions = ({
 
     telemetryUrl: "https://ponder.sh/api/telemetry",
     telemetryDisabled: Boolean(process.env.PONDER_TELEMETRY_DISABLED),
+    telemetryIsCi: Boolean(process.env.PONDER_TELEMETRY_IS_CI),
 
     logLevel,
     uiEnabled: true,

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -18,7 +18,7 @@ export type Options = {
   maxHealthcheckDuration: number;
   telemetryUrl: string;
   telemetryDisabled: boolean;
-  telemetryIsCi: boolean;
+  telemetryIsExampleProject: boolean;
 
   logLevel: LevelWithSilent;
   uiEnabled: boolean;
@@ -59,7 +59,9 @@ export const buildOptions = ({
 
     telemetryUrl: "https://ponder.sh/api/telemetry",
     telemetryDisabled: Boolean(process.env.PONDER_TELEMETRY_DISABLED),
-    telemetryIsCi: Boolean(process.env.PONDER_TELEMETRY_IS_CI),
+    telemetryIsExampleProject: Boolean(
+      process.env.PONDER_TELEMETRY_IS_EXAMPLE_PROJECT
+    ),
 
     logLevel,
     uiEnabled: true,

--- a/packages/core/src/telemetry/detached-flush.test.ts
+++ b/packages/core/src/telemetry/detached-flush.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import process from "node:process";
 import { expect, test } from "vitest";
 
-test("detached flush script should run without error", async ({ common }) => {
+test("detached flush script should run without error", async () => {
+  // This is a service that always responds to POST requests with a 200 OK.
+  const telemetryUrl = "https://reqres.in/api/users";
+
   const events = Array.from({ length: 5 }, () => ({
     event: "test",
     payload: {},
@@ -22,7 +25,7 @@ test("detached flush script should run without error", async ({ common }) => {
     stderr: string;
   }>((resolve) => {
     child_process.exec(
-      `${process.execPath} ${flushDetachedScriptPath} ${common.options.telemetryUrl} ${telemetryEventsFilePath}`,
+      `${process.execPath} ${flushDetachedScriptPath} ${telemetryUrl} ${telemetryEventsFilePath}`,
       (error, stdout, stderr) => resolve({ error, stdout, stderr })
     );
   });
@@ -31,6 +34,6 @@ test("detached flush script should run without error", async ({ common }) => {
   expect(stderr).toBe("");
   expect(error).toBe(null);
   expect(stdout).toContain(
-    `Sending 5 telemetry events to https://ponder.sh/api/telemetry from temporary file ${telemetryEventsFilePath}`
+    `Sending 5 telemetry events to ${telemetryUrl} from temporary file ${telemetryEventsFilePath}`
   );
 });

--- a/packages/core/src/telemetry/service.ts
+++ b/packages/core/src/telemetry/service.ts
@@ -28,20 +28,18 @@ type TelemetryDeviceConfig = {
 type TelemetryEventContext = {
   projectId: string;
   sessionId: string;
-  // package.json information
-  nodeVersion: string;
   packageManager: string;
   packageManagerVersion: string;
+  nodeVersion: string;
   ponderVersion: string;
-  // Software information
   systemPlatform: NodeJS.Platform;
   systemRelease: string;
   systemArchitecture: string;
-  // Machine information
   cpuCount: number;
   cpuModel: string | null;
   cpuSpeed: number | null;
   memoryInMb: number;
+  isCi: boolean;
 };
 
 export class TelemetryService {
@@ -235,6 +233,7 @@ export class TelemetryService {
       cpuModel: cpus.length ? cpus[0].model : null,
       cpuSpeed: cpus.length ? cpus[0].speed : null,
       memoryInMb: Math.trunc(os.totalmem() / Math.pow(1024, 2)),
+      isCi: this.options.telemetryIsCi,
     } satisfies TelemetryEventContext;
 
     return this.context;

--- a/packages/core/src/telemetry/service.ts
+++ b/packages/core/src/telemetry/service.ts
@@ -39,7 +39,7 @@ type TelemetryEventContext = {
   cpuModel: string | null;
   cpuSpeed: number | null;
   memoryInMb: number;
-  isCi: boolean;
+  isExampleProject: boolean;
 };
 
 export class TelemetryService {
@@ -233,7 +233,7 @@ export class TelemetryService {
       cpuModel: cpus.length ? cpus[0].model : null,
       cpuSpeed: cpus.length ? cpus[0].speed : null,
       memoryInMb: Math.trunc(os.totalmem() / Math.pow(1024, 2)),
-      isCi: this.options.telemetryIsCi,
+      isExampleProject: this.options.telemetryIsExampleProject,
     } satisfies TelemetryEventContext;
 
     return this.context;


### PR DESCRIPTION
Updates test setup to never send telemetry events.

Also adds a telemetry context value `isExampleProject` which is set by the `PONDER_TELEMETRY_IS_EXAMPLE_PROJECT` env var. Moving forward, if you're working on Ponder and running the projects in the `examples/` directory on your local device, be sure to include `PONDER_TELEMETRY_IS_EXAMPLE_PROJECT=true` in your `.env.local` so that the telemetry events emitted by that app are marked properly.

Also note that I've updated the Railway shared env to set that as well.
