### PR TITLE
Create many overflow

### DIFF
--- a/.changeset/tender-badgers-invent.md
+++ b/.changeset/tender-badgers-invent.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fixed a bug where adding too many items to `createMany()` fails

--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/where";
 
 const MAX_INTEGER = 2_147_483_647 as const;
+const MAX_BATCH_SIZE = 1_000 as const;
 
 const gqlScalarToSqlType = {
   Boolean: "integer",
@@ -538,11 +539,9 @@ export class PostgresUserStore implements UserStore {
       effectiveTo: MAX_INTEGER,
     }));
 
-    const chunkSize = 1000;
-
     const chunkedInstances = [];
-    for (let i = 0, len = createInstances.length; i < len; i += chunkSize)
-      chunkedInstances.push(createInstances.slice(i, i + chunkSize));
+    for (let i = 0, len = createInstances.length; i < len; i += MAX_BATCH_SIZE)
+      chunkedInstances.push(createInstances.slice(i, i + MAX_BATCH_SIZE));
 
     const instances = await Promise.all(
       chunkedInstances.map((c) =>

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -513,15 +513,21 @@ export class SqliteUserStore implements UserStore {
       effectiveTo: MAX_INTEGER,
     }));
 
-    const instances = await this.db
-      .insertInto(tableName)
-      .values(createInstances)
-      .returningAll()
-      .execute();
+    const chunkSize = 1000;
 
-    return instances.map((instance) =>
-      this.deserializeInstance({ modelName, instance })
+    const chunkedInstances = [];
+    for (let i = 0, len = createInstances.length; i < len; i += chunkSize)
+      chunkedInstances.push(createInstances.slice(i, i + chunkSize));
+
+    const instances = await Promise.all(
+      chunkedInstances.map((c) =>
+        this.db.insertInto(tableName).values(c).returningAll().execute()
+      )
     );
+
+    return instances
+      .flat()
+      .map((instance) => this.deserializeInstance({ modelName, instance }));
   };
 
   updateMany = async ({

--- a/packages/core/src/user-store/sqlite/store.ts
+++ b/packages/core/src/user-store/sqlite/store.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/where";
 
 const MAX_INTEGER = 2_147_483_647 as const;
+const MAX_BATCH_SIZE = 1_000 as const;
 
 const gqlScalarToSqlType = {
   Boolean: "integer",
@@ -513,11 +514,9 @@ export class SqliteUserStore implements UserStore {
       effectiveTo: MAX_INTEGER,
     }));
 
-    const chunkSize = 1000;
-
     const chunkedInstances = [];
-    for (let i = 0, len = createInstances.length; i < len; i += chunkSize)
-      chunkedInstances.push(createInstances.slice(i, i + chunkSize));
+    for (let i = 0, len = createInstances.length; i < len; i += MAX_BATCH_SIZE)
+      chunkedInstances.push(createInstances.slice(i, i + MAX_BATCH_SIZE));
 
     const instances = await Promise.all(
       chunkedInstances.map((c) =>

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -840,6 +840,29 @@ test("createMany() inserts multiple entities", async (context) => {
   await userStore.teardown();
 });
 
+test("createMany() inserts a large number of entities", async (context) => {
+  const { userStore } = context;
+  await userStore.reload({ schema });
+
+  const num = 100_000;
+
+  const createdInstances = await userStore.createMany({
+    modelName: "Pet",
+    timestamp: 10,
+    data: [...Array(num).keys()].map((i) => ({
+      id: `id${i}`,
+      name: "Alice",
+      bigAge: BigInt(i),
+    })),
+  });
+  expect(createdInstances.length).toBe(num);
+
+  const instances = await userStore.findMany({ modelName: "Pet" });
+  expect(instances.length).toBe(num);
+
+  await userStore.teardown();
+});
+
 test("updateMany() updates multiple entities", async (context) => {
   const { userStore } = context;
   await userStore.reload({ schema });

--- a/packages/core/src/user-store/store.test.ts
+++ b/packages/core/src/user-store/store.test.ts
@@ -844,21 +844,21 @@ test("createMany() inserts a large number of entities", async (context) => {
   const { userStore } = context;
   await userStore.reload({ schema });
 
-  const num = 100_000;
+  const ENTITY_COUNT = 100_000;
 
   const createdInstances = await userStore.createMany({
     modelName: "Pet",
     timestamp: 10,
-    data: [...Array(num).keys()].map((i) => ({
+    data: [...Array(ENTITY_COUNT).keys()].map((i) => ({
       id: `id${i}`,
       name: "Alice",
       bigAge: BigInt(i),
     })),
   });
-  expect(createdInstances.length).toBe(num);
+  expect(createdInstances.length).toBe(ENTITY_COUNT);
 
   const instances = await userStore.findMany({ modelName: "Pet" });
-  expect(instances.length).toBe(num);
+  expect(instances.length).toBe(ENTITY_COUNT);
 
   await userStore.teardown();
 });


### PR DESCRIPTION
Fixes #336 . Batch createMany() internally to a maximum size of 1000. This fixes a bug where adding too many values with `createMany()` fails. This was between 6000-7000 for me. 