### PR TITLE
Indexing function retries

### DIFF
--- a/packages/core/src/indexing-store/sqlite/store.ts
+++ b/packages/core/src/indexing-store/sqlite/store.ts
@@ -189,7 +189,6 @@ export class SqliteIndexingStore implements IndexingStore {
               .updateTable(table)
               .set({ effectiveToCheckpoint: "latest" })
               .where("effectiveToCheckpoint", ">=", encodedCheckpoint)
-              // .where("effectiveToCheckpoint", "!=", "latest")
               .execute();
           }),
         );

--- a/packages/core/src/indexing-store/sqlite/store.ts
+++ b/packages/core/src/indexing-store/sqlite/store.ts
@@ -168,28 +168,34 @@ export class SqliteIndexingStore implements IndexingStore {
 
   revert = async ({ safeCheckpoint }: { safeCheckpoint: Checkpoint }) => {
     return this.wrap({ method: "revert" }, async () => {
+      console.log("hi");
       await this.db.transaction().execute(async (tx) => {
         await Promise.all(
           Object.keys(this.schema?.tables ?? {}).map(async (tableName) => {
             const table = `${tableName}_versioned`;
             const encodedCheckpoint = encodeCheckpoint(safeCheckpoint);
 
+            console.log(1);
             // Delete any versions that are newer than the safe checkpoint.
             await tx
               .deleteFrom(table)
               .where("effectiveFromCheckpoint", ">", encodedCheckpoint)
               .execute();
+            console.log(2);
 
             // Now, any versions with effectiveToCheckpoint greater than or equal
             // to the safe checkpoint are the new latest version.
+            console.log({ table });
             await tx
               .updateTable(table)
               .where("effectiveToCheckpoint", ">=", encodedCheckpoint)
               .set({ effectiveToCheckpoint: "latest" })
               .execute();
+            console.log(table, "finished");
           }),
         );
       });
+      console.log("bye");
     });
   };
 

--- a/packages/core/src/indexing-store/store.test.ts
+++ b/packages/core/src/indexing-store/store.test.ts
@@ -902,6 +902,12 @@ test("revert() deletes versions newer than the safe timestamp", async (context) 
     id: "id1",
     data: { name: "Bobby" },
   });
+  await indexingStore.create({
+    tableName: "Person",
+    checkpoint: createCheckpoint(12),
+    id: "id2",
+    data: { name: "Kevin" },
+  });
 
   await indexingStore.revert({ checkpoint: createCheckpoint(12) });
 
@@ -920,7 +926,7 @@ test("revert() updates versions that only existed during the safe timestamp to l
 
   await indexingStore.create({
     tableName: "Pet",
-    checkpoint: createCheckpoint(10),
+    checkpoint: createCheckpoint(9),
     id: "id1",
     data: { name: "Skip" },
   });

--- a/packages/core/src/indexing-store/store.test.ts
+++ b/packages/core/src/indexing-store/store.test.ts
@@ -903,7 +903,7 @@ test("revert() deletes versions newer than the safe timestamp", async (context) 
     data: { name: "Bobby" },
   });
 
-  await indexingStore.revert({ safeCheckpoint: createCheckpoint(12) });
+  await indexingStore.revert({ checkpoint: createCheckpoint(12) });
 
   const pets = await indexingStore.findMany({ tableName: "Pet" });
   expect(pets.length).toBe(1);
@@ -930,7 +930,7 @@ test("revert() updates versions that only existed during the safe timestamp to l
     id: "id1",
   });
 
-  await indexingStore.revert({ safeCheckpoint: createCheckpoint(10) });
+  await indexingStore.revert({ checkpoint: createCheckpoint(10) });
 
   const pets = await indexingStore.findMany({ tableName: "Pet" });
   expect(pets.length).toBe(1);

--- a/packages/core/src/indexing-store/store.ts
+++ b/packages/core/src/indexing-store/store.ts
@@ -85,7 +85,7 @@ export interface IndexingStore {
   reload(options?: { schema?: Schema }): Promise<void>;
   kill(): Promise<void>;
 
-  revert(options: { safeCheckpoint: Checkpoint }): Promise<void>;
+  revert(options: { checkpoint: Checkpoint }): Promise<void>;
 
   findUnique(options: {
     tableName: string;

--- a/packages/core/src/indexing/transport.ts
+++ b/packages/core/src/indexing/transport.ts
@@ -4,9 +4,7 @@ import { custom, maxUint256 } from "viem";
 import type { Network } from "@/config/networks.js";
 import type { SyncStore } from "@/sync-store/store.js";
 import { toLowerCase } from "@/utils/lowercase.js";
-import { TASK_RETRY_TIMEOUT } from "@/utils/queue.js";
 import { request as requestHelper } from "@/utils/request.js";
-import { wait } from "@/utils/wait.js";
 
 export const ponderTransport = ({
   network,
@@ -68,9 +66,7 @@ export const ponderTransport = ({
 
           if (cachedResult?.result) return cachedResult.result;
           else {
-            const response = await requestWithRetry(() =>
-              requestHelper(network, { body }),
-            );
+            const response = await requestHelper(network, { body });
             await syncStore.insertRpcRequestResult({
               blockNumber: blockNumber,
               chainId: chain!.id,
@@ -80,21 +76,10 @@ export const ponderTransport = ({
             return response;
           }
         } else {
-          return await requestWithRetry(() => requestHelper(network, { body }));
+          return await requestHelper(network, { body });
         }
       },
     });
     return c({ chain });
   };
-};
-
-const requestWithRetry = async (request: () => Promise<any>) => {
-  for (let i = 0; i <= TASK_RETRY_TIMEOUT.length; i++) {
-    if (i > 0) await wait(TASK_RETRY_TIMEOUT[i - 1]);
-    try {
-      return await request();
-    } catch (err) {
-      if (i === TASK_RETRY_TIMEOUT.length) throw err;
-    }
-  }
 };

--- a/packages/core/src/utils/queue.ts
+++ b/packages/core/src/utils/queue.ts
@@ -105,7 +105,8 @@ export function createQueue<TTask, TContext = undefined, TReturn = void>({
 
     let retryTimeout: number | undefined = undefined;
     if (taskOptions?.retry) {
-      task._retryCount = !task._retryCount ? 0 : task._retryCount + 1;
+      task._retryCount =
+        task._retryCount === undefined ? 0 : task._retryCount + 1;
 
       if (task._retryCount >= TASK_RETRY_TIMEOUT.length) {
         retryTimeout = TASK_RETRY_TIMEOUT[task._retryCount - 1];


### PR DESCRIPTION
Retry indexing functions three times before stopping the service and displaying the error to the terminal. Internally, uses the same revert() function that reorgs use to reset the state of the indexing-store to what it was before the failed indexing function ran. 

Ponder actions on client no longer need retry logic and instead use this.