### PR TITLE
Use default exports for schema and config files

### DIFF
--- a/examples/art-gobblers/ponder.config.ts
+++ b/examples/art-gobblers/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { ArtGobblersAbi } from "./abis/ArtGobblers.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "mainnet",

--- a/examples/art-gobblers/ponder.schema.ts
+++ b/examples/art-gobblers/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   GobbledArt: p.createTable({
     id: p.string(),
     user: p.string(),

--- a/examples/ethfs/ponder.config.ts
+++ b/examples/ethfs/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { FileStoreAbi } from "./abis/FileStore.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "mainnet",

--- a/examples/ethfs/ponder.schema.ts
+++ b/examples/ethfs/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   File: p.createTable({
     id: p.string(),
     name: p.string(),

--- a/examples/factory-llama/ponder.config.ts
+++ b/examples/factory-llama/ponder.config.ts
@@ -9,7 +9,7 @@ const llamaFactoryEvent = parseAbiItem(
   "event LlamaInstanceCreated(address indexed deployer, string indexed name, address llamaCore, address llamaExecutor, address llamaPolicy, uint256 chainId)",
 );
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "sepolia",

--- a/examples/factory-llama/ponder.schema.ts
+++ b/examples/factory-llama/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   LlamaCoreInstance: p.createTable({
     id: p.string(),
   }),

--- a/examples/friendtech/ponder.config.ts
+++ b/examples/friendtech/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { FriendtechSharesV1Abi } from "./abis/FriendtechSharesV1.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "base",

--- a/examples/friendtech/ponder.schema.ts
+++ b/examples/friendtech/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   TradeType: p.createEnum(["BUY", "SELL"]),
   Share: p.createTable({
     id: p.bytes(),

--- a/examples/token-erc20/ponder.config.ts
+++ b/examples/token-erc20/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { AdventureGoldAbi } from "./abis/AdventureGold.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "mainnet",

--- a/examples/token-erc20/ponder.schema.ts
+++ b/examples/token-erc20/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   Account: p.createTable({
     id: p.string(),
     balance: p.bigint(),

--- a/examples/token-erc721/ponder.config.ts
+++ b/examples/token-erc721/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { SmolBrainAbi } from "./abis/SmolBrain.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "arbitrum",

--- a/examples/token-erc721/ponder.schema.ts
+++ b/examples/token-erc721/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   Account: p.createTable({
     id: p.string(),
     tokens: p.virtual("Token.ownerId"),

--- a/examples/token-reth/ponder.config.ts
+++ b/examples/token-reth/ponder.config.ts
@@ -3,7 +3,7 @@ import { http } from "viem";
 
 import { RocketTokenRETHAbi } from "./abis/RocketTokenRETH.abi";
 
-export const config = createConfig({
+export default createConfig({
   networks: [
     {
       name: "mainnet",

--- a/examples/token-reth/ponder.schema.ts
+++ b/examples/token-reth/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "@ponder/core";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   Transfer: p.createTable({
     id: p.string(),
     sender: p.string(),

--- a/packages/core/src/_test/art-gobblers/app/ponder.config.ts
+++ b/packages/core/src/_test/art-gobblers/app/ponder.config.ts
@@ -6,7 +6,7 @@ import { ArtGobblersAbi } from "./ArtGobblers.abi";
 const poolId = Number(process.env.VITEST_POOL_ID ?? 1);
 const transport = http(`http://127.0.0.1:8545/${poolId}`);
 
-export const config = createConfig({
+export default createConfig({
   networks: [{ name: "mainnet", chainId: 1, transport }],
   contracts: [
     {

--- a/packages/core/src/_test/art-gobblers/app/ponder.schema.ts
+++ b/packages/core/src/_test/art-gobblers/app/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "../../../../dist";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   SetupEntity: p.createTable({
     id: p.string(),
   }),

--- a/packages/core/src/_test/ens/app/ponder.config.ts
+++ b/packages/core/src/_test/ens/app/ponder.config.ts
@@ -6,7 +6,7 @@ import { BaseRegistrarImplementationAbi } from "./BaseRegistrarImplementation.ab
 const poolId = Number(process.env.VITEST_POOL_ID ?? 1);
 const transport = http(`http://127.0.0.1:8545/${poolId}`);
 
-export const config = createConfig({
+export default createConfig({
   networks: [{ name: "mainnet", chainId: 1, transport }],
   contracts: [
     {

--- a/packages/core/src/_test/ens/app/ponder.schema.ts
+++ b/packages/core/src/_test/ens/app/ponder.schema.ts
@@ -1,6 +1,6 @@
 import { p } from "../../../../dist";
 
-export const schema = p.createSchema({
+export default p.createSchema({
   EnsNft: p.createTable({
     id: p.string(),
     labelHash: p.string(),

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -191,16 +191,13 @@ export class BuildService extends Emittery<BuildServiceEvents> {
       return;
     }
 
-    const rawConfig = result.exports.config;
-    const resolvedConfig = (
-      typeof rawConfig === "function" ? await rawConfig() : await rawConfig
-    ) as Config;
+    const config = result.exports.default as Config;
 
     // TODO: Validate config lol
 
-    this.emit("newConfig", { config: resolvedConfig });
+    this.emit("newConfig", { config });
 
-    return resolvedConfig;
+    return config;
   }
 
   async loadSchema() {
@@ -210,7 +207,7 @@ export class BuildService extends Emittery<BuildServiceEvents> {
       return;
     }
 
-    const schema = result.exports.schema as Schema;
+    const schema = result.exports.default as Schema;
     const graphqlSchema = buildGqlSchema(schema);
 
     // TODO: Validate schema lol

--- a/packages/core/src/codegen/service.ts
+++ b/packages/core/src/codegen/service.ts
@@ -34,8 +34,8 @@ export class CodegenService extends Emittery {
   import type { PonderApp } from "@ponder/core";
 
   export const ponder: PonderApp<
-    typeof import("${configPath}").config,
-    typeof import("${schemaPath}").schema
+    typeof import("${configPath}").default,
+    typeof import("${schemaPath}").default
   >;
 }
 `;


### PR DESCRIPTION
Use default exports instead of named exports for `ponder.schema.ts` and `ponder.config.ts`