### PR TITLE
Historical sync retry and queue logic

### DIFF
--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -1,20 +1,32 @@
-import { type Client, createPublicClient, type PublicClient } from "viem";
+import {
+  type Client,
+  createPublicClient,
+  type PublicClient,
+  type Transport,
+} from "viem";
+import { rpc } from "viem/utils";
 
 import type { Config } from "@/config/config.js";
 import type { Common } from "@/Ponder.js";
 import { chains } from "@/utils/chains.js";
 
+type Request = (
+  options: Parameters<typeof rpc.webSocketAsync>[1] &
+    Parameters<typeof rpc.http>[1],
+) => any;
+
 export type Network = {
   name: string;
   chainId: number;
   client: PublicClient;
+  request: Request;
   pollingInterval: number;
   defaultMaxBlockRange: number;
   maxRpcRequestConcurrency: number;
   finalityBlockCount: number;
 };
 
-export function buildNetwork({
+export async function buildNetwork({
   networkName,
   network,
   common,
@@ -38,7 +50,9 @@ export function buildNetwork({
     },
   }) as PublicClient;
 
-  const rpcUrls = getRpcUrlsForClient({ client });
+  const rpcUrls = await getRpcUrlsForClient({ client });
+
+  const request = await getRequestForTransport({ transport });
 
   rpcUrls.forEach((rpcUrl) => {
     if (isRpcUrlPublic(rpcUrl)) {
@@ -53,6 +67,7 @@ export function buildNetwork({
     name: networkName,
     chainId: chainId,
     client,
+    request,
     pollingInterval: network.pollingInterval ?? 1_000,
     defaultMaxBlockRange: getDefaultMaxBlockRange({ chainId, rpcUrls }),
     maxRpcRequestConcurrency: network.maxRpcRequestConcurrency ?? 10,
@@ -161,29 +176,25 @@ function getFinalityBlockCount({ chainId }: { chainId: number }) {
  * @param client A viem Client.
  * @returns Array of RPC URLs.
  */
-export function getRpcUrlsForClient({ client }: { client: Client }) {
-  function getRpcUrlsForTransport(transport: Client["transport"]) {
+export async function getRpcUrlsForClient({ client }: { client: Client }) {
+  async function getRpcUrlsForTransport(transport: Client["transport"]) {
     switch (transport.type) {
       case "http": {
         return [transport.url as string | undefined];
       }
       case "webSocket": {
-        // TODO: Enable this codepath once we can make this function async.
-        // This will happen when we make the config file reloadable during
-        // https://github.com/0xOlias/ponder/issues/322.
-        // try {
-        //   const socket = await transport.getSocket();
-        //   return [socket.url];
-        // } catch (e) {
-        //   const symbol = Object.getOwnPropertySymbols(e).find(
-        //     (symbol) => symbol.toString() === "Symbol(kTarget)"
-        //   );
-        //   if (!symbol) return [];
-        //   const url = (e as any)[symbol]?._url;
-        //   if (!url) return [];
-        //   return [url.replace(/\/$/, "")];
-        // }
-        return [];
+        try {
+          const socket = await transport.getSocket();
+          return [socket.url];
+        } catch (e) {
+          const symbol = Object.getOwnPropertySymbols(e).find(
+            (symbol) => symbol.toString() === "Symbol(kTarget)",
+          );
+          if (!symbol) return [];
+          const url = (e as any)[symbol]?._url;
+          if (!url) return [];
+          return [url.replace(/\/$/, "")];
+        }
       }
       case "fallback": {
         // This is how viem converts a TransportConfig into the Client.transport type.
@@ -194,7 +205,7 @@ export function getRpcUrlsForClient({ client }: { client: Client }) {
 
         const urls: (string | undefined)[] = [];
         for (const fallbackTransport of fallbackTransports) {
-          urls.push(...getRpcUrlsForTransport(fallbackTransport));
+          urls.push(...(await getRpcUrlsForTransport(fallbackTransport)));
         }
 
         return urls;
@@ -208,6 +219,34 @@ export function getRpcUrlsForClient({ client }: { client: Client }) {
   }
 
   return getRpcUrlsForTransport(client.transport);
+}
+
+export async function getRequestForTransport(parameters: {
+  transport: Transport;
+}): Promise<Request> {
+  // This is how viem converts a Transport into the Client.transport type.
+  const { config, value } = parameters.transport({});
+  const transport = { ...config, ...value } as Client["transport"];
+
+  switch (transport.type) {
+    case "http": {
+      return (options) => rpc.http(transport.url, options);
+    }
+    case "webSocket": {
+      const socket = await transport.getSocket();
+      return (options) => rpc.webSocketAsync(socket, options);
+    }
+    case "fallback": {
+      return await getRequestForTransport({
+        transport: transport.transports[0],
+      });
+    }
+    default: {
+      throw Error(
+        `Unknown transport "${transport.type}" used. Please use "http", "websocket", or "fallback"`,
+      );
+    }
+  }
 }
 
 let publicRpcUrls: Set<string> | undefined = undefined;

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -20,6 +20,7 @@ export type Network = {
   chainId: number;
   client: PublicClient;
   request: Request;
+  url: string;
   pollingInterval: number;
   defaultMaxBlockRange: number;
   maxRpcRequestConcurrency: number;
@@ -68,6 +69,7 @@ export async function buildNetwork({
     chainId: chainId,
     client,
     request,
+    url: rpcUrls[0],
     pollingInterval: network.pollingInterval ?? 1_000,
     defaultMaxBlockRange: getDefaultMaxBlockRange({ chainId, rpcUrls }),
     maxRpcRequestConcurrency: network.maxRpcRequestConcurrency ?? 10,

--- a/packages/core/src/sync-gateway/service.test.ts
+++ b/packages/core/src/sync-gateway/service.test.ts
@@ -14,6 +14,8 @@ const mainnet: Network = {
   name: "mainnet",
   chainId: 1,
   client: publicClient,
+  request: () => {},
+  url: "",
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 10,

--- a/packages/core/src/sync-historical/service.test.ts
+++ b/packages/core/src/sync-historical/service.test.ts
@@ -22,6 +22,8 @@ const network: Network = {
   name: "mainnet",
   chainId: 1,
   client: publicClient,
+  request: () => {},
+  url: "",
   pollingInterval: 1_000,
   defaultMaxBlockRange: 100,
   finalityBlockCount: 10,

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -8,6 +8,7 @@ import {
   type RpcBlock,
   type RpcError,
   type RpcLog,
+  RpcRequestError,
   type RpcTransaction,
   toHex,
 } from "viem";
@@ -815,6 +816,16 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       fetchOptions: { signal },
     });
 
+    if (rawRequest.error)
+      throw new RpcRequestError({
+        body: {
+          method: "eth_getBlockByNumber",
+          params: [toHex(blockNumber), true],
+        },
+        error: rawRequest.error,
+        url: this.network.url,
+      });
+
     const block = rawRequest.result as RpcBlock & {
       transactions: RpcTransaction[];
     };
@@ -956,6 +967,16 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
         },
         fetchOptions: { signal },
       });
+
+      if (rawRequest.error)
+        throw new RpcRequestError({
+          body: {
+            method: "eth_getLogs",
+            params: [options],
+          },
+          error: rawRequest.error,
+          url: this.network.url,
+        });
 
       return rawRequest.result;
     } catch (err) {

--- a/packages/core/src/sync-realtime/service.test.ts
+++ b/packages/core/src/sync-realtime/service.test.ts
@@ -24,6 +24,8 @@ const network: Network = {
   name: "mainnet",
   chainId: 1,
   client: publicClient,
+  request: () => {},
+  url: "",
   pollingInterval: 1_000,
   defaultMaxBlockRange: 3,
   finalityBlockCount: 5,


### PR DESCRIPTION
Fix several bugs with sync-historical retry, timeout, and queue logic. Should increase reliability and sync speeds.

The results of the bugs were:
- No timeout on long running tasks
- Not aborting failed tasks
- Opaque retry logic
- Error messages not printed to the terminal
- Process not immediately exiting after kill

The main changes implemented were:
- Use p-queue internal timeout
- Use abort controller to abort long rpc calls
- Use our own retry logic instead of viem
- Historical sync requests are done with helper functions instead of viem client.request
