### PR TITLE
Fix bug where localhost was being incorrectly identified

### DIFF
--- a/.changeset/three-houses-argue.md
+++ b/.changeset/three-houses-argue.md
@@ -1,0 +1,5 @@
+---
+"@ponder/core": patch
+---
+
+Fix bug affecting local interactive graphql ui

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -203,7 +203,11 @@ export class ServerService {
           if (!host) {
             return response.status(400).send("No host header provided");
           }
-          const protocol = ["localhost", "0.0.0.0", "127.0.0.1"].includes(host)
+          const protocol = [
+            "localhost:42069",
+            "0.0.0.0:42069",
+            "127.0.0.1:42069",
+          ].includes(host)
             ? "http"
             : "https";
           const endpoint = `${protocol}://${host}`;


### PR DESCRIPTION
This fixes an issue where the localhost ui would return "failed to fetch graphiql"