### PR TITLE
refactor: rename create-ponder bin name

### DIFF
--- a/.changeset/perfect-mirrors-leave.md
+++ b/.changeset/perfect-mirrors-leave.md
@@ -1,0 +1,5 @@
+---
+"create-ponder": minor
+---
+
+Updated create-ponder bin script name from "ponder" to "create-ponder" to fix yarn create ponder

--- a/packages/create-ponder/package.json
+++ b/packages/create-ponder/package.json
@@ -9,7 +9,7 @@
     "!src/**/*.test.ts"
   ],
   "bin": {
-    "ponder": "./dist/bin/create-ponder.js"
+    "create-ponder": "./dist/bin/create-ponder.js"
   },
   "scripts": {
     "build": "pnpm clean && tsc --project tsconfig.build.json && tsc-alias --project tsconfig.build.json",


### PR DESCRIPTION
It seems becase we're not using a correct starter kit name pattern yarn is not detecting the bin from the npm registry.

See https://classic.yarnpkg.com/lang/en/docs/cli/create/