### PR TITLE
Wrong API breaks the `create` command for Goerli Base

### DIFF
--- a/packages/create-ponder/src/helpers/getEtherscanChainId.ts
+++ b/packages/create-ponder/src/helpers/getEtherscanChainId.ts
@@ -75,7 +75,7 @@ const networkByEtherscanHostname: Record<
   "goerli.basescan.org": {
     name: "base-goerli",
     chainId: 84531,
-    apiUrl: "https://api.goerli.basescan.org/api",
+    apiUrl: "https://api-goerli.basescan.org/api",
   },
 };
 


### PR DESCRIPTION
Updated to the right one