### PR TITLE
Watch and rebuild config file on change

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -120,6 +120,10 @@ export class Ponder {
         ? new SqliteUserStore({ db: database.db })
         : new PostgresUserStore({ pool: database.pool }));
 
+    // Reset metrics before instantiating sync services
+    // Required during config rebuilds
+    this.common.metrics.resetMetrics();
+
     networks.forEach((network) => {
       assert(this.eventStore);
 
@@ -333,6 +337,7 @@ export class Ponder {
       )
     );
 
+    this.networkSyncServices = [];
     this.uiService.kill();
     this.eventHandlerService.kill();
     await this.serverService.kill();
@@ -361,7 +366,7 @@ export class Ponder {
     assert(this.eventAggregatorService);
     assert(this.eventHandlerService);
     this.buildService.on("newConfig", async () => {
-      this.common.logger.fatal({
+      this.common.logger.info({
         service: "build",
         msg: "Detected change in ponder.config.ts",
       });

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -171,6 +171,7 @@ export class Ponder {
 
     this.serverService = new ServerService({
       common: this.common,
+      configOptions: config.options,
       userStore: this.userStore,
     });
     this.codegenService = new CodegenService({

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -311,6 +311,7 @@ export class Ponder {
   }
 
   async codegen() {
+    await this.buildService.buildConfig();
     await this.init();
     assert(this.codegenService);
     this.codegenService.generateAppFile();

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 
 import { BuildService } from "@/build/service";
 import { CodegenService } from "@/codegen/service";
+import { type ResolvedConfig } from "@/config/config";
 import { buildContracts } from "@/config/contracts";
 import { buildDatabase } from "@/config/database";
 import { type LogFilter } from "@/config/logFilters";
@@ -38,6 +39,7 @@ export class Ponder {
   common: Common;
   logFilters: LogFilter[] = [];
 
+  config?: ResolvedConfig;
   eventStore?: EventStore;
   userStore?: UserStore;
 
@@ -60,11 +62,13 @@ export class Ponder {
 
   constructor({
     options,
+    config,
     eventStore,
     userStore,
   }: {
     options: Options;
     // These options are only used for testing.
+    config?: ResolvedConfig;
     eventStore?: EventStore;
     userStore?: UserStore;
   }) {
@@ -80,12 +84,13 @@ export class Ponder {
     this.common = common;
     this.buildService = new BuildService({ common });
 
+    this.config = config;
     this.eventStore = eventStore;
     this.userStore = userStore;
   }
 
   async init() {
-    const config = this.buildService.config;
+    const config = this.config ?? this.buildService.config;
     assert(config, "Config is not set in init");
     const options = this.common.options;
     const logFilters = this.buildService.buildLogFilters();
@@ -177,7 +182,7 @@ export class Ponder {
   }
 
   async setup() {
-    await this.buildService?.buildConfig();
+    await this.buildService.buildConfig();
 
     await this.init();
     assert(this.serverService);

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -34,8 +34,8 @@ const setup = async ({ context }: { context: TestContext }) => {
   } as const;
 
   const ponder = new Ponder({
-    options: testOptions,
     config: testConfig,
+    options: testOptions,
     eventStore: context.eventStore,
     userStore: context.userStore,
   });

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert";
 import { rmSync } from "node:fs";
+import path from "node:path";
 import request from "supertest";
 import { type TestContext, afterEach, beforeEach, expect, test } from "vitest";
 
 import { setupEventStore, setupUserStore } from "@/_test/setup";
+import { testNetworkConfig } from "@/_test/utils";
+import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
 import { Ponder } from "@/Ponder";
 
@@ -11,11 +14,11 @@ beforeEach((context) => setupEventStore(context));
 beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
-  // const config = await buildConfig({
-  //   configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
-  // });
-  // // Inject proxied anvil chain.
-  // const testConfig = { ...config, networks: [testNetworkConfig] };
+  const config = await buildConfig({
+    configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
+  });
+  // Inject proxied anvil chain.
+  const testConfig = { ...config, networks: [testNetworkConfig] };
 
   const options = buildOptions({
     cliOptions: {
@@ -32,6 +35,7 @@ const setup = async ({ context }: { context: TestContext }) => {
 
   const ponder = new Ponder({
     options: testOptions,
+    config: testConfig,
     eventStore: context.eventStore,
     userStore: context.userStore,
   });

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -1,11 +1,9 @@
+import assert from "node:assert";
 import { rmSync } from "node:fs";
-import path from "node:path";
 import request from "supertest";
 import { type TestContext, afterEach, beforeEach, expect, test } from "vitest";
 
 import { setupEventStore, setupUserStore } from "@/_test/setup";
-import { testNetworkConfig } from "@/_test/utils";
-import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
 import { Ponder } from "@/Ponder";
 
@@ -13,11 +11,11 @@ beforeEach((context) => setupEventStore(context));
 beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
-  const config = await buildConfig({
-    configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
-  });
-  // Inject proxied anvil chain.
-  const testConfig = { ...config, networks: [testNetworkConfig] };
+  // const config = await buildConfig({
+  //   configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
+  // });
+  // // Inject proxied anvil chain.
+  // const testConfig = { ...config, networks: [testNetworkConfig] };
 
   const options = buildOptions({
     cliOptions: {
@@ -33,7 +31,6 @@ const setup = async ({ context }: { context: TestContext }) => {
   } as const;
 
   const ponder = new Ponder({
-    config: testConfig,
     options: testOptions,
     eventStore: context.eventStore,
     userStore: context.userStore,
@@ -43,6 +40,8 @@ const setup = async ({ context }: { context: TestContext }) => {
 
   // Wait for historical sync event processing to complete.
   await new Promise<void>((resolve) => {
+    assert(ponder.eventHandlerService);
+
     ponder.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
       // Block 15870405
       if (toTimestamp >= 1667247815) {
@@ -52,6 +51,8 @@ const setup = async ({ context }: { context: TestContext }) => {
   });
 
   const gql = async (query: string) => {
+    assert(ponder.serverService);
+
     const response = await request(ponder.serverService.app)
       .post("/")
       .send({ query: `query { ${query} }` });

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -15,7 +15,7 @@ beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
   const config = await buildConfig({
-    configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
+    configFile: path.resolve("src/_test/ens/app/ponder.config.ts"),
   });
   // Inject proxied anvil chain.
   const testConfig = { ...config, networks: [testNetworkConfig] };
@@ -34,8 +34,8 @@ const setup = async ({ context }: { context: TestContext }) => {
   } as const;
 
   const ponder = new Ponder({
-    options: testOptions,
     config: testConfig,
+    options: testOptions,
     eventStore: context.eventStore,
     userStore: context.userStore,
   });

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert";
 import { rmSync } from "node:fs";
+import path from "node:path";
 import request from "supertest";
 import { type TestContext, afterEach, beforeEach, expect, test } from "vitest";
 
 import { setupEventStore, setupUserStore } from "@/_test/setup";
+import { testNetworkConfig } from "@/_test/utils";
+import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
 import { Ponder } from "@/Ponder";
 
@@ -11,11 +14,11 @@ beforeEach((context) => setupEventStore(context));
 beforeEach((context) => setupUserStore(context));
 
 const setup = async ({ context }: { context: TestContext }) => {
-  // const config = await buildConfig({
-  //   configFile: path.resolve("src/_test/ens/app/ponder.config.ts"),
-  // });
-  // // Inject proxied anvil chain.
-  // const testConfig = { ...config, networks: [testNetworkConfig] };
+  const config = await buildConfig({
+    configFile: path.resolve("src/_test/art-gobblers/app/ponder.config.ts"),
+  });
+  // Inject proxied anvil chain.
+  const testConfig = { ...config, networks: [testNetworkConfig] };
 
   const options = buildOptions({
     cliOptions: {
@@ -32,6 +35,7 @@ const setup = async ({ context }: { context: TestContext }) => {
 
   const ponder = new Ponder({
     options: testOptions,
+    config: testConfig,
     eventStore: context.eventStore,
     userStore: context.userStore,
   });

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -4,9 +4,7 @@ import "@/utils/globals";
 
 import { cac } from "cac";
 import dotenv from "dotenv";
-import path from "node:path";
 
-import { buildConfig } from "@/config/config";
 import { buildOptions } from "@/config/options";
 import { Ponder } from "@/Ponder";
 
@@ -39,13 +37,11 @@ cli
   .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
-    const configFile = path.resolve(cliOptions.rootDir, cliOptions.configFile);
-    const config = await buildConfig({ configFile });
-    const options = buildOptions({ cliOptions, configOptions: config.options });
+    const options = buildOptions({ cliOptions });
 
     const devOptions = { ...options, uiEnabled: true };
 
-    const ponder = new Ponder({ config, options: devOptions });
+    const ponder = new Ponder({ options: devOptions });
     registerKilledProcessListener(() => ponder.kill());
     await ponder.dev();
   });
@@ -55,13 +51,11 @@ cli
   .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
-    const configFile = path.resolve(cliOptions.rootDir, cliOptions.configFile);
-    const config = await buildConfig({ configFile });
-    const options = buildOptions({ cliOptions, configOptions: config.options });
+    const options = buildOptions({ cliOptions });
 
     const startOptions = { ...options, uiEnabled: false };
 
-    const ponder = new Ponder({ config, options: startOptions });
+    const ponder = new Ponder({ options: startOptions });
     registerKilledProcessListener(() => ponder.kill());
     await ponder.start();
   });
@@ -71,9 +65,7 @@ cli
   .action(async (cliOptions: CliOptions) => {
     if (cliOptions.help) process.exit(0);
 
-    const configFile = path.resolve(cliOptions.rootDir, cliOptions.configFile);
-    const config = await buildConfig({ configFile });
-    const options = buildOptions({ cliOptions, configOptions: config.options });
+    const options = buildOptions({ cliOptions });
 
     const codegenOptions = {
       ...options,
@@ -81,7 +73,7 @@ cli
       logLevel: "silent",
     } as const;
 
-    const ponder = new Ponder({ config, options: codegenOptions });
+    const ponder = new Ponder({ options: codegenOptions });
     registerKilledProcessListener(() => ponder.kill());
     await ponder.codegen();
   });

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -87,21 +87,53 @@ export class BuildService extends Emittery<BuildServiceEvents> {
   }
 
   async buildConfig() {
-    const configFile = path.resolve(
-      this.common.options.rootDir,
-      this.common.options.configFile
-    );
-    this.config = await buildConfig({ configFile });
+    try {
+      const configFile = path.resolve(
+        this.common.options.rootDir,
+        this.common.options.configFile
+      );
+      this.config = await buildConfig({ configFile });
+    } catch (error_) {
+      const error = error_ as Error;
+
+      const message = `Error while building ponder.config.ts: ${error.message}`;
+      const userError = new UserError(message, {
+        stack: error.stack,
+      });
+
+      this.common.logger.error({
+        service: "build",
+        error: userError,
+      });
+      this.common.errors.submitUserError({ error: userError });
+    }
   }
 
   buildLogFilters() {
-    assert(this.config, "Config not set before building log filters");
-    const logFilters = buildLogFilters({
-      options: this.common.options,
-      config: this.config,
-    });
-    this.logFilters = logFilters;
-    return logFilters;
+    try {
+      assert(this.config, "Config not set before building log filters");
+      const logFilters = buildLogFilters({
+        options: this.common.options,
+        config: this.config,
+      });
+      this.logFilters = logFilters;
+      return logFilters;
+    } catch (error_) {
+      const error = error_ as Error;
+
+      const message = `Error while building log filters: ${error.message}`;
+      const userError = new UserError(message, {
+        stack: error.stack,
+      });
+
+      this.common.logger.error({
+        service: "build",
+        error: userError,
+      });
+      this.common.errors.submitUserError({ error: userError });
+
+      return [];
+    }
   }
 
   async buildHandlers() {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -115,6 +115,8 @@ export const buildConfig = async ({ configFile }: { configFile: string }) => {
       logLevel: "silent",
     });
 
+    // Delete require cache to get updated buildFile on making changes
+    delete require.cache[require.resolve(buildFile)];
     const { default: rawDefault, config: rawConfig } = require(buildFile);
     rmSync(buildFile, { force: true });
 

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -3,8 +3,6 @@ import type { LevelWithSilent } from "pino";
 
 import type { CliOptions } from "@/bin/ponder";
 
-import type { ResolvedConfig } from "./config";
-
 export type Options = {
   configFile: string;
   schemaFile: string;
@@ -26,10 +24,8 @@ export type Options = {
 
 export const buildOptions = ({
   cliOptions,
-  configOptions = {},
 }: {
   cliOptions: CliOptions;
-  configOptions?: ResolvedConfig["options"];
 }): Options => {
   const railwayHealthcheckTimeout = process.env.RAILWAY_HEALTHCHECK_TIMEOUT_SEC
     ? Math.max(Number(process.env.RAILWAY_HEALTHCHECK_TIMEOUT_SEC) - 5, 0) // Add 5 seconds of buffer.
@@ -54,8 +50,7 @@ export const buildOptions = ({
     logDir: ".ponder/logs",
 
     port: Number(process.env.PORT ?? 42069),
-    maxHealthcheckDuration:
-      configOptions?.maxHealthcheckDuration ?? railwayHealthcheckTimeout ?? 240,
+    maxHealthcheckDuration: railwayHealthcheckTimeout ?? 240,
 
     telemetryUrl: "https://ponder.sh/api/telemetry",
     telemetryDisabled: Boolean(process.env.PONDER_TELEMETRY_DISABLED),

--- a/packages/core/src/metrics/service.ts
+++ b/packages/core/src/metrics/service.ts
@@ -198,4 +198,11 @@ export class MetricsService {
   async getMetrics() {
     return await this.registry.metrics();
   }
+
+  /**
+   * Reset all metrics registered
+   */
+  resetMetrics() {
+    this.registry.resetMetrics();
+  }
 }

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -5,12 +5,14 @@ import type { GraphQLSchema } from "graphql";
 import { createHttpTerminator } from "http-terminator";
 import { createServer, Server } from "node:http";
 
+import { type ResolvedConfig } from "@/config/config";
 import type { Common } from "@/Ponder";
 import type { UserStore } from "@/user-store/store";
 import { startClock } from "@/utils/timer";
 
 export class ServerService {
   private common: Common;
+  private configOptions?: ResolvedConfig["options"];
   private userStore: UserStore;
 
   private port: number;
@@ -20,8 +22,17 @@ export class ServerService {
 
   isHistoricalEventProcessingComplete = false;
 
-  constructor({ common, userStore }: { common: Common; userStore: UserStore }) {
+  constructor({
+    common,
+    configOptions,
+    userStore,
+  }: {
+    common: Common;
+    configOptions?: ResolvedConfig["options"];
+    userStore: UserStore;
+  }) {
     this.common = common;
+    this.configOptions = configOptions;
     this.userStore = userStore;
     this.port = this.common.options.port;
   }
@@ -124,7 +135,9 @@ export class ServerService {
         return res.status(200).send();
       }
 
-      const max = this.common.options.maxHealthcheckDuration;
+      const max =
+        this.configOptions?.maxHealthcheckDuration ??
+        this.common.options.maxHealthcheckDuration;
       const elapsed = Math.floor(process.uptime());
 
       if (elapsed > max) {


### PR DESCRIPTION
Part of https://github.com/0xOlias/ponder/issues/236

> There's really no reason that we can't also hot reload ponder.config.ts, so we should implement that.

Implemented hot-reloading of `ponder.config.ts` according to implementation description in issue

- Refactored code in `bin/ponder.ts` and `Ponder.ts`
  - Watch and build config from config file path in build service
  - Moved setting up services based on config to new `init` method
  - Updated build service listener for `newConfig` (triggered on config file change)
    - Kill config based services
    - Reinitialize services using `dev` method
  - Added option for overriding config by passing a resolved config in constructor (required in tests)