### PR TITLE
Fix bug with inferring enum types

### DIFF
--- a/packages/core/src/schema/schema.test-d.ts
+++ b/packages/core/src/schema/schema.test-d.ts
@@ -96,5 +96,5 @@ test("schema", () => {
   type t = p.Infer<typeof s>;
   //   ^?
 
-  assertType<t>({} as { t: { id: string; e: ["ONE", "TWO"] } });
+  assertType<t>({} as { t: { id: string; e: "ONE" | "TWO" } });
 });

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -262,7 +262,12 @@ export type RecoverEnumType<
     | ReferenceColumn
     | EnumColumn
     | VirtualColumn
-> = TColumn extends EnumColumn ? TEnums[TColumn["type"] & keyof TEnums] : never;
+> = TColumn extends EnumColumn
+  ? TEnums[TColumn["type"] &
+      keyof TEnums] extends infer _enum extends readonly string[]
+    ? _enum[number]
+    : never
+  : never;
 
 export type RecoverTableType<
   TEnums extends Record<string, Enum>,


### PR DESCRIPTION
Fixes a bug in the `Infer` type that resolved enums to an array instead of a union of the elements of the array. 

For example, enum resolved to `["ONE", "TWO"]` instead of `"ONE" | "TWO"`
