### PR TITLE
Bytes and Address case sensivity

### DIFF
--- a/benchmarks/apps/ponder-univ2/ponder.config.ts
+++ b/benchmarks/apps/ponder-univ2/ponder.config.ts
@@ -1,5 +1,5 @@
 import { createConfig } from "@ponder/core";
-import { getAbiItem, getAddress, http } from "viem";
+import { getAbiItem, http } from "viem";
 
 import { FactoryAbi } from "./abis/FactoryAbi";
 import { PairAbi } from "./abis/PairAbi";
@@ -15,18 +15,20 @@ export default createConfig({
     Factory: {
       network: "mainnet",
       abi: FactoryAbi,
-      address: getAddress("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
+      address: "0x5C69bee701ef814a2B6a3edd4b1652CB9cc5aA6f",
       startBlock: 18700000,
+      endBlock: 18700500,
     },
     Pair: {
       network: "mainnet",
       abi: PairAbi,
       factory: {
-        address: getAddress("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
+        address: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
         event: getAbiItem({ abi: FactoryAbi, name: "PairCreated" }),
         parameter: "pair",
       },
       startBlock: 18700000,
+      endBlock: 18700500,
     },
   },
 });

--- a/benchmarks/apps/ponder-univ2/src/index.ts
+++ b/benchmarks/apps/ponder-univ2/src/index.ts
@@ -1,5 +1,3 @@
-import { getAddress } from "viem";
-
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { ponder } from "@/generated";
@@ -13,7 +11,7 @@ ponder.on("Factory:PairCreated", async ({ event, context }) => {
   const { UniswapFactory, Pair } = context.db;
 
   await UniswapFactory.upsert({
-    id: getAddress(context.contracts.Factory.address),
+    id: context.contracts.Factory.address,
     create: {
       pairCount: 0,
       txCount: 0,
@@ -25,7 +23,7 @@ ponder.on("Factory:PairCreated", async ({ event, context }) => {
   });
 
   await Pair.create({
-    id: getAddress(event.args.pair),
+    id: event.args.pair,
     data: {
       token0: event.args.token0,
       token1: event.args.token1,
@@ -41,21 +39,21 @@ ponder.on("Factory:PairCreated", async ({ event, context }) => {
 
 ponder.on("Pair:Sync", async ({ event, context }) => {
   await context.db.Pair.update({
-    id: getAddress(event.log.address),
+    id: event.log.address,
     data: { reserve0: event.args.reserve0, reserve1: event.args.reserve1 },
   });
 });
 
 ponder.on("Pair:Mint", async ({ event, context }) => {
   await context.db.UniswapFactory.update({
-    id: getAddress(context.contracts.Factory.address),
+    id: context.contracts.Factory.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
   });
 
   await context.db.Pair.update({
-    id: getAddress(event.log.address),
+    id: event.log.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
@@ -64,7 +62,7 @@ ponder.on("Pair:Mint", async ({ event, context }) => {
   await context.db.Mint.create({
     id: event.log.id,
     data: {
-      pair: getAddress(event.log.address),
+      pair: event.log.address,
       timestamp: event.block.timestamp,
       sender: event.args.sender,
       amount0: event.args.amount0,
@@ -76,14 +74,14 @@ ponder.on("Pair:Mint", async ({ event, context }) => {
 
 ponder.on("Pair:Burn", async ({ event, context }) => {
   await context.db.UniswapFactory.update({
-    id: getAddress(context.contracts.Factory.address),
+    id: context.contracts.Factory.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
   });
 
   await context.db.Pair.update({
-    id: getAddress(event.log.address),
+    id: event.log.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
@@ -92,7 +90,7 @@ ponder.on("Pair:Burn", async ({ event, context }) => {
   await context.db.Burn.create({
     id: event.log.id,
     data: {
-      pair: getAddress(event.log.address),
+      pair: event.log.address,
       timestamp: event.block.timestamp,
       sender: event.args.sender,
       to: event.args.sender,
@@ -105,14 +103,14 @@ ponder.on("Pair:Burn", async ({ event, context }) => {
 
 ponder.on("Pair:Swap", async ({ event, context }) => {
   await context.db.UniswapFactory.update({
-    id: getAddress(context.contracts.Factory.address),
+    id: context.contracts.Factory.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
   });
 
   await context.db.Pair.update({
-    id: getAddress(event.log.address),
+    id: event.log.address,
     data: ({ current }) => ({
       txCount: current.txCount + 1,
     }),
@@ -121,7 +119,7 @@ ponder.on("Pair:Swap", async ({ event, context }) => {
   await context.db.Swap.create({
     id: event.log.id,
     data: {
-      pair: getAddress(event.log.address),
+      pair: event.log.address,
       timestamp: event.block.timestamp,
       sender: event.args.sender,
       from: event.transaction.from,

--- a/examples/feature-factory/ponder.schema.ts
+++ b/examples/feature-factory/ponder.schema.ts
@@ -2,6 +2,6 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   LlamaCoreInstance: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
   }),
 }));

--- a/examples/feature-factory/ponder.schema.ts
+++ b/examples/feature-factory/ponder.schema.ts
@@ -2,6 +2,6 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   LlamaCoreInstance: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
   }),
 }));

--- a/examples/feature-filter/ponder.schema.ts
+++ b/examples/feature-filter/ponder.schema.ts
@@ -2,8 +2,8 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   SwapEvent: p.createTable({
-    id: p.string(),
-    recipient: p.string(),
-    payer: p.string(),
+    id: p.bytes(),
+    recipient: p.bytes(),
+    payer: p.bytes(),
   }),
 }));

--- a/examples/feature-filter/ponder.schema.ts
+++ b/examples/feature-filter/ponder.schema.ts
@@ -2,7 +2,7 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   SwapEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     recipient: p.bytes(),
     payer: p.bytes(),
   }),

--- a/examples/feature-multichain/ponder.schema.ts
+++ b/examples/feature-multichain/ponder.schema.ts
@@ -2,7 +2,7 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   Account: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     balance: p.bigint(),
   }),
 }));

--- a/examples/feature-proxy/ponder.schema.ts
+++ b/examples/feature-proxy/ponder.schema.ts
@@ -2,11 +2,11 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   LiquidationEvent: p.createTable({
-    id: p.string(),
-    liquidator: p.string(),
+    id: p.bytes(),
+    liquidator: p.bytes(),
   }),
   OwnershipTransferredEvent: p.createTable({
-    id: p.string(),
-    newOwner: p.string(),
+    id: p.bytes(),
+    newOwner: p.bytes(),
   }),
 }));

--- a/examples/feature-proxy/ponder.schema.ts
+++ b/examples/feature-proxy/ponder.schema.ts
@@ -2,11 +2,11 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   LiquidationEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     liquidator: p.bytes(),
   }),
   OwnershipTransferredEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     newOwner: p.bytes(),
   }),
 }));

--- a/examples/project-friendtech/ponder.schema.ts
+++ b/examples/project-friendtech/ponder.schema.ts
@@ -3,7 +3,7 @@ import { createSchema } from "@ponder/core";
 export default createSchema((p) => ({
   TradeType: p.createEnum(["BUY", "SELL"]),
   Share: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
 
     subjectId: p.bytes().references("Subject.id"),
     traderId: p.bytes().references("Trader.id"),
@@ -14,7 +14,7 @@ export default createSchema((p) => ({
     shareAmount: p.bigint(),
   }),
   TradeEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
 
     subjectId: p.bytes().references("Subject.id"),
     traderId: p.bytes().references("Trader.id"),

--- a/examples/project-friendtech/src/FriendtechSharesV1.ts
+++ b/examples/project-friendtech/src/FriendtechSharesV1.ts
@@ -21,7 +21,7 @@ ponder.on("FriendtechSharesV1:Trade", async ({ event, context }) => {
     : event.args.ethAmount - feeAmount;
 
   const tradeEvent = await TradeEvent.create({
-    id: tradeEventId as `0x${string}`,
+    id: tradeEventId,
     data: {
       subjectId: subjectId,
       traderId: traderId,
@@ -99,7 +99,7 @@ ponder.on("FriendtechSharesV1:Trade", async ({ event, context }) => {
 
   if (tradeEvent.tradeType === "BUY") {
     await Share.upsert({
-      id: shareId as `0x${string}`,
+      id: shareId,
       create: {
         subjectId,
         traderId,
@@ -111,7 +111,7 @@ ponder.on("FriendtechSharesV1:Trade", async ({ event, context }) => {
     });
   } else {
     const share = await Share.update({
-      id: shareId as `0x${string}`,
+      id: shareId,
       data: ({ current }) => ({
         shareAmount: current.shareAmount - tradeEvent.shareAmount,
       }),
@@ -119,7 +119,7 @@ ponder.on("FriendtechSharesV1:Trade", async ({ event, context }) => {
 
     if (share.shareAmount === 0n) {
       await Share.delete({
-        id: shareId as `0x${string}`,
+        id: shareId,
       });
     }
   }

--- a/examples/project-uniswap-v3-flash/ponder.schema.ts
+++ b/examples/project-uniswap-v3-flash/ponder.schema.ts
@@ -2,16 +2,16 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   PoolTokens: p.createTable({
-    id: p.string(),
-    token0: p.string(),
-    token1: p.string(),
+    id: p.bytes(),
+    token0: p.bytes(),
+    token1: p.bytes(),
   }),
   TokenPaid: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     amount: p.bigint(),
   }),
   TokenBorrowed: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     amount: p.bigint(),
   }),
 }));

--- a/examples/reference-erc20/ponder.schema.ts
+++ b/examples/reference-erc20/ponder.schema.ts
@@ -23,7 +23,7 @@ export default createSchema((p) => ({
     spender: p.one("spenderId"),
   }),
   TransferEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     amount: p.bigint(),
     timestamp: p.int(),
 
@@ -34,7 +34,7 @@ export default createSchema((p) => ({
     to: p.one("toId"),
   }),
   ApprovalEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     amount: p.bigint(),
     timestamp: p.int(),
 

--- a/examples/reference-erc20/ponder.schema.ts
+++ b/examples/reference-erc20/ponder.schema.ts
@@ -2,7 +2,7 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   Account: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     balance: p.bigint(),
     isOwner: p.boolean(),
 
@@ -16,25 +16,25 @@ export default createSchema((p) => ({
     id: p.bytes(),
     amount: p.bigint(),
 
-    ownerId: p.string().references("Account.id"),
-    spenderId: p.string().references("Account.id"),
+    ownerId: p.bytes().references("Account.id"),
+    spenderId: p.bytes().references("Account.id"),
 
     owner: p.one("ownerId"),
     spender: p.one("spenderId"),
   }),
   TransferEvent: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     amount: p.bigint(),
     timestamp: p.int(),
 
-    fromId: p.string().references("Account.id"),
-    toId: p.string().references("Account.id"),
+    fromId: p.bytes().references("Account.id"),
+    toId: p.bytes().references("Account.id"),
 
     from: p.one("fromId"),
     to: p.one("toId"),
   }),
   ApprovalEvent: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     amount: p.bigint(),
     timestamp: p.int(),
 

--- a/examples/reference-erc721/ponder.schema.ts
+++ b/examples/reference-erc721/ponder.schema.ts
@@ -16,7 +16,7 @@ export default createSchema((p) => ({
     transferEvents: p.many("TransferEvent.tokenId"),
   }),
   TransferEvent: p.createTable({
-    id: p.bytes(),
+    id: p.string(),
     timestamp: p.int(),
     fromId: p.bytes().references("Account.id"),
     toId: p.bytes().references("Account.id"),

--- a/examples/reference-erc721/ponder.schema.ts
+++ b/examples/reference-erc721/ponder.schema.ts
@@ -2,7 +2,7 @@ import { createSchema } from "@ponder/core";
 
 export default createSchema((p) => ({
   Account: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     tokens: p.many("Token.ownerId"),
 
     transferFromEvents: p.many("TransferEvent.fromId"),
@@ -10,16 +10,16 @@ export default createSchema((p) => ({
   }),
   Token: p.createTable({
     id: p.bigint(),
-    ownerId: p.string().references("Account.id"),
+    ownerId: p.bytes().references("Account.id"),
 
     owner: p.one("ownerId"),
     transferEvents: p.many("TransferEvent.tokenId"),
   }),
   TransferEvent: p.createTable({
-    id: p.string(),
+    id: p.bytes(),
     timestamp: p.int(),
-    fromId: p.string().references("Account.id"),
-    toId: p.string().references("Account.id"),
+    fromId: p.bytes().references("Account.id"),
+    toId: p.bytes().references("Account.id"),
     tokenId: p.bigint().references("Token.id"),
 
     from: p.one("fromId"),

--- a/packages/core/src/_test/constants.ts
+++ b/packages/core/src/_test/constants.ts
@@ -997,7 +997,7 @@ export const blockOneTransactions: RpcTransaction[] = [
 
 export const blockOneLogs: RpcLog[] = [
   {
-    address: "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+    address: "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xec6fc6",
@@ -1014,7 +1014,7 @@ export const blockOneLogs: RpcLog[] = [
     transactionIndex: "0x45",
   },
   {
-    address: "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
+    address: "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xec6fc6",

--- a/packages/core/src/_test/constants.ts
+++ b/packages/core/src/_test/constants.ts
@@ -1,4 +1,5 @@
 import {
+  checksumAddress,
   parseAbiItem,
   type RpcBlock,
   type RpcLog,
@@ -247,7 +248,7 @@ const usdcContractAbi = [
 
 export const usdcContractConfig = {
   chainId: 1,
-  address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  address: checksumAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
   abi: usdcContractAbi,
   events: getEvents({ abi: usdcContractAbi }),
 } as const;
@@ -996,7 +997,7 @@ export const blockOneTransactions: RpcTransaction[] = [
 
 export const blockOneLogs: RpcLog[] = [
   {
-    address: "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    address: "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xec6fc6",
@@ -1013,7 +1014,7 @@ export const blockOneLogs: RpcLog[] = [
     transactionIndex: "0x45",
   },
   {
-    address: "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    address: "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xec6fc6",

--- a/packages/core/src/config/factories.test.ts
+++ b/packages/core/src/config/factories.test.ts
@@ -1,5 +1,5 @@
 import type { RpcLog } from "viem";
-import { getEventSelector, parseAbiItem } from "viem";
+import { checksumAddress, getEventSelector, parseAbiItem } from "viem";
 import { expect, test } from "vitest";
 
 import {
@@ -139,7 +139,9 @@ test("getAddressFromFactoryEventLog gets address from indexed parameter 1", () =
     log: llamaInstanceCreatedLog,
   });
 
-  expect(address).toBe("0x0aae40c12678f810634ae552f420a46d0d951c30");
+  expect(address).toBe(
+    checksumAddress("0x0aae40c12678f810634ae552f420a46d0d951c30"),
+  );
 });
 
 test("getAddressFromFactoryEventLog gets address from nonindexed parameter 1", () => {
@@ -154,7 +156,9 @@ test("getAddressFromFactoryEventLog gets address from nonindexed parameter 1", (
     log: llamaInstanceCreatedLog,
   });
 
-  expect(address).toBe("0x713fb111d31c494cefd6d12f3208a0cb20e6cbfa");
+  expect(address).toBe(
+    checksumAddress("0x713fb111d31c494cefd6d12f3208a0cb20e6cbfa"),
+  );
 });
 
 test("getAddressFromFactoryEventLog gets address from nonindexed parameter 3", () => {
@@ -169,5 +173,7 @@ test("getAddressFromFactoryEventLog gets address from nonindexed parameter 3", (
     log: llamaInstanceCreatedLog,
   });
 
-  expect(address).toBe("0x5a6480483462533564634b8c81aea01cf87c6ddb");
+  expect(address).toBe(
+    checksumAddress("0x5a6480483462533564634b8c81aea01cf87c6ddb"),
+  );
 });

--- a/packages/core/src/config/factories.ts
+++ b/packages/core/src/config/factories.ts
@@ -1,8 +1,7 @@
 import type { AbiEvent } from "abitype";
 import type { RpcLog } from "viem";
-import { getEventSelector } from "viem";
+import { checksumAddress, getEventSelector } from "viem";
 
-import { toLowerCase } from "@/utils/lowercase.js";
 import { getBytesConsumedByParam } from "@/utils/offset.js";
 
 import type { FactoryCriteria } from "./sources.js";
@@ -16,7 +15,7 @@ export function buildFactoryCriteria({
   event: AbiEvent;
   parameter: string;
 }) {
-  const address = toLowerCase(_address);
+  const address = checksumAddress(_address);
   const eventSelector = getEventSelector(event);
 
   // Check if the provided parameter is present in the list of indexed inputs.
@@ -80,7 +79,7 @@ export function getAddressFromFactoryEventLog({
     const start = 2 + 12 * 2;
     const end = start + 20 * 2;
 
-    return ("0x" + topic.slice(start, end)) as `0x${string}`;
+    return checksumAddress(("0x" + topic.slice(start, end)) as `0x${string}`);
   }
 
   if (childAddressLocation.startsWith("offset")) {
@@ -95,7 +94,9 @@ export function getAddressFromFactoryEventLog({
       );
     }
 
-    return ("0x" + log.data.slice(start, end)) as `0x${string}`;
+    return checksumAddress(
+      ("0x" + log.data.slice(start, end)) as `0x${string}`,
+    );
   }
 
   throw new Error(

--- a/packages/core/src/config/sources.ts
+++ b/packages/core/src/config/sources.ts
@@ -1,9 +1,12 @@
 import type { AbiEvent } from "abitype";
 import { parseAbiItem } from "abitype";
 import type { Abi, Address, GetEventArgs, Hex } from "viem";
-import { encodeEventTopics, getAbiItem, getEventSelector } from "viem";
-
-import { toLowerCase } from "@/utils/lowercase.js";
+import {
+  checksumAddress,
+  encodeEventTopics,
+  getAbiItem,
+  getEventSelector,
+} from "viem";
 
 import type { AbiEvents } from "./abi.js";
 import { getEvents } from "./abi.js";
@@ -119,9 +122,9 @@ export const buildSources = ({ config }: { config: Config }): Source[] => {
           type: "logFilter",
           criteria: {
             address: Array.isArray(resolvedAddress)
-              ? resolvedAddress.map((r) => toLowerCase(r))
+              ? resolvedAddress.map((r) => checksumAddress(r))
               : resolvedAddress
-                ? toLowerCase(resolvedAddress)
+                ? checksumAddress(resolvedAddress)
                 : undefined,
             topics,
           },
@@ -181,9 +184,9 @@ export const buildSources = ({ config }: { config: Config }): Source[] => {
             type: "logFilter",
             criteria: {
               address: Array.isArray(resolvedAddress)
-                ? resolvedAddress.map((r) => toLowerCase(r))
+                ? resolvedAddress.map((r) => checksumAddress(r))
                 : resolvedAddress
-                  ? toLowerCase(resolvedAddress)
+                  ? checksumAddress(resolvedAddress)
                   : undefined,
               topics,
             },

--- a/packages/core/src/indexing-store/postgres/store.ts
+++ b/packages/core/src/indexing-store/postgres/store.ts
@@ -227,7 +227,11 @@ export class PostgresIndexingStore implements IndexingStore {
       let query = this.db
         .selectFrom(table)
         .selectAll()
-        .where("id", "=", formattedId);
+        .where(
+          "id",
+          this.idColumnComparator({ tableName, schema: this.schema }),
+          formattedId,
+        );
 
       if (checkpoint === "latest") {
         query = query.where("effectiveToCheckpoint", "=", "latest");
@@ -410,7 +414,11 @@ export class PostgresIndexingStore implements IndexingStore {
         const latestRow = await tx
           .selectFrom(table)
           .selectAll()
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveToCheckpoint", "=", "latest")
           .executeTakeFirstOrThrow();
 
@@ -436,7 +444,11 @@ export class PostgresIndexingStore implements IndexingStore {
           return await tx
             .updateTable(table)
             .set(updateRow)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
             .returningAll()
             .executeTakeFirstOrThrow();
@@ -447,7 +459,11 @@ export class PostgresIndexingStore implements IndexingStore {
         const [, row] = await Promise.all([
           tx
             .updateTable(table)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .set({ effectiveToCheckpoint: encodedCheckpoint })
             .execute(),
@@ -538,7 +554,11 @@ export class PostgresIndexingStore implements IndexingStore {
               return await tx
                 .updateTable(table)
                 .set(updateRow)
-                .where("id", "=", formattedId)
+                .where(
+                  "id",
+                  this.idColumnComparator({ tableName, schema: this.schema }),
+                  formattedId,
+                )
                 .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
                 .returningAll()
                 .executeTakeFirstOrThrow();
@@ -549,7 +569,11 @@ export class PostgresIndexingStore implements IndexingStore {
             const [, row] = await Promise.all([
               tx
                 .updateTable(table)
-                .where("id", "=", formattedId)
+                .where(
+                  "id",
+                  this.idColumnComparator({ tableName, schema: this.schema }),
+                  formattedId,
+                )
                 .where("effectiveToCheckpoint", "=", "latest")
                 .set({ effectiveToCheckpoint: encodedCheckpoint })
                 .execute(),
@@ -603,7 +627,11 @@ export class PostgresIndexingStore implements IndexingStore {
         const latestRow = await tx
           .selectFrom(table)
           .selectAll()
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveToCheckpoint", "=", "latest")
           .executeTakeFirst();
 
@@ -642,7 +670,11 @@ export class PostgresIndexingStore implements IndexingStore {
           return await tx
             .updateTable(table)
             .set(updateRow)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
             .returningAll()
             .executeTakeFirstOrThrow();
@@ -653,7 +685,11 @@ export class PostgresIndexingStore implements IndexingStore {
         const [, row] = await Promise.all([
           tx
             .updateTable(table)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .set({ effectiveToCheckpoint: encodedCheckpoint })
             .execute(),
@@ -698,7 +734,11 @@ export class PostgresIndexingStore implements IndexingStore {
         // this row was created within the same indexing function, and we can delete it.
         let deletedRow = await tx
           .deleteFrom(table)
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
           .where("effectiveToCheckpoint", "=", "latest")
           .returning(["id"])
@@ -710,7 +750,11 @@ export class PostgresIndexingStore implements IndexingStore {
           deletedRow = await tx
             .updateTable(table)
             .set({ effectiveToCheckpoint: encodedCheckpoint })
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .returning(["id"])
             .executeTakeFirst();
@@ -785,4 +829,12 @@ export class PostgresIndexingStore implements IndexingStore {
     );
     return result;
   };
+
+  private idColumnComparator = ({
+    tableName,
+    schema,
+  }: {
+    tableName: string;
+    schema: Schema | undefined;
+  }) => (schema?.tables[tableName]?.id.type === "bytes" ? "ilike" : "=");
 }

--- a/packages/core/src/indexing-store/sqlite/store.ts
+++ b/packages/core/src/indexing-store/sqlite/store.ts
@@ -212,7 +212,11 @@ export class SqliteIndexingStore implements IndexingStore {
       let query = this.db
         .selectFrom(table)
         .selectAll()
-        .where("id", "=", formattedId);
+        .where(
+          "id",
+          this.idColumnComparator({ tableName, schema: this.schema }),
+          formattedId,
+        );
 
       if (checkpoint === "latest") {
         query = query.where("effectiveToCheckpoint", "=", "latest");
@@ -390,7 +394,11 @@ export class SqliteIndexingStore implements IndexingStore {
         const latestRow = await tx
           .selectFrom(table)
           .selectAll()
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveToCheckpoint", "=", "latest")
           .executeTakeFirstOrThrow();
 
@@ -416,7 +424,11 @@ export class SqliteIndexingStore implements IndexingStore {
           return await tx
             .updateTable(table)
             .set(updateRow)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
             .returningAll()
             .executeTakeFirstOrThrow();
@@ -427,7 +439,11 @@ export class SqliteIndexingStore implements IndexingStore {
         const [, row] = await Promise.all([
           tx
             .updateTable(table)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .set({ effectiveToCheckpoint: encodedCheckpoint })
             .execute(),
@@ -518,7 +534,11 @@ export class SqliteIndexingStore implements IndexingStore {
               return await tx
                 .updateTable(table)
                 .set(updateRow)
-                .where("id", "=", formattedId)
+                .where(
+                  "id",
+                  this.idColumnComparator({ tableName, schema: this.schema }),
+                  formattedId,
+                )
                 .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
                 .returningAll()
                 .executeTakeFirstOrThrow();
@@ -529,7 +549,11 @@ export class SqliteIndexingStore implements IndexingStore {
             const [, row] = await Promise.all([
               tx
                 .updateTable(table)
-                .where("id", "=", formattedId)
+                .where(
+                  "id",
+                  this.idColumnComparator({ tableName, schema: this.schema }),
+                  formattedId,
+                )
                 .where("effectiveToCheckpoint", "=", "latest")
                 .set({ effectiveToCheckpoint: encodedCheckpoint })
                 .execute(),
@@ -583,7 +607,11 @@ export class SqliteIndexingStore implements IndexingStore {
         const latestRow = await tx
           .selectFrom(table)
           .selectAll()
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveToCheckpoint", "=", "latest")
           .executeTakeFirst();
 
@@ -622,7 +650,11 @@ export class SqliteIndexingStore implements IndexingStore {
           return await tx
             .updateTable(table)
             .set(updateRow)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
             .returningAll()
             .executeTakeFirstOrThrow();
@@ -633,7 +665,11 @@ export class SqliteIndexingStore implements IndexingStore {
         const [, row] = await Promise.all([
           tx
             .updateTable(table)
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .set({ effectiveToCheckpoint: encodedCheckpoint })
             .execute(),
@@ -678,7 +714,11 @@ export class SqliteIndexingStore implements IndexingStore {
         // this row was created within the same indexing function, and we can delete it.
         let deletedRow = await tx
           .deleteFrom(table)
-          .where("id", "=", formattedId)
+          .where(
+            "id",
+            this.idColumnComparator({ tableName, schema: this.schema }),
+            formattedId,
+          )
           .where("effectiveFromCheckpoint", "=", encodedCheckpoint)
           .where("effectiveToCheckpoint", "=", "latest")
           .returning(["id"])
@@ -690,7 +730,11 @@ export class SqliteIndexingStore implements IndexingStore {
           deletedRow = await tx
             .updateTable(table)
             .set({ effectiveToCheckpoint: encodedCheckpoint })
-            .where("id", "=", formattedId)
+            .where(
+              "id",
+              this.idColumnComparator({ tableName, schema: this.schema }),
+              formattedId,
+            )
             .where("effectiveToCheckpoint", "=", "latest")
             .returning(["id"])
             .executeTakeFirst();
@@ -763,4 +807,12 @@ export class SqliteIndexingStore implements IndexingStore {
     );
     return result;
   };
+
+  private idColumnComparator = ({
+    tableName,
+    schema,
+  }: {
+    tableName: string;
+    schema: Schema | undefined;
+  }) => (schema?.tables[tableName]?.id.type === "bytes" ? "like" : "=");
 }

--- a/packages/core/src/sync-historical/service.test.ts
+++ b/packages/core/src/sync-historical/service.test.ts
@@ -1,4 +1,5 @@
 import {
+  checksumAddress,
   type EIP1193RequestFn,
   HttpRequestError,
   InvalidParamsRpcError,
@@ -140,10 +141,10 @@ test("start() with factory contract inserts child contract addresses", async (co
 
   expect(childContractAddresses).toMatchObject(
     expect.arrayContaining([
-      "0x6e4c301b43b5d6fc47ceac2fb9b6b3209e640eab",
-      "0x8d92afe4ab7f4d0379d37a6da3643763964cb6df",
-      "0x01b2848a0d9ffced595b0df3df10fb32430fa200",
-      "0xd5f83865bf8edb1f02e688dc2ee02d39e28692b3",
+      checksumAddress("0x6e4c301b43b5d6fc47ceac2fb9b6b3209e640eab"),
+      checksumAddress("0x8d92afe4ab7f4d0379d37a6da3643763964cb6df"),
+      checksumAddress("0x01b2848a0d9ffced595b0df3df10fb32430fa200"),
+      checksumAddress("0xd5f83865bf8edb1f02e688dc2ee02d39e28692b3"),
     ]),
   );
 

--- a/packages/core/src/sync-historical/service.ts
+++ b/packages/core/src/sync-historical/service.ts
@@ -31,6 +31,7 @@ import {
   intervalSum,
   ProgressTracker,
 } from "@/utils/interval.js";
+import { toLowerCase } from "@/utils/lowercase.js";
 import { createQueue, type Queue, type Worker } from "@/utils/queue.js";
 import { getErrorMessage, request } from "@/utils/request.js";
 import { startClock } from "@/utils/timer.js";
@@ -943,7 +944,16 @@ export class HistoricalSyncService extends Emittery<HistoricalSyncEvents> {
       return await request(this.network, {
         body: {
           method: "eth_getLogs",
-          params: [options],
+          params: [
+            {
+              ...options,
+              address: options.address
+                ? Array.isArray(options.address)
+                  ? options.address.map((a) => toLowerCase(a))
+                  : toLowerCase(options.address)
+                : undefined,
+            },
+          ],
         },
         fetchOptions: { signal },
       });

--- a/packages/core/src/sync-realtime/filter.test.ts
+++ b/packages/core/src/sync-realtime/filter.test.ts
@@ -5,7 +5,7 @@ import { filterLogs } from "./filter.js";
 
 export const logs: RpcLog[] = [
   {
-    address: "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    address: "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xe6e55f",
@@ -22,7 +22,7 @@ export const logs: RpcLog[] = [
     transactionIndex: "0x45",
   },
   {
-    address: "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    address: "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
     blockHash:
       "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
     blockNumber: "0xe6e55f",
@@ -55,12 +55,12 @@ export const logs: RpcLog[] = [
 test("filterLogs handles one logFilter, one address", () => {
   const filteredLogs = filterLogs({
     logs,
-    logFilters: [{ address: "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da" }],
+    logFilters: [{ address: "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA" }],
   });
 
   expect(filteredLogs).toHaveLength(1);
   expect(filteredLogs[0].address).toEqual(
-    "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
   );
 });
 
@@ -70,8 +70,8 @@ test("filterLogs handles one logFilter, two addresses", () => {
     logFilters: [
       {
         address: [
-          "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-          "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+          "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+          "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
         ],
       },
     ],
@@ -79,10 +79,10 @@ test("filterLogs handles one logFilter, two addresses", () => {
 
   expect(filteredLogs).toHaveLength(2);
   expect(filteredLogs[0].address).toEqual(
-    "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
   );
   expect(filteredLogs[1].address).toEqual(
-    "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
   );
 });
 
@@ -99,17 +99,17 @@ test("filterLogs handles two logFilters, one address each", () => {
   const filteredLogs = filterLogs({
     logs,
     logFilters: [
-      { address: "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da" },
-      { address: "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da" },
+      { address: "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA" },
+      { address: "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA" },
     ],
   });
 
   expect(filteredLogs).toHaveLength(2);
   expect(filteredLogs[0].address).toEqual(
-    "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
   );
   expect(filteredLogs[1].address).toEqual(
-    "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
   );
 });
 

--- a/packages/core/src/sync-realtime/filter.ts
+++ b/packages/core/src/sync-realtime/filter.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex, RpcLog } from "viem";
+import { type Address, checksumAddress, type Hex, type RpcLog } from "viem";
 
 import type { Topics } from "@/config/sources.js";
 
@@ -32,11 +32,13 @@ export function isLogMatchedByFilter({
   address?: Address | Address[];
   topics?: Topics;
 }) {
+  const logAddress = checksumAddress(log.address);
+
   if (address !== undefined && address.length > 0) {
     if (Array.isArray(address)) {
-      if (!address.includes(log.address)) return false;
+      if (!address.includes(logAddress)) return false;
     } else {
-      if (log.address !== address) return false;
+      if (logAddress !== address) return false;
     }
   }
 

--- a/packages/core/src/sync-realtime/service.test.ts
+++ b/packages/core/src/sync-realtime/service.test.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { type EIP1193RequestFn, HttpRequestError, parseAbi } from "viem";
+import {
+  checksumAddress,
+  type EIP1193RequestFn,
+  HttpRequestError,
+  parseAbi,
+} from "viem";
 import { rpc } from "viem/utils";
 import { beforeEach, expect, test, vi } from "vitest";
 
@@ -564,7 +569,7 @@ test("start() with factory contract inserts new child contracts records and chil
   for await (const page of iterator) childContractAddresses.push(...page);
 
   expect(childContractAddresses).toMatchObject([
-    "0x25e0870d42b6cef90b6dc8216588fad55d5f55c4",
+    checksumAddress("0x25e0870d42b6cef90b6dc8216588fad55d5f55c4"),
   ]);
 
   const eventIterator = syncStore.getLogEvents({
@@ -586,7 +591,7 @@ test("start() with factory contract inserts new child contracts records and chil
     expect.objectContaining({
       sourceId: "UniswapV3Pool",
       log: expect.objectContaining({
-        address: "0x25e0870d42b6cef90b6dc8216588fad55d5f55c4",
+        address: checksumAddress("0x25e0870d42b6cef90b6dc8216588fad55d5f55c4"),
       }),
     }),
   );

--- a/packages/core/src/sync-store/postgres/format.ts
+++ b/packages/core/src/sync-store/postgres/format.ts
@@ -1,13 +1,12 @@
 import type { Generated, Insertable } from "kysely";
 import type { Address, Hash, Hex } from "viem";
 import {
+  checksumAddress,
   hexToNumber,
   type RpcBlock,
   type RpcLog,
   type RpcTransaction,
 } from "viem";
-
-import { toLowerCase } from "@/utils/lowercase.js";
 
 type BlocksTable = {
   baseFeePerGas: bigint | null;
@@ -46,7 +45,7 @@ export function rpcToPostgresBlock(
     gasUsed: BigInt(block.gasUsed),
     hash: block.hash!,
     logsBloom: block.logsBloom!,
-    miner: toLowerCase(block.miner),
+    miner: checksumAddress(block.miner),
     mixHash: block.mixHash,
     nonce: block.nonce!,
     number: BigInt(block.number!),
@@ -96,7 +95,7 @@ export function rpcToPostgresTransaction(
       : undefined,
     blockHash: transaction.blockHash!,
     blockNumber: BigInt(transaction.blockNumber!),
-    from: toLowerCase(transaction.from),
+    from: checksumAddress(transaction.from),
     gas: BigInt(transaction.gas),
     gasPrice: transaction.gasPrice ? BigInt(transaction.gasPrice) : null,
     hash: transaction.hash,
@@ -110,7 +109,7 @@ export function rpcToPostgresTransaction(
     nonce: hexToNumber(transaction.nonce),
     r: transaction.r,
     s: transaction.s,
-    to: transaction.to ? toLowerCase(transaction.to) : null,
+    to: transaction.to ? checksumAddress(transaction.to) : null,
     transactionIndex: Number(transaction.transactionIndex),
     type: transaction.type ?? "0x0",
     value: BigInt(transaction.value),
@@ -140,7 +139,7 @@ export type InsertableLog = Insertable<LogsTable>;
 
 export function rpcToPostgresLog(log: RpcLog): Omit<InsertableLog, "chainId"> {
   return {
-    address: toLowerCase(log.address),
+    address: checksumAddress(log.address),
     blockHash: log.blockHash!,
     blockNumber: BigInt(log.blockNumber!),
     data: log.data,

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -1309,8 +1309,8 @@ export class PostgresSyncStore implements SyncStore {
 
     exprs.push(
       eb(
-        "logs.address",
-        "like",
+        sql`lower(logs.address)`,
+        "in",
         eb
           .selectFrom("logs")
           .select(selectChildAddressExpression.as("childAddress"))
@@ -1358,12 +1358,12 @@ function buildFactoryChildAddressSelectExpression({
     const childAddressOffset = Number(childAddressLocation.substring(6));
     const start = 2 + 12 * 2 + childAddressOffset * 2 + 1;
     const length = 20 * 2;
-    return sql<Hex>`'0x' || substring(data from ${start}::int for ${length}::int)`;
+    return sql<Hex>`'0x' || lower(substring(data from ${start}::int for ${length}::int))`;
   } else {
     const start = 2 + 12 * 2 + 1;
     const length = 20 * 2;
-    return sql<Hex>`'0x' || substring(${sql.ref(
+    return sql<Hex>`'0x' || lower(substring(${sql.ref(
       childAddressLocation,
-    )} from ${start}::integer for ${length}::integer)`;
+    )} from ${start}::integer for ${length}::integer))`;
   }
 }

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -1046,7 +1046,7 @@ export class PostgresSyncStore implements SyncStore {
             blockHash: row.log_blockHash,
             blockNumber: row.log_blockNumber,
             data: row.log_data,
-            id: row.log_id,
+            id: row.log_id as Log["id"],
             logIndex: Number(row.log_logIndex),
             removed: false,
             topics: [

--- a/packages/core/src/sync-store/postgres/store.ts
+++ b/packages/core/src/sync-store/postgres/store.ts
@@ -7,7 +7,13 @@ import {
   sql,
   type Transaction as KyselyTransaction,
 } from "kysely";
-import type { Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
+import {
+  checksumAddress,
+  type Hex,
+  type RpcBlock,
+  type RpcLog,
+  type RpcTransaction,
+} from "viem";
 
 import type {
   FactoryCriteria,
@@ -349,7 +355,7 @@ export class PostgresSyncStore implements SyncStore {
       }
 
       if (batch.length > 0) {
-        yield batch.map((a) => a.childAddress);
+        yield batch.map((a) => checksumAddress(a.childAddress));
       }
 
       if (batch.length < pageSize) break;
@@ -1026,7 +1032,7 @@ export class PostgresSyncStore implements SyncStore {
       exprs.push(
         eb(
           "logs.address",
-          "in",
+          "like",
           eb
             .selectFrom("logs")
             .select(selectChildAddressExpression.as("childAddress"))

--- a/packages/core/src/sync-store/sqlite/format.ts
+++ b/packages/core/src/sync-store/sqlite/format.ts
@@ -1,6 +1,7 @@
 import type { Generated, Insertable } from "kysely";
 import type { Address, Hash, Hex } from "viem";
 import {
+  checksumAddress,
   hexToNumber,
   type RpcBlock,
   type RpcLog,
@@ -8,7 +9,6 @@ import {
 } from "viem";
 
 import { encodeAsText } from "@/utils/encoding.js";
-import { toLowerCase } from "@/utils/lowercase.js";
 
 export type BigIntText = string;
 
@@ -51,7 +51,7 @@ export function rpcToSqliteBlock(
     gasUsed: encodeAsText(block.gasUsed),
     hash: block.hash!,
     logsBloom: block.logsBloom!,
-    miner: toLowerCase(block.miner),
+    miner: checksumAddress(block.miner),
     mixHash: block.mixHash,
     nonce: block.nonce!,
     number: encodeAsText(block.number!),
@@ -101,7 +101,7 @@ export function rpcToSqliteTransaction(
       : undefined,
     blockHash: transaction.blockHash!,
     blockNumber: encodeAsText(transaction.blockNumber!),
-    from: toLowerCase(transaction.from),
+    from: checksumAddress(transaction.from),
     gas: encodeAsText(transaction.gas),
     gasPrice: transaction.gasPrice ? encodeAsText(transaction.gasPrice) : null,
     hash: transaction.hash,
@@ -115,7 +115,7 @@ export function rpcToSqliteTransaction(
     nonce: hexToNumber(transaction.nonce),
     r: transaction.r,
     s: transaction.s,
-    to: transaction.to ? toLowerCase(transaction.to) : null,
+    to: transaction.to ? checksumAddress(transaction.to) : null,
     transactionIndex: Number(transaction.transactionIndex),
     type: transaction.type ?? "0x0",
     value: encodeAsText(transaction.value),
@@ -145,7 +145,7 @@ export type InsertableLog = Insertable<LogsTable>;
 
 export function rpcToSqliteLog(log: RpcLog): Omit<InsertableLog, "chainId"> {
   return {
-    address: toLowerCase(log.address),
+    address: checksumAddress(log.address),
     blockHash: log.blockHash!,
     blockNumber: encodeAsText(log.blockNumber!),
     data: log.data,

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -6,7 +6,13 @@ import {
   SqliteDialect,
   type Transaction as KyselyTransaction,
 } from "kysely";
-import type { Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
+import {
+  checksumAddress,
+  type Hex,
+  type RpcBlock,
+  type RpcLog,
+  type RpcTransaction,
+} from "viem";
 
 import type {
   FactoryCriteria,
@@ -319,7 +325,7 @@ export class SqliteSyncStore implements SyncStore {
       }
 
       if (batch.length > 0) {
-        yield batch.map((a) => a.childAddress);
+        yield batch.map((a) => checksumAddress(a.childAddress));
       }
 
       if (batch.length < pageSize) break;
@@ -1010,7 +1016,7 @@ export class SqliteSyncStore implements SyncStore {
       exprs.push(
         eb(
           "logs.address",
-          "in",
+          "like",
           eb
             .selectFrom("logs")
             .select(selectChildAddressExpression.as("childAddress"))

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -1303,8 +1303,8 @@ export class SqliteSyncStore implements SyncStore {
 
     exprs.push(
       eb(
-        "logs.address",
-        "like",
+        sql`lower(logs.address)`,
+        "in",
         eb
           .selectFrom("logs")
           .select(selectChildAddressExpression.as("childAddress"))
@@ -1352,12 +1352,12 @@ function buildFactoryChildAddressSelectExpression({
     const childAddressOffset = Number(childAddressLocation.substring(6));
     const start = 2 + 12 * 2 + childAddressOffset * 2 + 1;
     const length = 20 * 2;
-    return sql<Hex>`'0x' || substring(data, ${start}, ${length})`;
+    return sql<Hex>`'0x' || lower(substring(data, ${start}, ${length}))`;
   } else {
     const start = 2 + 12 * 2 + 1;
     const length = 20 * 2;
-    return sql<Hex>`'0x' || substring(${sql.ref(
+    return sql<Hex>`'0x' || lower(substring(${sql.ref(
       childAddressLocation,
-    )}, ${start}, ${length})`;
+    )}, ${start}, ${length}))`;
   }
 }

--- a/packages/core/src/sync-store/sqlite/store.ts
+++ b/packages/core/src/sync-store/sqlite/store.ts
@@ -1038,7 +1038,7 @@ export class SqliteSyncStore implements SyncStore {
             blockHash: row.log_blockHash,
             blockNumber: decodeToBigInt(row.log_blockNumber),
             data: row.log_data,
-            id: row.log_id,
+            id: row.log_id as Log["id"],
             logIndex: Number(row.log_logIndex),
             removed: false,
             topics: [

--- a/packages/core/src/sync-store/store.test.ts
+++ b/packages/core/src/sync-store/store.test.ts
@@ -1201,14 +1201,14 @@ test("getLogEvents filters on log filter with one address", async (context) => {
       {
         id: "singleAddress",
         chainId: 1,
-        criteria: { address: blockOneLogs[0].address },
+        criteria: { address: checksumAddress(blockOneLogs[0].address) },
       },
     ],
   });
   const events = [];
   for await (const page of iterator) events.push(...page.events);
 
-  expect(events[0].log.address).toBe(blockOneLogs[0].address);
+  expect(events[0].log.address).toBe(checksumAddress(blockOneLogs[0].address));
   expect(events).toHaveLength(1);
 });
 
@@ -1237,7 +1237,10 @@ test("getLogEvents filters on log filter with multiple addresses", async (contex
         id: "multipleAddress",
         chainId: 1,
         criteria: {
-          address: [blockOneLogs[0].address, blockOneLogs[1].address],
+          address: [
+            checksumAddress(blockOneLogs[0].address),
+            checksumAddress(blockOneLogs[1].address),
+          ],
         },
       },
     ],
@@ -1248,13 +1251,13 @@ test("getLogEvents filters on log filter with multiple addresses", async (contex
   expect(events[0]).toMatchObject({
     sourceId: "multipleAddress",
     log: {
-      address: blockOneLogs[0].address,
+      address: checksumAddress(blockOneLogs[0].address),
     },
   });
   expect(events[1]).toMatchObject({
     sourceId: "multipleAddress",
     log: {
-      address: blockOneLogs[1].address,
+      address: checksumAddress(blockOneLogs[1].address),
     },
   });
   expect(events).toHaveLength(2);
@@ -1474,7 +1477,7 @@ test("getLogEvents filters on multiple filters", async (context) => {
       {
         id: "singleAddress", // This should match blockOneLogs[0]
         chainId: 1,
-        criteria: { address: blockOneLogs[0].address },
+        criteria: { address: checksumAddress(blockOneLogs[0].address) },
       },
       {
         id: "singleTopic", // This should match blockOneLogs[0] AND blockTwoLogs[0]
@@ -1491,13 +1494,13 @@ test("getLogEvents filters on multiple filters", async (context) => {
   expect(events[0]).toMatchObject({
     sourceId: "singleAddress",
     log: {
-      address: blockOneLogs[0].address,
+      address: checksumAddress(blockOneLogs[0].address),
     },
   });
   expect(events[1]).toMatchObject({
     sourceId: "singleTopic",
     log: {
-      address: blockOneLogs[0].address,
+      address: checksumAddress(blockOneLogs[0].address),
     },
   });
   expect(events[2]).toMatchObject({

--- a/packages/core/src/sync-store/store.test.ts
+++ b/packages/core/src/sync-store/store.test.ts
@@ -1,4 +1,4 @@
-import { hexToBigInt, hexToNumber, toHex } from "viem";
+import { checksumAddress, hexToBigInt, hexToNumber, toHex } from "viem";
 import { beforeEach, expect, test } from "vitest";
 
 import {
@@ -311,7 +311,7 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
   const { syncStore } = context;
 
   const factoryCriteria = {
-    address: "0xfactory",
+    address: checksumAddress("0xfactory"),
     eventSelector:
       "0x0000000000000000000000000000000000000000000factoryeventsignature",
     childAddressLocation: "topic1",
@@ -322,7 +322,7 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
     logs: [
       {
         ...blockOneLogs[0],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child10000000000000000000000000000000000",
@@ -332,7 +332,7 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
       },
       {
         ...blockOneLogs[1],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child30000000000000000000000000000000000",
@@ -353,8 +353,8 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
   for await (const page of iterator) results.push(...page);
 
   expect(results).toMatchObject([
-    "0xchild10000000000000000000000000000000000",
-    "0xchild30000000000000000000000000000000000",
+    checksumAddress("0xchild10000000000000000000000000000000000"),
+    checksumAddress("0xchild30000000000000000000000000000000000"),
   ]);
 
   iterator = syncStore.getFactoryChildAddresses({
@@ -367,8 +367,8 @@ test("getFactoryChildAddresses gets child addresses for topic location", async (
   for await (const page of iterator) results.push(...page);
 
   expect(results).toMatchObject([
-    "0xchild20000000000000000000000000000000000",
-    "0xchild40000000000000000000000000000000000",
+    checksumAddress("0xchild20000000000000000000000000000000000"),
+    checksumAddress("0xchild40000000000000000000000000000000000"),
   ]);
 });
 
@@ -376,7 +376,7 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
   const { syncStore } = context;
 
   const factoryCriteria = {
-    address: "0xfactory",
+    address: checksumAddress("0xfactory"),
     eventSelector:
       "0x0000000000000000000000000000000000000000000factoryeventsignature",
     childAddressLocation: "offset32",
@@ -387,7 +387,7 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
     logs: [
       {
         ...blockOneLogs[0],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
         ],
@@ -396,7 +396,7 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
       },
       {
         ...blockOneLogs[1],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
         ],
@@ -416,8 +416,8 @@ test("getFactoryChildAddresses gets child addresses for offset location", async 
   for await (const page of iterator) results.push(...page);
 
   expect(results).toMatchObject([
-    "0xchild10000000000000000000000000000000000",
-    "0xchild20000000000000000000000000000000000",
+    checksumAddress("0xchild10000000000000000000000000000000000"),
+    checksumAddress("0xchild20000000000000000000000000000000000"),
   ]);
 });
 
@@ -425,7 +425,7 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
   const { syncStore } = context;
 
   const factoryCriteria = {
-    address: "0xfactory",
+    address: checksumAddress("0xfactory"),
     eventSelector:
       "0x0000000000000000000000000000000000000000000factoryeventsignature",
     childAddressLocation: "topic1",
@@ -436,7 +436,7 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
     logs: [
       {
         ...blockOneLogs[0],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child10000000000000000000000000000000000",
@@ -445,7 +445,7 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
       },
       {
         ...blockOneLogs[1],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child20000000000000000000000000000000000",
@@ -464,7 +464,9 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
   let results = [];
   for await (const page of iterator) results.push(...page);
 
-  expect(results).toMatchObject(["0xchild10000000000000000000000000000000000"]);
+  expect(results).toMatchObject([
+    checksumAddress("0xchild10000000000000000000000000000000000"),
+  ]);
 
   iterator = syncStore.getFactoryChildAddresses({
     chainId: 1,
@@ -476,8 +478,8 @@ test("getFactoryChildAddresses respects upToBlockNumber argument", async (contex
   for await (const page of iterator) results.push(...page);
 
   expect(results).toMatchObject([
-    "0xchild10000000000000000000000000000000000",
-    "0xchild20000000000000000000000000000000000",
+    checksumAddress("0xchild10000000000000000000000000000000000"),
+    checksumAddress("0xchild20000000000000000000000000000000000"),
   ]);
 });
 
@@ -1052,7 +1054,7 @@ test("getLogEvents returns log events", async (context) => {
 
   expect(events[0].log).toMatchInlineSnapshot(`
     {
-      "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
       "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
       "blockNumber": 15495110n,
       "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
@@ -1115,7 +1117,7 @@ test("getLogEvents returns log events", async (context) => {
 
   expect(events[1].log).toMatchInlineSnapshot(`
     {
-      "address": "0x72d4c048f83bd7e37d49ea4c83a07267ec4203da",
+      "address": "0x72D4C048f83bd7E37D49eA4C83a07267ec4203dA",
       "blockHash": "0xebc3644804e4040c0a74c5a5bbbc6b46a71a5d4010fe0c92ebb2fdf4a43ea5dd",
       "blockNumber": 15495110n,
       "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
@@ -1360,7 +1362,7 @@ test("getLogEvents filters on simple factory", async (context) => {
     logs: [
       {
         ...blockOneLogs[0],
-        address: "0xfactory",
+        address: checksumAddress("0xfactory"),
         topics: [
           "0x0000000000000000000000000000000000000000000factoryeventsignature",
           "0x000000000000000000000000child10000000000000000000000000000000000",
@@ -1376,7 +1378,7 @@ test("getLogEvents filters on simple factory", async (context) => {
     transactions: blockTwoTransactions,
     logs: blockTwoLogs.map((l) => ({
       ...l,
-      address: "0xchild10000000000000000000000000000000000",
+      address: checksumAddress("0xchild10000000000000000000000000000000000"),
     })),
   });
 
@@ -1388,7 +1390,7 @@ test("getLogEvents filters on simple factory", async (context) => {
         id: "simple",
         chainId: 1,
         criteria: {
-          address: "0xfactory",
+          address: checksumAddress("0xfactory"),
           eventSelector:
             "0x0000000000000000000000000000000000000000000factoryeventsignature",
           childAddressLocation: "topic1",

--- a/packages/core/src/types/log.ts
+++ b/packages/core/src/types/log.ts
@@ -7,7 +7,7 @@ import type { Address, Hash, Hex } from "viem";
  */
 export type Log = {
   /** Globally unique identifier for this log (`${blockHash}-${logIndex}`). */
-  id: `${Hash}-${number}`;
+  id: string;
   /** The address from which this log originated */
   address: Address;
   /** Hash of block containing this log */

--- a/packages/core/src/types/log.ts
+++ b/packages/core/src/types/log.ts
@@ -7,7 +7,7 @@ import type { Address, Hash, Hex } from "viem";
  */
 export type Log = {
   /** Globally unique identifier for this log (`${blockHash}-${logIndex}`). */
-  id: string;
+  id: `${Hash}-${number}`;
   /** The address from which this log originated */
   address: Address;
   /** Hash of block containing this log */


### PR DESCRIPTION
Two main case sensitivity problems were addressed:
- viem decoding returned checksum addresses while ponder was using lowercase
- bytes values were case sensitive

These issues were fixed by:
- internally representing addresses with checksum
- case insensitive comparisons for "bytes" columns

This closes #478 and closes #194 