### PR TITLE
Fix historical sync logging

### DIFF
--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { cac } from "cac";
 import dotenv from "dotenv";
+import pc from "picocolors";
 
 import { buildOptions } from "@/config/options.js";
 import { Ponder } from "@/Ponder.js";
@@ -122,9 +123,12 @@ function registerKilledProcessListener(fn: () => Promise<unknown>) {
   process.on("SIGTERM", listener); // `kill` command
 }
 
-const validateNodeVersion = () => {
-  if (Number(process.version.split(".")[0].slice(1)) < 18)
-    throw Error(
-      `Node version:${process.version} does not meet the >=18 requirement`,
+function validateNodeVersion() {
+  if (Number(process.version.split(".")[0].slice(1)) < 18) {
+    console.log(
+      `Ponder requires ${pc.cyan("Node >=18")}, detected ${process.version}.`,
     );
-};
+    console.log("");
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
1. Fixed bug where historical sync progress logs continued after the sync is complete
2. Fixed Node version check bug, was previously
<img width="741" alt="Screen Shot 2023-11-21 at 12 28 42 PM" src="https://github.com/0xOlias/ponder/assets/90073088/7e1b7e12-96e3-4c45-a48c-0cb1e14c0a36">
Now looks like
<img width="739" alt="Screen Shot 2023-11-21 at 12 38 17 PM" src="https://github.com/0xOlias/ponder/assets/90073088/2ef7e10b-8d0e-4189-9274-1e5de4e3f384">