### PR TITLE
Update client.readContract

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -174,7 +174,7 @@ export class Ponder {
       indexingStore: this.indexingStore,
       syncGatewayService: this.syncGatewayService,
       sources: this.sources,
-      networks: config.networks,
+      networks: networksToSync,
     });
 
     this.serverService = new ServerService({

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -146,7 +146,7 @@ test("processEvents() calls getEvents with sequential timestamp ranges", async (
   await service.kill();
 });
 
-test.only("processEvents() calls indexing functions with correct arguments", async (context) => {
+test("processEvents() calls indexing functions with correct arguments", async (context) => {
   const { common, syncStore, indexingStore } = context;
 
   const service = new IndexingService({

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -1,9 +1,12 @@
-import { checksumAddress, getEventSelector, http } from "viem";
+import { checksumAddress, getEventSelector } from "viem";
+import { rpc } from "viem/utils";
 import { beforeEach, expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants.js";
 import { setupIndexingStore, setupSyncStore } from "@/_test/setup.js";
+import { anvil } from "@/_test/utils.js";
 import type { IndexingFunctions } from "@/build/functions.js";
+import type { Network } from "@/config/networks.js";
 import type { Source } from "@/config/sources.js";
 import { createSchema } from "@/schema/schema.js";
 import type { SyncGateway } from "@/sync-gateway/service.js";
@@ -13,12 +16,14 @@ import { IndexingService } from "./service.js";
 beforeEach((context) => setupIndexingStore(context));
 beforeEach((context) => setupSyncStore(context));
 
-const networks = {
-  mainnet: {
+const networks: Pick<Network, "url" | "request" | "chainId" | "name">[] = [
+  {
+    request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+    url: anvil.rpcUrls.default.http[0],
     chainId: 1,
-    transport: http(),
+    name: "mainnet",
   },
-};
+];
 
 const sources: Source[] = [
   {
@@ -141,7 +146,7 @@ test("processEvents() calls getEvents with sequential timestamp ranges", async (
   await service.kill();
 });
 
-test("processEvents() calls indexing functions with correct arguments", async (context) => {
+test.only("processEvents() calls indexing functions with correct arguments", async (context) => {
   const { common, syncStore, indexingStore } = context;
 
   const service = new IndexingService({

--- a/packages/core/src/indexing/service.test.ts
+++ b/packages/core/src/indexing/service.test.ts
@@ -59,22 +59,18 @@ const transferIndexingFunction = vi.fn(async ({ event, context }) => {
 
 const readContractTransferIndexingFunction = vi.fn(
   async ({ event, context }) => {
-    try {
-      const totalSupply = await context.client.readContract({
-        abi: usdcContractConfig.abi,
-        functionName: "totalSupply",
-        address: usdcContractConfig.address,
-      });
+    const totalSupply = await context.client.readContract({
+      abi: usdcContractConfig.abi,
+      functionName: "totalSupply",
+      address: usdcContractConfig.address,
+    });
 
-      await context.db.Supply.create({
-        id: event.log.id,
-        data: {
-          supply: totalSupply,
-        },
-      });
-    } catch (err) {
-      console.log(err);
-    }
+    await context.db.Supply.create({
+      id: event.log.id,
+      data: {
+        supply: totalSupply,
+      },
+    });
   },
 );
 

--- a/packages/core/src/indexing/service.ts
+++ b/packages/core/src/indexing/service.ts
@@ -4,7 +4,7 @@ import type { Abi, Address, Client, Hex } from "viem";
 import { createClient, decodeEventLog } from "viem";
 
 import type { IndexingFunctions } from "@/build/functions.js";
-import type { Config } from "@/config/config.js";
+import type { Network } from "@/config/networks.js";
 import type { Source } from "@/config/sources.js";
 import { UserError } from "@/errors/user.js";
 import type { IndexingStore } from "@/indexing-store/store.js";
@@ -103,7 +103,7 @@ export class IndexingService extends Emittery<IndexingEvents> {
     syncStore: SyncStore;
     indexingStore: IndexingStore;
     syncGatewayService: SyncGateway;
-    networks: Config["networks"];
+    networks: Pick<Network, "url" | "request" | "chainId" | "name">[];
     sources: Source[];
   }) {
     super();
@@ -686,7 +686,7 @@ export class IndexingService extends Emittery<IndexingEvents> {
 
 const buildContexts = (
   sources: Source[],
-  networks: Config["networks"],
+  networks: Pick<Network, "url" | "request" | "chainId" | "name">[],
   syncStore: SyncStore,
   actions: ReturnType<typeof ponderActions>,
 ) => {
@@ -708,18 +708,18 @@ const buildContexts = (
     }
   > = {};
 
-  Object.entries(networks).forEach(([networkName, network]) => {
+  networks.forEach((network) => {
     const defaultChain =
       Object.values(chains).find((c) => c.id === network.chainId) ??
       chains.mainnet;
 
     const client = createClient({
-      transport: ponderTransport({ transport: network.transport, syncStore }),
-      chain: { ...defaultChain, name: networkName, id: network.chainId },
+      transport: ponderTransport({ network, syncStore }),
+      chain: { ...defaultChain, name: network.name, id: network.chainId },
     });
 
     contexts[network.chainId] = {
-      network: { name: networkName, chainId: network.chainId },
+      network: { name: network.name, chainId: network.chainId },
       // Changing the arguments of readContract is not usually allowed,
       // because we have such a limited api we should be good
       client: client.extend(actions as any) as ReadOnlyClient,

--- a/packages/core/src/indexing/transport.test.ts
+++ b/packages/core/src/indexing/transport.test.ts
@@ -1,5 +1,6 @@
 import type { Transport } from "viem";
-import { getFunctionSelector, http, toHex } from "viem";
+import { getFunctionSelector, toHex } from "viem";
+import { rpc } from "viem/utils";
 import { assertType, beforeEach, expect, test, vi } from "vitest";
 
 import { usdcContractConfig } from "@/_test/constants.js";
@@ -12,7 +13,10 @@ beforeEach((context) => setupSyncStore(context));
 
 test("default", ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http("https://mockapi.com/rpc"),
+    network: {
+      request: (options) => rpc.http("https://mockapi.com/rpc", options),
+      url: "https://mockapi.com/rpc",
+    },
     syncStore,
   });
 
@@ -37,7 +41,10 @@ test("default", ({ syncStore }) => {
 
 test("eth_call", async ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http(),
+    network: {
+      request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+      url: anvil.rpcUrls.default.http[0],
+    },
     syncStore,
   })({
     chain: anvil,
@@ -76,7 +83,10 @@ test("eth_call", async ({ syncStore }) => {
 
 test("eth_getBalance", async ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http(),
+    network: {
+      request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+      url: anvil.rpcUrls.default.http[0],
+    },
     syncStore,
   })({
     chain: anvil,
@@ -103,7 +113,10 @@ test("eth_getBalance", async ({ syncStore }) => {
 
 test("eth_getStorageAt", async ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http(),
+    network: {
+      request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+      url: anvil.rpcUrls.default.http[0],
+    },
     syncStore,
   })({
     chain: anvil,
@@ -130,7 +143,10 @@ test("eth_getStorageAt", async ({ syncStore }) => {
 
 test("eth_getCode", async ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http(),
+    network: {
+      request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+      url: anvil.rpcUrls.default.http[0],
+    },
     syncStore,
   })({
     chain: anvil,
@@ -157,7 +173,10 @@ test("eth_getCode", async ({ syncStore }) => {
 
 test("fallback method", async ({ syncStore }) => {
   const transport = ponderTransport({
-    transport: http(),
+    network: {
+      request: (options) => rpc.http(anvil.rpcUrls.default.http[0], options),
+      url: anvil.rpcUrls.default.http[0],
+    },
     syncStore,
   })({
     chain: anvil,


### PR DESCRIPTION
- use request helper function instead of viem client.request()
- retry logic

Note: this is lacking abort logic in readContract. Not sure how this would look without big, annoying changes