### PR TITLE
Realtime sync request logic

### DIFF
--- a/packages/core/src/config/networks.test.ts
+++ b/packages/core/src/config/networks.test.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, fallback, http, webSocket } from "viem";
+import { fallback, http, webSocket } from "viem";
 import { mainnet } from "viem/chains";
 import { expect, test, vi } from "vitest";
 
@@ -10,42 +10,37 @@ import {
 } from "./networks.js";
 
 test("getRpcUrlsForClient handles default RPC URL", async () => {
-  const client = createPublicClient({
+  const rpcUrls = await getRpcUrlsForClient({
+    transport: http("http://localhost:8545"),
     chain: mainnet,
-    transport: http(),
   });
 
-  const rpcUrls = await getRpcUrlsForClient({ client });
-
-  expect(rpcUrls).toMatchObject([undefined]);
+  expect(rpcUrls).toMatchObject(["http://localhost:8545"]);
 });
 
 test("getRpcUrlsForClient should handle an http transport", async () => {
-  const client = createPublicClient({
+  const rpcUrls = await getRpcUrlsForClient({
     transport: http("http://localhost:8545"),
+    chain: mainnet,
   });
-
-  const rpcUrls = await getRpcUrlsForClient({ client });
 
   expect(rpcUrls).toMatchObject(["http://localhost:8545"]);
 });
 
 test("getRpcUrlsForClient should handle a websocket transport", async () => {
-  const client = createPublicClient({
+  const rpcUrls = await getRpcUrlsForClient({
     transport: webSocket("wss://localhost:8545"),
+    chain: mainnet,
   });
-
-  const rpcUrls = await getRpcUrlsForClient({ client });
 
   expect(rpcUrls).toMatchObject(["wss://localhost:8545"]);
 });
 
 test("getRpcUrlsForClient should handle a fallback containing an http transport", async () => {
-  const client = createPublicClient({
+  const rpcUrls = await getRpcUrlsForClient({
     transport: fallback([http("http://localhost:8545")]),
+    chain: mainnet,
   });
-
-  const rpcUrls = await getRpcUrlsForClient({ client });
 
   expect(rpcUrls).toMatchObject(["http://localhost:8545"]);
 });

--- a/packages/core/src/sync-gateway/service.test.ts
+++ b/packages/core/src/sync-gateway/service.test.ts
@@ -14,7 +14,6 @@ beforeEach((context) => setupSyncStore(context));
 const mainnet: Network = {
   name: "mainnet",
   chainId: 1,
-  client: publicClient,
   request: (options) =>
     rpc.http(publicClient.chain.rpcUrls.default.http[0], options),
   url: publicClient.chain.rpcUrls.default.http[0],

--- a/packages/core/src/sync-historical/service.test.ts
+++ b/packages/core/src/sync-historical/service.test.ts
@@ -22,7 +22,6 @@ beforeEach((context) => setupSyncStore(context));
 const network: Network = {
   name: "mainnet",
   chainId: 1,
-  client: publicClient,
   request: (options) =>
     rpc.http(publicClient.chain.rpcUrls.default.http[0], options),
   url: publicClient.chain.rpcUrls.default.http[0],
@@ -33,7 +32,7 @@ const network: Network = {
 };
 
 const rpcRequestSpy = vi.spyOn(
-  network.client as { request: EIP1193RequestFn },
+  network as { request: EIP1193RequestFn },
   "request",
 );
 

--- a/packages/core/src/sync-realtime/service.test.ts
+++ b/packages/core/src/sync-realtime/service.test.ts
@@ -24,7 +24,6 @@ beforeEach(resetTestClient);
 const network: Network = {
   name: "mainnet",
   chainId: 1,
-  client: publicClient,
   request: (options) =>
     rpc.http(publicClient.chain.rpcUrls.default.http[0], options),
   url: publicClient.chain.rpcUrls.default.http[0],
@@ -35,7 +34,7 @@ const network: Network = {
 };
 
 const rpcRequestSpy = vi.spyOn(
-  network.client as { request: EIP1193RequestFn },
+  network as { request: EIP1193RequestFn },
   "request",
 );
 

--- a/packages/core/src/sync-realtime/service.ts
+++ b/packages/core/src/sync-realtime/service.ts
@@ -19,6 +19,7 @@ import type { SyncStore } from "@/sync-store/store.js";
 import { poll } from "@/utils/poll.js";
 import { createQueue, type Queue } from "@/utils/queue.js";
 import { range } from "@/utils/range.js";
+import { getErrorMessage, request } from "@/utils/request.js";
 import { startClock } from "@/utils/timer.js";
 
 import { isMatchedLogInBloomFilter } from "./bloom.js";
@@ -81,8 +82,10 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     // Fetch the latest block, and remote chain Id for the network.
     const [latestBlock, rpcChainId] = await Promise.all([
-      this.getLatestBlock(),
-      this.network.client.getChainId(),
+      this.getLatestBlock(undefined),
+      hexToNumber(
+        await request(this.network, { body: { method: "eth_chainId" } }),
+      ),
     ]);
     const latestBlockNumber = hexToNumber(latestBlock.number);
 
@@ -149,9 +152,11 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     // Fetch the block at the finalized block number.
     const stopClock = startClock();
-    const finalizedBlock = await this.network.client.request({
-      method: "eth_getBlockByNumber",
-      params: [numberToHex(this.finalizedBlockNumber), false],
+    const finalizedBlock = await request(this.network, {
+      body: {
+        method: "eth_getBlockByNumber",
+        params: [numberToHex(this.finalizedBlockNumber), false],
+      },
     });
     if (!finalizedBlock) throw new Error(`Unable to fetch finalized block`);
     this.common.metrics.ponder_realtime_rpc_request_duration.observe(
@@ -200,12 +205,15 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     await this.queue.onIdle();
   };
 
-  private getLatestBlock = async () => {
+  private getLatestBlock = async (signal: AbortSignal | undefined) => {
     // Fetch the latest block for the network.
     const stopClock = startClock();
-    const latestBlock_ = await this.network.client.request({
-      method: "eth_getBlockByNumber",
-      params: ["latest", true],
+    const latestBlock_ = await request(this.network, {
+      body: {
+        method: "eth_getBlockByNumber",
+        params: ["latest", true],
+      },
+      fetchOptions: { signal },
     });
     if (!latestBlock_) throw new Error(`Unable to fetch latest block`);
     this.common.metrics.ponder_realtime_rpc_request_duration.observe(
@@ -216,32 +224,33 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
   };
 
   // This method is only public for to support the tests.
-  addNewLatestBlock = async () => {
+  addNewLatestBlock = async (signal: AbortSignal | undefined = undefined) => {
     try {
-      const block = await this.getLatestBlock();
+      const block = await this.getLatestBlock(signal);
       const priority = Number.MAX_SAFE_INTEGER - hexToNumber(block.number);
       this.queue.addTask(block, { priority });
     } catch (error) {
       // Do nothing, log the error. Might consider a retry limit here after which the service should die.
-      this.common.logger.error({
+      const message = getErrorMessage(error as Error);
+      this.common.logger.warn({
         service: "realtime",
-        msg: "Error while fetching latest block",
-        error: error as Error,
+        msg: `Error while fetching latest block (error=${message})`,
       });
     }
   };
 
   private buildQueue = () => {
     const queue = createQueue<RealtimeBlockTask>({
-      worker: async ({ task }: { task: RealtimeBlockTask }) => {
-        await this.blockTaskWorker(task);
+      worker: async ({ task, signal }) => {
+        await this.blockTaskWorker({ block: task, signal });
       },
       options: { concurrency: 1, autoStart: false },
       onError: ({ error, task }) => {
-        this.common.logger.error({
+        const message = getErrorMessage(error);
+
+        this.common.logger.warn({
           service: "realtime",
-          msg: `Realtime sync task failed (network=${this.network.name})`,
-          error,
+          msg: `Realtime sync task failed (network=${this.network.name}, error=${message})`,
           network: this.network.name,
           hash: task.hash,
           parentHash: task.parentHash,
@@ -250,14 +259,20 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         });
 
         // Default to a retry (uses the retry options passed to the queue).
-        // queue.addTask(task, { retry: true });
+        queue.addTask(task, { retry: true });
       },
     });
 
     return queue;
   };
 
-  private blockTaskWorker = async (block: BlockWithTransactions) => {
+  private blockTaskWorker = async ({
+    block,
+    signal,
+  }: {
+    block: BlockWithTransactions;
+    signal: AbortSignal;
+  }) => {
     const previousHeadBlock = this.blocks[this.blocks.length - 1];
 
     // If no block is passed, fetch the latest block.
@@ -304,9 +319,12 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         } else {
           // Block (maybe) contains logs matching the registered log filters.
           const stopClock = startClock();
-          logs = await this.network.client.request({
-            method: "eth_getLogs",
-            params: [{ blockHash: newBlock.hash }],
+          logs = await request(this.network, {
+            body: {
+              method: "eth_getLogs",
+              params: [{ blockHash: newBlock.hash }],
+            },
+            fetchOptions: { signal },
           });
           this.common.metrics.ponder_realtime_rpc_request_duration.observe(
             { method: "eth_getLogs", network: this.network.name },
@@ -322,9 +340,12 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
         // The app has factory contracts.
         // Don't attempt to skip calling eth_getLogs, just call it every time.
         const stopClock = startClock();
-        logs = await this.network.client.request({
-          method: "eth_getLogs",
-          params: [{ blockHash: newBlock.hash }],
+        logs = await request(this.network, {
+          body: {
+            method: "eth_getLogs",
+            params: [{ blockHash: newBlock.hash }],
+          },
+          fetchOptions: { signal },
         });
         this.common.metrics.ponder_realtime_rpc_request_duration.observe(
           { method: "eth_getLogs", network: this.network.name },
@@ -506,9 +527,12 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       const missingBlockRequests = missingBlockNumbers.map((number) => {
         return limit(async () => {
           const stopClock = startClock();
-          const block = await this.network.client.request({
-            method: "eth_getBlockByNumber",
-            params: [numberToHex(number), true],
+          const block = await request(this.network, {
+            body: {
+              method: "eth_getBlockByNumber",
+              params: [numberToHex(number), true],
+            },
+            fetchOptions: { signal },
           });
           if (!block) {
             throw new Error(`Failed to fetch block number: ${number}`);
@@ -597,7 +621,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
         // Also add a new latest block, so we don't have to wait for the next poll to
         // start fetching any newer blocks on the canonical chain.
-        await this.addNewLatestBlock();
+        await this.addNewLatestBlock(signal);
         this.emit("shallowReorg", {
           commonAncestorBlockTimestamp: commonAncestorBlock.timestamp,
         });
@@ -612,9 +636,12 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
       // If the parent block is not present in our local chain, keep traversing up the canonical chain.
       const stopClock = startClock();
-      const parentBlock_ = await this.network.client.request({
-        method: "eth_getBlockByHash",
-        params: [canonicalBlock.parentHash, true],
+      const parentBlock_ = await request(this.network, {
+        body: {
+          method: "eth_getBlockByHash",
+          params: [canonicalBlock.parentHash, true],
+        },
+        fetchOptions: { signal },
       });
       this.common.metrics.ponder_realtime_rpc_request_duration.observe(
         {

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -138,7 +138,7 @@ export function createQueue<TTask, TContext = undefined, TReturn = void>({
       );
     } catch (error_) {
       taskController.abort();
-      if (!(error_ instanceof AbortError)) {
+      if (!(error_ instanceof AbortError) && !queueSignal.aborted) {
         await onError?.({ error: error_ as Error, task, context, queue });
       }
     }

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,0 +1,26 @@
+import { RpcRequestError } from "viem";
+
+import type { Network } from "@/config/networks.js";
+
+import { TASK_TIMEOUT } from "./queue.js";
+
+export const getErrorMessage = (error: Error) =>
+  error.name === "TimeoutError"
+    ? `Timed out after ${TASK_TIMEOUT} ms`
+    : `${error.name}: ${error.message}`;
+
+export const request = async (
+  network: Pick<Network, "url" | "request">,
+  options: Parameters<Network["request"]>[0],
+): Promise<any> => {
+  const rawRequest = await network.request(options);
+
+  if (rawRequest.error)
+    throw new RpcRequestError({
+      body: options.body,
+      error: rawRequest.error,
+      url: network.url,
+    });
+
+  return rawRequest.result;
+};


### PR DESCRIPTION
Same changes that were recently applied to the historical sync service. Recap:

- don't use viem retry logic
- use custom request function instead of client.request
- pass abort signals to interrupt failed requests
