### PR TITLE
Reload sync and index state for a specific chain ID when developing

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -433,5 +433,10 @@ export class Ponder {
         this.serverService.setIsHistoricalIndexingComplete();
       }
     });
+
+    // Server listeners.
+    this.serverService.on("admin:reload", async () => {
+      // TODO: Reload only the specified chainIds.
+    });
   }
 }

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -192,6 +192,7 @@ export class Ponder {
 
     // One-time setup for some services.
     await this.syncStore.migrateUp();
+    await this.serverService.start();
 
     // Finally, load the schema + indexing functions which will trigger
     // the indexing service to reload (for the first time).
@@ -208,7 +209,7 @@ export class Ponder {
         databaseKind: this.syncStore.kind,
       },
     });
-    await this.serverService.start({ mode: "development" });
+    this.serverService.registerDevRoutes();
 
     await Promise.all(
       this.syncServices.map(async ({ historical, realtime }) => {
@@ -231,7 +232,6 @@ export class Ponder {
       },
     });
 
-    await this.serverService.start({ mode: "production" });
     // If not using `dev`, can kill the build service here to avoid hot reloads.
     await this.buildService.kill();
 
@@ -292,7 +292,7 @@ export class Ponder {
       indexingStore: this.indexingStore,
     });
 
-    await this.serverService.start({ mode: "production" });
+    await this.serverService.start();
 
     const { schema, graphqlSchema } = schemaResult;
 

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -179,6 +179,7 @@ export class Ponder {
       common: this.common,
       indexingStore: this.indexingStore,
     });
+
     this.codegenService = new CodegenService({ common: this.common });
     this.uiService = new UiService({
       common: this.common,
@@ -191,7 +192,6 @@ export class Ponder {
 
     // One-time setup for some services.
     await this.syncStore.migrateUp();
-    await this.serverService.start();
 
     // Finally, load the schema + indexing functions which will trigger
     // the indexing service to reload (for the first time).
@@ -208,6 +208,7 @@ export class Ponder {
         databaseKind: this.syncStore.kind,
       },
     });
+    await this.serverService.start({ mode: "development" });
 
     await Promise.all(
       this.syncServices.map(async ({ historical, realtime }) => {
@@ -230,6 +231,7 @@ export class Ponder {
       },
     });
 
+    await this.serverService.start({ mode: "production" });
     // If not using `dev`, can kill the build service here to avoid hot reloads.
     await this.buildService.kill();
 
@@ -290,7 +292,7 @@ export class Ponder {
       indexingStore: this.indexingStore,
     });
 
-    await this.serverService.start();
+    await this.serverService.start({ mode: "production" });
 
     const { schema, graphqlSchema } = schemaResult;
 

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -447,7 +447,6 @@ export class Ponder {
         return;
       }
 
-      console.log("Deleting realtime data");
       await this.syncStore.deleteRealtimeData({
         chainId,
         fromBlock: BigInt(0),
@@ -477,7 +476,6 @@ export class Ponder {
           await realtime.kill();
           await historical.kill();
 
-          console.log("Not killing the services");
           const blockNumbers = await realtime.setup();
           await historical.setup(blockNumbers);
 
@@ -485,6 +483,8 @@ export class Ponder {
           historical.start();
         }),
       );
+
+      this.uiService.resetHistoricalState();
 
       // Reload the indexing service with existing schema. We use the exisiting schema as there is
       // alternative resetting behavior for a schema change.

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -468,7 +468,7 @@ export class Ponder {
         );
       });
 
-      this.syncGatewayService.reset({ chainId });
+      this.syncGatewayService.resetCheckpoints({ chainId });
 
       await Promise.all(
         this.syncServices.map(async ({ historical, realtime }) => {

--- a/packages/core/src/server/service.test.ts
+++ b/packages/core/src/server/service.test.ts
@@ -1587,6 +1587,8 @@ test("/admin/reload emits chainIds in reload event", async (context) => {
       hasCompletedHistoricalIndexing: false,
     },
   });
+  service.registerDevRoutes();
+
   const emitSpy = vi.spyOn(service, "emit");
 
   await request(service.app)
@@ -1610,12 +1612,36 @@ test("/admin/reload fails with non-integer chain IDs", async (context) => {
       hasCompletedHistoricalIndexing: false,
     },
   });
+  service.registerDevRoutes();
+
   const emitSpy = vi.spyOn(service, "emit");
 
   await request(service.app)
     .post("/admin/reload")
     .query({ chainId: "badchainid" })
     .expect(400);
+
+  expect(emitSpy).not.toHaveBeenCalled();
+
+  await service.kill();
+});
+
+test("/admin/reload does not exist if dev routes aren't registered", async (context) => {
+  const { common, indexingStore } = context;
+  const { service } = await setup({
+    common,
+    indexingStore,
+    options: {
+      hasCompletedHistoricalIndexing: false,
+    },
+  });
+
+  const emitSpy = vi.spyOn(service, "emit");
+
+  await request(service.app)
+    .post("/admin/reload")
+    .query({ chainId: "badchainid" })
+    .expect(404);
 
   expect(emitSpy).not.toHaveBeenCalled();
 

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -19,8 +19,6 @@ type ServerEvents = {
   "admin:reload": { chainId: number };
 };
 
-type Mode = "development" | "production";
-
 export class ServerService extends Emittery<ServerEvents> {
   private common: Common;
   private indexingStore: IndexingStore;

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -19,6 +19,8 @@ type ServerEvents = {
   "admin:reload": { chainId: number };
 };
 
+type Mode = "development" | "production";
+
 export class ServerService extends Emittery<ServerEvents> {
   private common: Common;
   private indexingStore: IndexingStore;

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -16,7 +16,7 @@ import { graphiQLHtml } from "@/ui/graphiql.html.js";
 import { startClock } from "@/utils/timer.js";
 
 type ServerEvents = {
-  "admin:reload": { chainIds: number[] };
+  "admin:reload": { chainId: number };
 };
 
 export class ServerService extends Emittery<ServerEvents> {

--- a/packages/core/src/sync-gateway/service.test.ts
+++ b/packages/core/src/sync-gateway/service.test.ts
@@ -330,5 +330,6 @@ test("resetCheckpoints resets the checkpoint states", async (context) => {
 
   // Global checkpoints should be reset to 0.
   expect(service.checkpoint).toBe(0);
+  expect(service.finalityCheckpoint).toBe(0);
   expect(service.historicalSyncCompletedAt).toBe(0);
 });

--- a/packages/core/src/sync-gateway/service.ts
+++ b/packages/core/src/sync-gateway/service.ts
@@ -205,6 +205,18 @@ export class SyncGateway extends Emittery<SyncGatewayEvents> {
     this.emit("reorg", { commonAncestorTimestamp });
   };
 
+  // Resets the network checkpoint for the specified chain ID.
+  reset = ({ chainId }: { chainId: number }) => {
+    this.checkpoint = 0;
+    this.finalityCheckpoint = 0;
+    this.networkCheckpoints[chainId] = {
+      isHistoricalSyncComplete: false,
+      historicalCheckpoint: 0,
+      realtimeCheckpoint: 0,
+      finalityCheckpoint: 0,
+    };
+  };
+
   private recalculateCheckpoint = () => {
     const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
       n.isHistoricalSyncComplete

--- a/packages/core/src/sync-gateway/service.ts
+++ b/packages/core/src/sync-gateway/service.ts
@@ -205,8 +205,12 @@ export class SyncGateway extends Emittery<SyncGatewayEvents> {
     this.emit("reorg", { commonAncestorTimestamp });
   };
 
-  // Resets the network checkpoint for the specified chain ID.
-  reset = ({ chainId }: { chainId: number }) => {
+  /** Resets global checkpoints as well as the network checkpoint for the specified chain ID.
+   *  Keeps previous checkpoint values for other networks.
+   *
+   * @param options.chainId Chain ID for which to reset the checkpoint.
+   */
+  resetCheckpoints = ({ chainId }: { chainId: number }) => {
     this.checkpoint = 0;
     this.finalityCheckpoint = 0;
     this.networkCheckpoints[chainId] = {

--- a/packages/core/src/sync-gateway/service.ts
+++ b/packages/core/src/sync-gateway/service.ts
@@ -213,6 +213,7 @@ export class SyncGateway extends Emittery<SyncGatewayEvents> {
   resetCheckpoints = ({ chainId }: { chainId: number }) => {
     this.checkpoint = 0;
     this.finalityCheckpoint = 0;
+    this.historicalSyncCompletedAt = 0;
     this.networkCheckpoints[chainId] = {
       isHistoricalSyncComplete: false,
       historicalCheckpoint: 0,

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -155,7 +155,10 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     latestBlockNumber: number;
     finalizedBlockNumber: number;
   }) {
+    // Initialize state variables. Required when restarting the service.
     this.isKilling = false;
+    this.blockTasksEnqueuedCheckpoint = 0;
+
     this.finalizedBlockNumber = finalizedBlockNumber;
 
     await Promise.all(

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -155,6 +155,7 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
     latestBlockNumber: number;
     finalizedBlockNumber: number;
   }) {
+    this.isKilling = false;
     this.finalizedBlockNumber = finalizedBlockNumber;
 
     await Promise.all(

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -76,6 +76,9 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
   }
 
   setup = async () => {
+    // Initialize state variables. Required when restarting the service.
+    this.blocks = [];
+
     // Fetch the latest block, and remote chain Id for the network.
     const [latestBlock, rpcChainId] = await Promise.all([
       this.getLatestBlock(),

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -186,6 +186,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     this.queue.pause();
     this.queue.clear();
     await this.onIdle();
+    this.blocks = [];
 
     this.common.logger.debug({
       service: "realtime",

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -186,7 +186,6 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     this.queue.pause();
     this.queue.clear();
     await this.onIdle();
-    this.blocks = [];
 
     this.common.logger.debug({
       service: "realtime",

--- a/packages/core/src/ui/service.ts
+++ b/packages/core/src/ui/service.ts
@@ -96,6 +96,10 @@ export class UiService {
     }, 17);
   }
 
+  resetHistoricalState() {
+    this.ui.isHistoricalSyncComplete = false;
+  }
+
   kill() {
     clearInterval(this.renderInterval);
     this.unmount();


### PR DESCRIPTION
### Changes
- Adds an `/admin/reload` route to the server which will reload all the sync and index data for a specific chain ID
- Adds helper reset methods to services
- `app.use()` -> `app.all()` for custom routing behavior for a single path
- Adds more testing

### Steps to test
- Run an example app from `/examples` using `ponder dev`
- After historical sync has completed, reload the state using (replacing the `<CHAIN_ID>` placeholder for your specific chain:
 - `curl -X POST "localhost:42069/admin/reload?chainId=<CHAIN_ID>"` 