### PR TITLE
fix http protocol when visiting graphiql

### DIFF
--- a/.changeset/curly-carpets-agree.md
+++ b/.changeset/curly-carpets-agree.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-fix: http protocol when visiting GraphiQL
+Fixed a bug introduced in `0.0.90` that broke the GraphiQL interface.

--- a/.changeset/curly-carpets-agree.md
+++ b/.changeset/curly-carpets-agree.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+fix: http protocol when visiting GraphiQL

--- a/.changeset/curly-carpets-agree.md
+++ b/.changeset/curly-carpets-agree.md
@@ -2,4 +2,4 @@
 "@ponder/core": patch
 ---
 
-Fixed a bug introduced in `0.0.90` that broke the GraphiQL interface.
+Fixed a bug introduced in `0.0.91` that broke the GraphiQL interface.

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -170,14 +170,18 @@ export class ServerService {
         case "POST":
           return graphqlMiddleware(request, response, next);
         case "GET": {
+          const host = request.get("host");
+          if (!host) {
+            return response.status(400).send("No host header provided");
+          }
+          const protocol = ["localhost", "0.0.0.0", "127.0.0.1"].includes(host)
+            ? "http"
+            : "https";
+          const endpoint = `${protocol}://${host}`;
           return response
             .status(200)
             .setHeader("Content-Type", "text/html")
-            .send(
-              graphiQLHtml({
-                endpoint: `${request.protocol}://${request.get("host")}`,
-              })
-            );
+            .send(graphiQLHtml({ endpoint }));
         }
         case "HEAD":
           return response.status(200).send();
@@ -195,14 +199,18 @@ export class ServerService {
         case "POST":
           return graphqlMiddleware(request, response, next);
         case "GET": {
+          const host = request.get("host");
+          if (!host) {
+            return response.status(400).send("No host header provided");
+          }
+          const protocol = ["localhost", "0.0.0.0", "127.0.0.1"].includes(host)
+            ? "http"
+            : "https";
+          const endpoint = `${protocol}://${host}`;
           return response
             .status(200)
             .setHeader("Content-Type", "text/html")
-            .send(
-              graphiQLHtml({
-                endpoint: `${request.protocol}://${request.get("host")}`,
-              })
-            );
+            .send(graphiQLHtml({ endpoint }));
         }
         case "HEAD":
           return response.status(200).send();


### PR DESCRIPTION
the protocol was always set to `http`. Now it checks if `localhost` then `http` otherwise `https`