### PR TITLE
Fix zero downtime deployments

### DIFF
--- a/examples/project-uniswap-v3-flash/package.json
+++ b/examples/project-uniswap-v3-flash/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "ponder dev",
     "start": "ponder start",
+    "serve": "ponder serve",
     "codegen": "ponder codegen",
     "lint": "eslint .",
     "typecheck": "tsc"

--- a/examples/project-uniswap-v3-flash/ponder.config.ts
+++ b/examples/project-uniswap-v3-flash/ponder.config.ts
@@ -20,7 +20,7 @@ export default createConfig({
         event: getAbiItem({ abi: UniswapV3FactoryAbi, name: "PoolCreated" }),
         parameter: "pool",
       },
-      startBlock: 12369621,
+      startBlock: 18740465,
       filter: {
         event: "Flash",
       },

--- a/examples/project-uniswap-v3-flash/ponder.config.ts
+++ b/examples/project-uniswap-v3-flash/ponder.config.ts
@@ -20,7 +20,7 @@ export default createConfig({
         event: getAbiItem({ abi: UniswapV3FactoryAbi, name: "PoolCreated" }),
         parameter: "pool",
       },
-      startBlock: 18740465,
+      startBlock: 18700465,
       filter: {
         event: "Flash",
       },

--- a/examples/project-uniswap-v3-flash/ponder.config.ts
+++ b/examples/project-uniswap-v3-flash/ponder.config.ts
@@ -20,7 +20,7 @@ export default createConfig({
         event: getAbiItem({ abi: UniswapV3FactoryAbi, name: "PoolCreated" }),
         parameter: "pool",
       },
-      startBlock: 18700465,
+      startBlock: 18500465,
       filter: {
         event: "Flash",
       },

--- a/examples/project-uniswap-v3-flash/ponder.config.ts
+++ b/examples/project-uniswap-v3-flash/ponder.config.ts
@@ -20,7 +20,7 @@ export default createConfig({
         event: getAbiItem({ abi: UniswapV3FactoryAbi, name: "PoolCreated" }),
         parameter: "pool",
       },
-      startBlock: 18500465,
+      startBlock: 12369621,
       filter: {
         event: "Flash",
       },

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -297,6 +297,7 @@ export class Ponder {
         : new PostgresIndexingStore({
             common: this.common,
             pool: database.indexing.pool,
+            isReadOnly: true,
           });
 
     this.serverService = new ServerService({

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -340,7 +340,6 @@ export class Ponder {
     await Promise.all([
       await this.indexingService.kill(),
       await this.buildService.kill(),
-      await this.serverService.kill(),
       await this.common.telemetry.kill(),
     ]);
 
@@ -354,6 +353,8 @@ export class Ponder {
     await this.indexingStore.kill();
     await this.syncStore.kill();
 
+    // TODO: Test if this causes the service to early shutdown.
+    await this.serverService.kill();
     this.common.logger.debug({
       service: "app",
       msg: `Finished shutdown sequence`,

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -340,6 +340,7 @@ export class Ponder {
     await Promise.all([
       await this.indexingService.kill(),
       await this.buildService.kill(),
+      await this.serverService.kill(),
       await this.common.telemetry.kill(),
     ]);
 
@@ -353,8 +354,6 @@ export class Ponder {
     await this.indexingStore.kill();
     await this.syncStore.kill();
 
-    // TODO: Test if this causes the service to early shutdown.
-    await this.serverService.kill();
     this.common.logger.debug({
       service: "app",
       msg: `Finished shutdown sequence`,

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -107,11 +107,9 @@ export async function setupSyncStore(
 export async function setupIndexingStore(context: TestContext) {
   if (process.env.DATABASE_URL) {
     const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
-    const databaseSchema = `vitest_pool_${process.pid}_${poolId}`;
     context.indexingStore = new PostgresIndexingStore({
       common: context.common,
       pool,
-      databaseSchema,
     });
   } else {
     context.indexingStore = new SqliteIndexingStore({

--- a/packages/core/src/indexing-store/postgres/store.ts
+++ b/packages/core/src/indexing-store/postgres/store.ts
@@ -103,8 +103,8 @@ export class PostgresIndexingStore implements IndexingStore {
       }),
     });
     if (isReadOnly) {
-      // This is a hack to stop readonly connections from connecting to a schema using the Kysely plugin.
-      //
+      // This is a hack to stop readonly connections from connecting to a namespace using the Kysely plugin as readonly
+      // connections set their namespace using the search_path setter in the onCreateConnection hook.
       return;
     }
 

--- a/packages/core/src/indexing-store/postgres/store.ts
+++ b/packages/core/src/indexing-store/postgres/store.ts
@@ -27,8 +27,6 @@ import {
 
 const MAX_BATCH_SIZE = 1_000 as const;
 
-const NAMESPACE_QUERY = `SELECT nspname FROM pg_namespace WHERE nspname LIKE 'ponder_index_%' ORDER BY nspname`;
-
 const scalarToSqlType = {
   boolean: "integer",
   int: "integer",
@@ -71,8 +69,10 @@ export class PostgresIndexingStore implements IndexingStore {
 
           if (isReadOnly) {
             const result = await connection.executeQuery(
-              // Finds the latest namespace by sorting the list of namespaces in descending order and taking the first one.
-              CompiledQuery.raw(NAMESPACE_QUERY + ` DESC LIMIT 1`),
+              // Finds the latest namespace which should have been created by the indexer writer.
+              CompiledQuery.raw(
+                `SELECT nspname FROM pg_namespace WHERE nspname LIKE 'ponder_index_%' ORDER BY nspname DESC LIMIT 1`,
+              ),
             );
             if (result.rows.length === 0) {
               throw new Error("No namespace found");


### PR DESCRIPTION
**Changes**
- Uses schema versions to separate new instances of the indexer
- Readonly behavior on the index store for web server responses

**Tests**
- Tested on railway with uniswap example