### PR TITLE
Refactor "Contract:setup" indexing function

### DIFF
--- a/packages/core/src/_test/art-gobblers/app/src/index.ts
+++ b/packages/core/src/_test/art-gobblers/app/src/index.ts
@@ -7,9 +7,7 @@ declare const ponder: import("@/index.js").PonderApp<
   typeof import("../ponder.schema.ts").default
 >;
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-ponder.on("setup", async ({ context }) => {
+ponder.on("ArtGobblers:setup", async ({ context }) => {
   const { SetupEntity } = context.db;
 
   await SetupEntity.upsert({

--- a/packages/core/src/build/functions.ts
+++ b/packages/core/src/build/functions.ts
@@ -10,21 +10,9 @@ export function validateIndexingFunctions(rawIndexingFunctions: {
   const indexingFunctions: IndexingFunctions = {};
   for (const fileFns of Object.values(rawIndexingFunctions)) {
     for (const [eventKey, fn] of Object.entries(fileFns)) {
-      let sourceName: string;
-      let eventName: string;
-
-      if (eventKey === "setup") {
-        const [sourceName_] = eventKey.split(":");
-
-        sourceName = sourceName_;
-        eventName = "setup";
-      } else {
-        const [sourceName_, eventName_] = eventKey.split(":");
-        if (!sourceName_ || !eventName_)
-          throw new Error(`Invalid event name: ${eventKey}`);
-        sourceName = sourceName_;
-        eventName = eventName_;
-      }
+      const [sourceName, eventName] = eventKey.split(":");
+      if (!sourceName || !eventName)
+        throw new Error(`Invalid event name: ${eventKey}`);
 
       indexingFunctions[sourceName] ||= {};
 

--- a/packages/core/src/build/functions.ts
+++ b/packages/core/src/build/functions.ts
@@ -14,7 +14,9 @@ export function validateIndexingFunctions(rawIndexingFunctions: {
       let eventName: string;
 
       if (eventKey === "setup") {
-        sourceName = "_meta_";
+        const [sourceName_] = eventKey.split(":");
+
+        sourceName = sourceName_;
         eventName = "setup";
       } else {
         const [sourceName_, eventName_] = eventKey.split(":");

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -532,7 +532,6 @@ export class IndexingService extends Emittery<IndexingEvents> {
           // This enables contract calls occurring within the
           // user code to use the start block number by default.
           this.currentEventBlockNumber = event.blockNumber;
-          // this.currentEventTimestamp = 0; // TODO:KYLE should we have this line?
 
           try {
             this.common.logger.trace({

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -41,7 +41,15 @@ type LogEvent = {
   block: Block;
   transaction: Transaction;
 };
-type SetupTask = { kind: "SETUP" };
+type SetupTask = {
+  kind: "SETUP";
+  event: {
+    chainId: number;
+    networkName: string;
+    contractName: string;
+    blockNumber: bigint;
+  };
+};
 type LogEventTask = { kind: "LOG"; event: LogEvent };
 type IndexingFunctionTask = SetupTask | LogEventTask;
 type IndexingFunctionQueue = Queue<IndexingFunctionTask>;
@@ -288,19 +296,43 @@ export class IndexingService extends Emittery<IndexingEvents> {
 
         const toTimestamp = eventsAvailableTo;
 
-        // If no events have been added yet, add the setup event & associated metrics.
-        if (
-          this.eventsProcessedToTimestamp === 0 &&
-          this.indexingFunctions?._meta_?.setup
-        ) {
-          const labels = {
-            network: "_meta_",
-            contract: "_meta_",
-            event: "setup",
-          };
-          this.common.metrics.ponder_indexing_matched_events.inc(labels);
-          this.queue.addTask({ kind: "SETUP" });
-          this.common.metrics.ponder_indexing_handled_events.inc(labels);
+        // If no events have been added yet, add the setup events for each chain & associated metrics.
+        if (this.eventsProcessedToTimestamp === 0 && this.indexingFunctions) {
+          for (const [sourceName, events] of Object.entries(
+            this.indexingFunctions,
+          )) {
+            if (Object.keys(events).some((e) => e === "setup")) {
+              // Get all chains that have the contract "sourceName"
+              const chains = Object.entries(this.contexts)
+                .filter(
+                  ([, { contracts }]) => contracts[sourceName] !== undefined,
+                )
+                .map(([, { contracts, network }]) => ({
+                  chainId: network.chainId,
+                  networkName: network.name,
+                  startBlock: contracts[sourceName].startBlock,
+                }));
+              for (const { networkName, chainId, startBlock } of chains) {
+                const labels = {
+                  network: networkName,
+                  contract: sourceName,
+                  event: "setup",
+                };
+
+                this.common.metrics.ponder_indexing_matched_events.inc(labels);
+                this.queue.addTask({
+                  kind: "SETUP",
+                  event: {
+                    chainId,
+                    contractName: sourceName,
+                    blockNumber: BigInt(startBlock),
+                    networkName,
+                  },
+                });
+                this.common.metrics.ponder_indexing_handled_events.inc(labels);
+              }
+            }
+          }
         }
 
         const sourcesById: { [sourceId: string]: Source } = {};
@@ -310,7 +342,7 @@ export class IndexingService extends Emittery<IndexingEvents> {
           sourcesById[source.id] = source;
           const registeredSafeEventNames = Object.keys(
             this.indexingFunctions![source.contractName],
-          );
+          ).filter((name) => name !== "setup");
           const registeredSelectors = registeredSafeEventNames.map(
             (safeEventName) => {
               const abiItemMeta = source.events.bySafeName[safeEventName];
@@ -486,26 +518,41 @@ export class IndexingService extends Emittery<IndexingEvents> {
 
       switch (task.kind) {
         case "SETUP": {
-          const setupFunction = indexingFunctions._meta_?.setup;
-          if (!setupFunction) return;
+          const event = task.event;
+
+          const fullEventName = `${event.contractName}:setup`;
+
+          const indexingFunction =
+            indexingFunctions?.[event.contractName]?.["setup"];
+          if (!indexingFunction)
+            throw new Error(
+              `Internal: Indexing function not found for ${fullEventName}`,
+            );
+
+          // This enables contract calls occurring within the
+          // user code to use the start block number by default.
+          this.currentEventBlockNumber = event.blockNumber;
+          // this.currentEventTimestamp = 0; // TODO:KYLE should we have this line?
 
           try {
             this.common.logger.trace({
               service: "indexing",
-              msg: `Started indexing function (event="setup")`,
+              msg: `Started indexing function (event="${fullEventName}", block=${event.blockNumber})`,
             });
 
             // Running user code here!
-            await setupFunction({ context: { db: this.db } });
+            await indexingFunction({
+              context: { db: this.db, ...this.contexts[event.chainId] },
+            });
 
             this.common.logger.trace({
               service: "indexing",
-              msg: `Completed indexing function (event="setup")`,
+              msg: `Completed indexing function (event="${fullEventName}", block=${event.blockNumber})`,
             });
 
             const labels = {
-              network: "_meta_",
-              contract: "_meta_",
+              network: event.networkName,
+              contract: event.contractName,
               event: "setup",
             };
             this.common.metrics.ponder_indexing_processed_events.inc(labels);
@@ -546,7 +593,7 @@ export class IndexingService extends Emittery<IndexingEvents> {
           const fullEventName = `${event.contractName}:${event.eventName}`;
 
           const indexingFunction =
-            this.indexingFunctions?.[event.contractName]?.[event.eventName];
+            indexingFunctions?.[event.contractName]?.[event.eventName];
           if (!indexingFunction)
             throw new Error(
               `Internal: Indexing function not found for ${fullEventName}`,

--- a/packages/core/src/types/ponder.test-d.ts
+++ b/packages/core/src/types/ponder.test-d.ts
@@ -21,7 +21,7 @@ test("PonderApp non intersecting event names", () => {
   type name = Parameters<p["on"]>[0];
   //   ^?
 
-  assertType<name>("" as "One:Event0" | "One:Event1");
+  assertType<name>("" as "One:Event0" | "One:Event1" | "One:setup");
 });
 
 test("PonderApp intersecting event names", () => {
@@ -55,9 +55,14 @@ test("PonderApp multiple contracts", () => {
 
   // Events should only correspond to their contract
   type name = Exclude<
-    //   ^?
+    // ^?
     Parameters<p["on"]>[0],
-    "One:Event0" | "One:Event1" | "Two:Event(bytes32 indexed)" | "Two:Event()"
+    | "One:Event0"
+    | "One:Event1"
+    | "Two:Event(bytes32 indexed)"
+    | "Two:Event()"
+    | "One:setup"
+    | "Two:setup"
   >;
 
   assertType<never>("" as name);
@@ -73,8 +78,11 @@ test("PonderApp event type", () => {
     any
   >;
 
-  type name = Parameters<Parameters<p["on"]>[1]>[0]["event"]["name"];
-  //   ^?
+  type name = Extract<
+    // ^?
+    Parameters<Parameters<p["on"]>[1]>[0],
+    { event: unknown }
+  >["event"]["name"];
 
   assertType<name>("" as "Event0" | "Event1");
 
@@ -155,4 +163,29 @@ test("PonderApp context contracts type", () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (({}) as p).on("One:Event1", ({ context: { contracts } }) => {});
   //                                         ^?
+});
+
+test("PonderApp setup function", () => {
+  type p = PonderApp<
+    // ^?
+    {
+      networks: any;
+      contracts: {
+        One: {
+          network: { mainnet: { address: "0x1" }; optimism: {} };
+          abi: OneAbi;
+          address: "0x2";
+          startBlock: 1;
+          endBlock: 2;
+        };
+      };
+    },
+    any
+  >;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (({}) as p).on("One:setup", (a) => {});
+  //                           ^?
 });

--- a/packages/core/src/types/ponder.ts
+++ b/packages/core/src/types/ponder.ts
@@ -1,3 +1,4 @@
+import type { AbiEvent } from "abitype";
 import type { Abi, GetEventArgs } from "viem";
 
 import type {
@@ -17,90 +18,100 @@ import type { Prettify } from "./utils.js";
 
 /** "{ContractName}:{EventName}". */
 export type Names<TContracts extends Config["contracts"]> = {
-  [key in keyof TContracts]: `${key & string}:${SafeEventNames<
-    FilterAbiEvents<TContracts[key]["abi"]>
-  >[number]}`;
+  [key in keyof TContracts]: `${key & string}:${
+    | SafeEventNames<FilterAbiEvents<TContracts[key]["abi"]>>[number]
+    | "setup"}`;
 }[keyof TContracts];
 
+type ExtractEventName<TName extends string> =
+  TName extends `${string}:${infer EventName extends string}`
+    ? EventName
+    : never;
+
+type ExtractContractName<TName extends string> =
+  TName extends `${infer ContractName extends string}:${string}`
+    ? ContractName
+    : never;
+
 export type PonderApp<TConfig extends Config, TSchema extends Schema> = {
-  on: <TName extends Names<TConfig["contracts"]>>(
+  on: <
+    TName extends Names<TConfig["contracts"]>,
+    TContractName extends
+      ExtractContractName<TName> = ExtractContractName<TName>,
+    TEventName extends ExtractEventName<TName> = ExtractEventName<TName>,
+  >(
     name: TName,
-    indexingFunction: ({
-      event,
-      context,
-    }: {
-      event: {
-        name: TName extends `${string}:${infer EventName}` ? EventName : string;
-        args: GetEventArgs<
-          Abi,
-          string,
-          {
-            EnableUnion: false;
-            IndexedOnly: false;
-            Required: true;
-          },
-          TName extends `${infer ContractName}:${infer EventName}`
-            ? RecoverAbiEvent<
-                TConfig["contracts"][ContractName] extends {
-                  abi: infer _abi extends Abi;
-                }
-                  ? FilterAbiEvents<_abi>
-                  : never,
-                EventName
-              >
-            : never
-        >;
-        log: Log;
-        block: Block;
-        transaction: Transaction;
-      };
-      context: {
-        contracts: {
-          [ContractName in keyof TConfig["contracts"]]: {
-            abi: TConfig["contracts"][ContractName]["abi"];
-            address:
-              | Extract<
-                  TConfig["contracts"][ContractName],
-                  { address: unknown }
-                >["address"]
-              | Extract<
-                  TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
-                  { address: unknown }
-                >["address"];
-            startBlock:
-              | Extract<
-                  TConfig["contracts"][ContractName],
-                  { startBlock: unknown }
-                >["startBlock"]
-              | Extract<
-                  TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
-                  { startBlock: unknown }
-                >["startBlock"];
-            endBlock:
-              | Extract<
-                  TConfig["contracts"][ContractName],
-                  { endBlock: unknown }
-                >["endBlock"]
-              | Extract<
-                  TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
-                  { endBlock: unknown }
-                >["endBlock"];
+    indexingFunction: (
+      args: (TEventName extends "setup"
+        ? {}
+        : {
+            event: {
+              name: TEventName;
+              args: GetEventArgs<
+                Abi,
+                string,
+                {
+                  EnableUnion: false;
+                  IndexedOnly: false;
+                  Required: true;
+                },
+                AbiEvent &
+                  RecoverAbiEvent<
+                    FilterAbiEvents<TConfig["contracts"][TContractName]["abi"]>,
+                    TEventName
+                  >
+              >;
+              log: Log;
+              block: Block;
+              transaction: Transaction;
+            };
+          }) & {
+        context: {
+          contracts: {
+            [ContractName in keyof TConfig["contracts"]]: {
+              abi: TConfig["contracts"][ContractName]["abi"];
+              address:
+                | Extract<
+                    TConfig["contracts"][ContractName],
+                    { address: unknown }
+                  >["address"]
+                | Extract<
+                    TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
+                    { address: unknown }
+                  >["address"];
+              startBlock:
+                | Extract<
+                    TConfig["contracts"][ContractName],
+                    { startBlock: unknown }
+                  >["startBlock"]
+                | Extract<
+                    TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
+                    { startBlock: unknown }
+                  >["startBlock"];
+              endBlock:
+                | Extract<
+                    TConfig["contracts"][ContractName],
+                    { endBlock: unknown }
+                  >["endBlock"]
+                | Extract<
+                    TConfig["contracts"][ContractName]["network"][keyof TConfig["contracts"][ContractName]["network"]],
+                    { endBlock: unknown }
+                  >["endBlock"];
+            };
+          };
+          network: {
+            [key in keyof TConfig["contracts"][TContractName]["network"]]: {
+              name: key;
+              chainId: TConfig["networks"][key &
+                keyof TConfig["networks"]]["chainId"];
+            };
+          }[keyof TConfig["contracts"][TContractName]["network"]];
+          client: Prettify<Omit<ReadOnlyClient, "extend">>;
+          db: {
+            [key in keyof Infer<TSchema>]: DatabaseModel<Infer<TSchema>[key]>;
           };
         };
-        network: TName extends `${infer ContractName}:${string}`
-          ? {
-              [key in keyof TConfig["contracts"][ContractName]["network"]]: {
-                name: key;
-                chainId: TConfig["networks"][key &
-                  keyof TConfig["networks"]]["chainId"];
-              };
-            }[keyof TConfig["contracts"][ContractName]["network"]]
-          : never;
-        client: Prettify<Omit<ReadOnlyClient, "extend">>;
-        db: {
-          [key in keyof Infer<TSchema>]: DatabaseModel<Infer<TSchema>[key]>;
-        };
-      };
-    }) => Promise<void> | void,
+      },
+    ) => Promise<void> | void,
   ) => void;
 };


### PR DESCRIPTION
Refactor the logic for `ContractName:setup` for a indexing function. Now a setup function will run on each chain the contract is on.

A type-level bug relating to the `network: "mainnet"` shortcut in config was also fixed.